### PR TITLE
prep: branding sync-FS + speed-positive net prefs; kebab-case all JS exports

### DIFF
--- a/src/gjoa/chrome/bjs/tabs/snapshot.bjs
+++ b/src/gjoa/chrome/bjs/tabs/snapshot.bjs
@@ -4,7 +4,7 @@
 (define-mode strict)
 
 (declare-extern [CLOSED-MEMORY console Map] Any)
-(js/export (defn buildEnvelope [snapshot :- Any] :- Any
+(js/export (defn build-envelope [snapshot :- Any] :- Any
   (let [tab-space-map (Map.)]
     (when (and (.-spaces snapshot) (.-tabSpaces (.-spaces snapshot)))
       (.forEach (.-tabSpaces (.-spaces snapshot))
@@ -59,7 +59,7 @@
     (set! (.-pending flags) true)
     (do
       (set! (.-inFlight flags) true)
-      (-> (.appendEvent history (buildEnvelope (getSnapshot)))
+      (-> (.appendEvent history (build-envelope (getSnapshot)))
           (.catch #(onErr %))
           (.then (fn []
             (set! (.-inFlight flags) false)
@@ -77,7 +77,7 @@
     (let [i (.findIndex queue #(= (.-url %) url))]
       (when (>= i 0) (aget (.splice queue i 1) 0))))))
 
-(js/export (defn popSavedByIndex [queue :- Any idx :- Int] :- Any
+(js/export (defn pop-saved-by-index [queue :- Any idx :- Int] :- Any
   (when (>= idx 0)
     (let [i (.findIndex queue #(= (.-_origIdx %) idx))]
       (when (>= i 0) (aget (.splice queue i 1) 0))))))

--- a/src/gjoa/defaults/pref/perf-prefs.js
+++ b/src/gjoa/defaults/pref/perf-prefs.js
@@ -36,9 +36,15 @@ pref("browser.discovery.enabled", false);
 pref("app.normandy.enabled", false);
 pref("app.shield.optoutstudies.enabled", false);
 pref("browser.safebrowsing.downloads.remote.enabled", false);
-pref("network.prefetch-next", false);
-pref("network.dns.disablePrefetch", true);
-pref("network.http.speculative-parallel-limit", 0);
+
+// --- Networking: SPEED-positive ---
+// Firefox ships prefetch / DNS-prefetch / speculative-connect ON. They were
+// being DISABLED here (lumped in with telemetry as if a privacy nicety), which
+// directly HURTS page-load — the opposite of gjoa's speed thesis. Restored to
+// Firefox defaults. Minor privacy cost (leaks likely-next hosts); speed wins.
+pref("network.prefetch-next", true);
+pref("network.dns.disablePrefetch", false);
+pref("network.http.speculative-parallel-limit", 6);
 
 // --- Rendering performance ---
 pref("gfx.webrender.all", true);

--- a/tools/bench/cold-start.bjs
+++ b/tools/bench/cold-start.bjs
@@ -6,7 +6,7 @@
 (ns gjoa.tools.bench.cold-start
   (:require [util :refer [parseArgs]]
             [path :refer [join]]
-            [gjoa.tools.bench.stats :refer [confidenceInterval95 median formatResult]]))
+            [gjoa.tools.bench.stats :refer [confidence-interval95 median format-result]]))
 (define-mode strict)
 (declare-extern [Bun process console performance Date Number setTimeout clearTimeout parseInt] Any)
 
@@ -122,7 +122,7 @@
 
     ;; Drop first run as warm-up
     (let [results (.slice @times 1)
-          ci (confidenceInterval95 results)
+          ci (confidence-interval95 results)
           med (median results)]
       (.log console (str "\n  " label " results (excluding warm-up run):"))
       (.log console (str "    Median: " (.toFixed med 1) " ms"))
@@ -146,5 +146,5 @@
 (def firefoxTimes :- Any (js/await (runBenchmark! FIREFOX-BIN "Firefox" "Mozilla Firefox|Firefox")))
 
 (.log console "\n=== Comparison ===\n")
-(.log console (formatResult "Cold Start (time to window visible)" gjoaTimes firefoxTimes))
+(.log console (format-result "Cold Start (time to window visible)" gjoaTimes firefoxTimes))
 (.log console "")

--- a/tools/bench/memory.bjs
+++ b/tools/bench/memory.bjs
@@ -9,7 +9,7 @@
 (ns gjoa.tools.bench.memory
   (:require [util :refer [parseArgs]]
             [path :refer [join]]
-            [gjoa.tools.bench.stats :refer [formatResult]]))
+            [gjoa.tools.bench.stats :refer [format-result]]))
 (define-mode strict)
 (declare-extern [Bun process console Date Error Array RegExp parseInt isNaN setTimeout clearTimeout] Any)
 
@@ -169,11 +169,11 @@
 (def firefoxResults :- Any (js/await (runBenchmark! FIREFOX-BIN "Firefox" "Mozilla Firefox|Firefox" RUNS)))
 
 (.log console "\n=== Comparison ===\n")
-(.log console (formatResult (str "Memory (" NUM-TABS " tabs, total PSS MB)") gjoaResults firefoxResults "MB"))
+(.log console (format-result (str "Memory (" NUM-TABS " tabs, total PSS MB)") gjoaResults firefoxResults "MB"))
 
 ;; Per-tab summary
 (def gjoaPerTab :- Any (.map gjoaResults (fn [v] (/ v NUM-TABS))))
 (def firefoxPerTab :- Any (.map firefoxResults (fn [v] (/ v NUM-TABS))))
 (.log console "")
-(.log console (formatResult "Memory (per-tab MB)" gjoaPerTab firefoxPerTab "MB"))
+(.log console (format-result "Memory (per-tab MB)" gjoaPerTab firefoxPerTab "MB"))
 (.log console "")

--- a/tools/bench/stats.bjs
+++ b/tools/bench/stats.bjs
@@ -43,31 +43,31 @@
       (< df 2) 12.706 ;; df=1, very wide
       :else 1.96))) ;; approximate for df > 29
 
-(js/export (defn geometricMean [values :- Any] :- Number
+(js/export (defn geometric-mean [values :- Any] :- Number
   (if (= (.-length values) 0)
     0
     (let [logSum (.reduce values (fn [acc v] (+ acc (.log Math v))) 0)]
       (.exp Math (/ logSum (.-length values)))))))
 
-(js/export (defn arithmeticMean [values :- Any] :- Number
+(js/export (defn arithmetic-mean [values :- Any] :- Number
   (if (= (.-length values) 0)
     0
     (/ (.reduce values (fn [a b] (+ a b)) 0) (.-length values)))))
 
-(js/export (defn standardDeviation [values :- Any] :- Number
+(js/export (defn standard-deviation [values :- Any] :- Number
   (if (< (.-length values) 2)
     0
-    (let [mean (arithmeticMean values)
+    (let [mean (arithmetic-mean values)
           squaredDiffs (.map values (fn [v] (.pow Math (- v mean) 2)))
           variance (/ (.reduce squaredDiffs (fn [a b] (+ a b)) 0) (- (.-length values) 1))]
       (.sqrt Math variance)))))
 
-(js/export (defn confidenceInterval95 [values :- Any] :- Any
+(js/export (defn confidence-interval95 [values :- Any] :- Any
   (let [n (.-length values)
-        mean (arithmeticMean values)]
+        mean (arithmetic-mean values)]
     (if (< n 2)
       {:mean mean :ci 0 :low mean :high mean}
-      (let [sd (standardDeviation values)
+      (let [sd (standard-deviation values)
             df (- n 1)
             t (tCritical df)
             se (/ sd (.sqrt Math n))
@@ -83,9 +83,9 @@
         (/ (+ (get sorted (- mid 1)) (get sorted mid)) 2)
         (get sorted mid))))))
 
-(js/export (defn formatResult [label :- String gjoa :- Any firefox :- Any unit :- String] :- String
-  (let [gjoaCI (confidenceInterval95 gjoa)
-        firefoxCI (confidenceInterval95 firefox)
+(js/export (defn format-result [label :- String gjoa :- Any firefox :- Any unit :- String] :- String
+  (let [gjoaCI (confidence-interval95 gjoa)
+        firefoxCI (confidence-interval95 firefox)
         lines []]
     (.push lines (str "  " label))
     (.push lines

--- a/tools/prep/branding.bjs
+++ b/tools/prep/branding.bjs
@@ -4,9 +4,8 @@
 ;; overlay gjoa icons + content, append gjoa default prefs, and assert no
 ;; zen-browser.app substring leaked through.
 (ns gjoa.tools.prep.branding
-  (:require [fs :refer [existsSync readdirSync statSync]]
+  (:require [fs :refer [existsSync readdirSync statSync mkdirSync readFileSync rmSync writeFileSync]]
             [path :refer [dirname extname join relative]]
-            [fs/promises :refer [mkdir readFile rm writeFile]]
             [gjoa.tools.prep.config :refer [loadConfig]]
             [gjoa.tools.prep.paths :refer [BRANDING-SRC
                                            ENGINE-BRANDING-DIR
@@ -128,8 +127,8 @@
                           "did you run `bun run download` first?"))))
 
     (.step log (str "generating branding tree at engine/browser/branding/" (.-binaryName cfg) "/"))
-    (when (existsSync target) (js/await (rm target {:recursive true})))
-    (js/await (mkdir target {:recursive true}))
+    (when (existsSync target) (rmSync target {:recursive true}))
+    (mkdirSync target {:recursive true})
 
     ;; 1. Walk mozilla's unofficial tree and copy each file, with substitution
     ;;    on text files.
@@ -139,10 +138,10 @@
       (doseq [src all-files]
         (let [rel (relative ENGINE-UNOFFICIAL-BRANDING src)
               dst (join target rel)]
-          (js/await (mkdir (dirname dst) {:recursive true}))
+          (mkdirSync (dirname dst) {:recursive true})
           (if (is-text-file src)
-            (let [text (js/await (readFile src "utf8"))]
-              (js/await (writeFile dst (apply-substitutions! text cfg)))
+            (let [text (readFileSync src "utf8")]
+              (writeFileSync dst (apply-substitutions! text cfg))
               (reset! text-count (+ @text-count 1)))
             ;; Binary copy — preserves icon bytes etc.
             (do
@@ -170,10 +169,10 @@
         (doseq [name gjoa-pref-files]
           (let [src (join SRC-DIR "defaults" "pref" name)]
             (when (not (existsSync src)) (throw (Error. (str "gjoa pref source missing: " src))))
-            (let [contents (js/await (readFile src "utf8"))]
+            (let [contents (readFileSync src "utf8")]
               (reset! pref-blocks (str @pref-blocks "\n// ---- " name " ----\n" (.trimEnd contents) "\n")))))
-        (let [existing (js/await (readFile branding-pref-file "utf8"))]
-          (js/await (writeFile branding-pref-file (str existing @pref-blocks))))
+        (let [existing (readFileSync branding-pref-file "utf8")]
+          (writeFileSync branding-pref-file (str existing @pref-blocks)))
         (.info log (str "appended " (.-length gjoa-pref-files) " gjoa pref files to branding/" (.-binaryName cfg) "/pref/firefox-branding.js"))))
 
     ;; 2. Overlay our own logo PNGs from configs/branding/gjoa/. Mozilla's
@@ -213,7 +212,7 @@
     (let [written (walk-files target)]
       (doseq [f written]
         (when (is-text-file f)
-          (let [text (js/await (readFile f "utf8"))]
+          (let [text (readFileSync f "utf8")]
             (when (.includes text "zen-browser.app")
               (throw (Error. (str "zen-browser.app leaked into " f " — extend substitutions in branding.bjs"))))))))
 

--- a/tools/prep/branding.bjs
+++ b/tools/prep/branding.bjs
@@ -6,7 +6,7 @@
 (ns gjoa.tools.prep.branding
   (:require [fs :refer [existsSync readdirSync statSync mkdirSync readFileSync rmSync writeFileSync]]
             [path :refer [dirname extname join relative]]
-            [gjoa.tools.prep.config :refer [loadConfig]]
+            [gjoa.tools.prep.config :refer [load-config]]
             [gjoa.tools.prep.paths :refer [BRANDING-SRC
                                            ENGINE-BRANDING-DIR
                                            ENGINE-UNOFFICIAL-BRANDING
@@ -119,7 +119,7 @@
 ;; Copy mozilla's unofficial branding tree to engine/browser/branding/<binaryName>/,
 ;; applying string substitutions to text files and overwriting our PNG icons.
 (js/export (defn branding [] :- Any
-  (let [cfg (loadConfig)
+  (let [cfg (load-config)
         target (join ENGINE-BRANDING-DIR (.-binaryName cfg))]
 
     (when (not (existsSync ENGINE-UNOFFICIAL-BRANDING))

--- a/tools/prep/chrome-bake.bjs
+++ b/tools/prep/chrome-bake.bjs
@@ -70,7 +70,7 @@
             (recur (+ i 1))))
         nil))))
 
-(js/export (defn chromeBake [] :- Any
+(js/export (defn chrome-bake [] :- Any
   (js/await (ensureChromeDist))
   (.step log (str "baking " (.-length SCRIPTS) " scripts + "
                   (.-length STYLES) " stylesheets into engine"))

--- a/tools/prep/cli.bjs
+++ b/tools/prep/cli.bjs
@@ -3,7 +3,7 @@
   (:require [fs :refer [existsSync]]
             [fs/promises :refer [rm]]
             [gjoa.tools.prep.download :refer [download]]
-            [gjoa.tools.prep.import :refer [importSources]]
+            [gjoa.tools.prep.import :refer [import-sources]]
             [gjoa.tools.prep.paths :refer [ENGINE-DIR]]
             [gjoa.tools.prep.log :refer [log]]
             [gjoa.tools.security.check :refer [check]]))
@@ -83,7 +83,7 @@ After editing src/gjoa/ or gjoa.json: `bun run import`.
             (err "engine/ does not exist — run `bun run download` first"))
           (.exit process 1))
         (js/await (printSecurityBanner))
-        (js/await (importSources)))
+        (js/await (import-sources)))
 
       (= cmd "clean")
       (if (existsSync ENGINE-DIR)

--- a/tools/prep/config.bjs
+++ b/tools/prep/config.bjs
@@ -25,7 +25,7 @@
 ;; `const` in JS; the original `let cached` mutation becomes atom reset!/deref.
 (def cached :- Any (atom nil))
 
-(js/export (defn loadConfig [] :- Any
+(js/export (defn load-config [] :- Any
   (if (deref cached)
     (deref cached)
     (let [path (join REPO-ROOT "gjoa.json")

--- a/tools/prep/download.bjs
+++ b/tools/prep/download.bjs
@@ -6,7 +6,7 @@
 (ns gjoa.tools.prep.download
   (:require [fs :refer [existsSync mkdirSync statSync]]
             [path :refer [join]]
-            [gjoa.tools.prep.config :refer [loadConfig]]
+            [gjoa.tools.prep.config :refer [load-config]]
             [gjoa.tools.prep.paths :refer [ENGINE-DIR REPO-ROOT SOURCES-CACHE]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
@@ -65,7 +65,7 @@
       (js/await (.write Bun dest res)))))
 
 (js/export (defn download [] :- Any
-  (let [cfg (loadConfig)]
+  (let [cfg (load-config)]
     (mkdirSync SOURCES-CACHE {:recursive true})
     (let [version (.-version (.-firefox cfg))
           tarball (join SOURCES-CACHE (tarballName version))

--- a/tools/prep/import.bjs
+++ b/tools/prep/import.bjs
@@ -1,7 +1,7 @@
 #lang beagle/js
 (ns gjoa.tools.prep.import
   (:require [gjoa.tools.prep.branding :refer [branding]]
-            [gjoa.tools.prep.chrome-bake :refer [chromeBake]]
+            [gjoa.tools.prep.chrome-bake :refer [chrome-bake]]
             [gjoa.tools.prep.locales :refer [locales]]
             [gjoa.tools.prep.mozconfig :refer [mozconfig]]
             [gjoa.tools.prep.overlay :refer [overlay]]
@@ -11,7 +11,7 @@
 
 ;; Six sequential phases. Each is idempotent, so re-running `bun run import`
 ;; after editing src/gjoa/ or gjoa.json picks up the changes correctly.
-(js/export (defn importSources [] :- Any
+(js/export (defn import-sources [] :- Any
   (.step log "phase 1/6 — overlaying src/gjoa/")
   (js/await (overlay))
 
@@ -19,7 +19,7 @@
   (js/await (patches))
 
   (.step log "phase 3/6 — baking chrome bundles into engine/")
-  (js/await (chromeBake))
+  (js/await (chrome-bake))
 
   (.step log "phase 4/6 — generating branding")
   (js/await (branding))

--- a/tools/prep/mozconfig.bjs
+++ b/tools/prep/mozconfig.bjs
@@ -3,7 +3,7 @@
   (:require [fs :refer [existsSync]]
             [fs/promises :refer [writeFile]]
             [path :refer [join]]
-            [gjoa.tools.prep.config :refer [loadConfig]]
+            [gjoa.tools.prep.config :refer [load-config]]
             [gjoa.tools.prep.paths :refer [ENGINE-DIR]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
@@ -20,7 +20,7 @@
 ;; to pick up the env var, because mach's configure subprocess doesn't
 ;; always inherit env vars cleanly through its virtualenv layers.
 (js/export (defn mozconfig [] :- Any
-  (let [cfg (loadConfig)
+  (let [cfg (load-config)
         libclang (.-LIBCLANG_PATH (.-env process))]
     (when (not libclang)
       (.warn log

--- a/tools/prep/patch-header.bjs
+++ b/tools/prep/patch-header.bjs
@@ -83,7 +83,7 @@
 ;; that differs from gjoa.json.firefox.version. Returns the count of
 ;; problems found (0 = clean). Non-fatal: prints to stderr; caller
 ;; decides whether to bail.
-(js/export (defn checkAll [] :- Any
+(js/export (defn check-all [] :- Any
   (let [current (js/await (loadCurrentBaseline))
         names (js/await (listPatches))]
     (loop [i 0 problems 0]
@@ -116,7 +116,7 @@
 ;; current gjoa.json firefox.version as the baseline label. Only run
 ;; AFTER you've just regenerated the patch against the current source,
 ;; otherwise the baseline label will lie.
-(js/export (defn retrofitAll [] :- Any
+(js/export (defn retrofit-all [] :- Any
   (let [current (js/await (loadCurrentBaseline))
         names (js/await (listPatches))]
     (loop [i 0 changed 0]
@@ -139,11 +139,11 @@
   (let [cmd (aget (.-argv process) 2)]
     (cond
       (= cmd "check")
-      (let [problems (js/await (checkAll))]
+      (let [problems (js/await (check-all))]
         (.exit process (if (= problems 0) 0 2)))
 
       (= cmd "retrofit")
-      (js/await (retrofitAll))
+      (js/await (retrofit-all))
 
       :else
       (do

--- a/tools/prep/patches.bjs
+++ b/tools/prep/patches.bjs
@@ -9,7 +9,7 @@
   (:require [fs :refer [existsSync readdirSync]]
             [path :refer [join]]
             [gjoa.tools.prep.paths :refer [ENGINE-DIR PATCHES-DIR]]
-            [gjoa.tools.prep.patch-header :refer [checkAll]]
+            [gjoa.tools.prep.patch-header :refer [check-all]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
 (declare-extern [Bun Array] Any)
@@ -55,7 +55,7 @@
 ;; incomplete.
 (defn runLint [] :- Any
   (try
-    (let [problems (js/await (checkAll))]
+    (let [problems (js/await (check-all))]
       (if (> problems 0)
         (.warn log (str problems " patch(es) missing the gjoa-patch header"))
         nil))

--- a/tools/scripts/probe-nav-bar.bjs
+++ b/tools/scripts/probe-nav-bar.bjs
@@ -12,9 +12,9 @@
 (ns gjoa.tools.scripts.probe-nav-bar
   (:require [child_process :refer [spawn]]
             [fs/promises :refer [writeFile]]
-            [gjoa.tools.test-driver.marionette :refer [connectMarionette]]
-            [gjoa.tools.test-driver.profile :refer [createProfile]]
-            [gjoa.tools.test-driver.gjoa-locator :refer [locateGjoa]]))
+            [gjoa.tools.test-driver.marionette :refer [connect-marionette]]
+            [gjoa.tools.test-driver.profile :refer [create-profile]]
+            [gjoa.tools.test-driver.gjoa-locator :refer [locate-gjoa]]))
 (define-mode strict)
 (declare-extern [process console setTimeout Buffer Object JSON String] Any)
 
@@ -95,8 +95,8 @@
                            (.padStart (String (.-width c)) 4) " order=" (.padStart (.-order c) 3) " mIS="
                            (.padStart (.-marginInlineStart c) 6) "  " (or (.-id c) (.-tag c))))))))
 
-(def profile :- Any (js/await (createProfile)))
-(def gjoaBin :- String (.-path (locateGjoa)))
+(def profile :- Any (js/await (create-profile)))
+(def gjoaBin :- String (.-path (locate-gjoa)))
 (.log console (str "profile: " (.-path profile)))
 (.log console (str "binary:  " gjoaBin))
 
@@ -113,7 +113,7 @@
 (some-> (.-stdout child) .resume)
 (some-> (.-stderr child) .resume)
 
-(def mn :- Any (js/await (connectMarionette {:port 2828})))
+(def mn :- Any (js/await (connect-marionette {:port 2828})))
 (js/await (.newSession mn))
 (js/await (.setContext mn "chrome"))
 

--- a/tools/test-driver/gjoa-locator.bjs
+++ b/tools/test-driver/gjoa-locator.bjs
@@ -30,8 +30,8 @@
     (if (< i 0) "." (.slice p 0 i))))
 
 ;; Find the gjoa binary. Throws with a setup hint if not present.
-(js/export (defn locateGjoa
-  ([] :- Any (locateGjoa (.cwd process)))
+(js/export (defn locate-gjoa
+  ([] :- Any (locate-gjoa (.cwd process)))
   ([cwd :- String] :- Any
     (let [gjoa-bin (aget (.-env process) "GJOA_BIN")]
       (if gjoa-bin

--- a/tools/test-driver/marionette.bjs
+++ b/tools/test-driver/marionette.bjs
@@ -31,7 +31,7 @@
 
 ;; Connect to a running Marionette server. Polls until the port accepts a
 ;; connection or the timeout elapses.
-(js/export (defn connectMarionette [opts :- Any] :- Any
+(js/export (defn connect-marionette [opts :- Any] :- Any
   (let [o (or opts {})
         host (or (.-host o) "127.0.0.1")
         port (or (.-port o) 2828)

--- a/tools/test-driver/profile.bjs
+++ b/tools/test-driver/profile.bjs
@@ -53,8 +53,8 @@
     "// tests can drive the chrome layer past public surfaces.\n"
     "user_pref(\"gjoa.test.exposeAPI\", true);\n"))
 
-(js/export (defn createProfile [opts :- Any] :- Any
-  ;; opts defaults to {} (TS `opts = {}`); callers invoke createProfile() with
+(js/export (defn create-profile [opts :- Any] :- Any
+  ;; opts defaults to {} (TS `opts = {}`); callers invoke create-profile() with
   ;; no args, so guard against an undefined opts before reading .extraPrefs.
   (let [o (or opts {})
         path (js/await (mkdtemp (join (tmpdir) "gjoa-test-")))

--- a/tools/test-driver/runner.bjs
+++ b/tools/test-driver/runner.bjs
@@ -29,9 +29,9 @@
   (:require [child_process :refer [spawn]]
             [fs/promises :refer [readdir]]
             [path :refer [join basename]]
-            [gjoa.tools.test-driver.marionette :refer [connectMarionette]]
-            [gjoa.tools.test-driver.profile :refer [createProfile]]
-            [gjoa.tools.test-driver.gjoa-locator :refer [locateGjoa]]))
+            [gjoa.tools.test-driver.marionette :refer [connect-marionette]]
+            [gjoa.tools.test-driver.profile :refer [create-profile]]
+            [gjoa.tools.test-driver.gjoa-locator :refer [locate-gjoa]]))
 (define-mode strict)
 
 (declare-extern [process JSON Date setTimeout clearTimeout] Any)
@@ -113,9 +113,9 @@
     (.once child "error" (fn [e] (logErr (str "gjoa spawn error: " (.-message e)))))
     child))
 
-(js/export (defn runAll [opts0 :- Any] :- Any
+(js/export (defn run-all [opts0 :- Any] :- Any
   (let [opts (or opts0 {})
-        gjoaBin (or (.-gjoaBin opts) (.-path (locateGjoa)))
+        gjoaBin (or (.-gjoaBin opts) (.-path (locate-gjoa)))
         ;; Compiled test suites live under .beagle-tools/ (the source is .bjs).
         testDir (or (.-testDir opts) (join (.cwd process) ".beagle-tools" "gjoa" "tests" "integration"))
         marionettePort (or (.-marionettePort opts) 2828)]
@@ -171,7 +171,7 @@
                                         :verbose (.-verbose opts)
                                         :headed (.-headed opts)}))]
                     (reset! gjoa g))
-                    (let [client (js/await (connectMarionette {:port marionettePort}))]
+                    (let [client (js/await (connect-marionette {:port marionettePort}))]
                       (js/await (.newSession client))
                       (js/await (.setContext client "chrome"))
                       client))
@@ -243,7 +243,7 @@
               (js/await
                (try
                 (do
-                  (let [p (js/await (createProfile))] (reset! profile p))
+                  (let [p (js/await (create-profile))] (reset! profile p))
                   (when (.-verbose opts) (logErr (str "profile: " (.-path (deref profile)))))
                   (when (.-verbose opts) (logErr (str "binary:  " gjoaBin)))
                   (let [m (js/await (bootGjoa (.-path (deref profile))))] (reset! mn m))
@@ -272,7 +272,7 @@
             {:pass (deref pass) :fail (deref fail) :skip (deref skip)})))))))
 
 ;; CLI entrypoint. The original guarded this with `import.meta.main`; beagle
-;; has no import.meta, and no module imports `runAll` at runtime (the integration
+;; has no import.meta, and no module imports `run-all` at runtime (the integration
 ;; tests import only the type-only `IntegrationTest`), so the block runs
 ;; unconditionally — equivalent to running the file as a script.
 (def cliArgs :- Any (.slice (.-argv process) 2))
@@ -294,7 +294,7 @@
 ;; Run the suite only when invoked directly (tests import this module for types).
 (when (.-main (js/import-meta))
   (.catch
-    (.then (runAll {:verbose cliVerbose :grep cliGrep :headed cliHeaded})
+    (.then (run-all {:verbose cliVerbose :grep cliGrep :headed cliHeaded})
            (fn [res] (.exit process (if (> (.-fail res) 0) 1 0))))
     (fn [e]
       (logErr (str "fatal: " (or (.-stack e) e)))


### PR DESCRIPTION
Two independent fixes.

### 1. prep: branding sync-FS + net pref defaults (`c272232`)
- `branding.bjs`: `bun run import` was copying 0 files and reporting "pref file missing" — a `doseq` over async `fs/promises` calls ran without awaiting. Switched the copy/append loops to sync FS (`mkdirSync`/`readFileSync`/`writeFileSync`/`rmSync`).
- `perf-prefs.js`: reverted 3 prefetch/DNS prefs to Firefox defaults (`network.prefetch-next` on, `network.dns.disablePrefetch` off, `network.http.speculative-parallel-limit` 6). adblock-rust config unchanged.

### 2. refactor: kebab-case JS exports (`51c8697`)
beagle mangles kebab to `snake_case` and emits camelCase as-is, so a camelCase export referenced cross-module in kebab resolves to a different identifier. Renamed the 16 remaining camelCase exports and their references to kebab. All references were in-corpus (`.bjs` only), no collisions.

### Verification
- 79/79 `.bjs` compile clean, 0 lint warnings
- tooling clean rebuild, integration 42/42, `chrome:dist` 46 files
