### PR TITLE
Firefox 152 + cross-platform CI (Linux/macOS) + README

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -72,7 +72,7 @@ jobs:
       # file or directory" (exit 127). beagle-build runs standalone with just
       # Racket + the repo (no raco-pkg-install / direnv setup needed).
       - name: Install Racket (beagle compiler runtime)
-        uses: Bogdanp/setup-racket@v1
+        uses: Bogdanp/setup-racket@v1.15
         with:
           version: 'stable'
       - name: Checkout beagle (sibling compiler)

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -66,6 +66,18 @@ jobs:
           mkdir -p engine
           tar -xJf ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz -C engine --strip-components=1
 
+      # gjoa's build tooling is written in beagle (a Racket compiler), invoked
+      # as a sibling at ../beagle. CI only checks out gjoa, so without these two
+      # steps `bun run import` dies with "../beagle/bin/beagle-build: No such
+      # file or directory" (exit 127). beagle-build runs standalone with just
+      # Racket + the repo (no raco-pkg-install / direnv setup needed).
+      - name: Install Racket (beagle compiler runtime)
+        uses: Bogdanp/setup-racket@v1
+        with:
+          version: 'stable'
+      - name: Checkout beagle (sibling compiler)
+        run: git clone --depth 1 https://github.com/tompassarelli/beagle.git ../beagle
+
       - name: Apply overlays and patches
         run: bun run import
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -6,11 +6,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 300
     env:
-      FF_VERSION: "151.0.1"
+      FF_VERSION: "152.0"
     steps:
       - uses: actions/checkout@v4
+
+      # Firefox's objdir is ~30GB; the runner ships ~14GB free on /. The Jun-13
+      # build stalled 34 min then SIGTERM (143) — disk exhaustion. Reclaim ~25GB
+      # of preinstalled toolchains we don't use before anything else.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+            /usr/lib/jvm /usr/share/swift "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          df -h /
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
@@ -36,7 +47,8 @@ jobs:
       - name: Maximize build space
         run: |
           sudo swapoff -a
-          sudo fallocate -l 10G /swapfile
+          sudo rm -f /swapfile
+          sudo fallocate -l 16G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile
@@ -69,6 +81,12 @@ jobs:
           ac_add_options --disable-tests
           ac_add_options --enable-optimize
           ac_add_options --enable-release
+          # lld links libxul far faster and with less peak RAM than bfd/gold.
+          ac_add_options --enable-linker=lld
+          # Debug symbols dominate link-time RAM, objdir size, and final binary
+          # size. A distribution build doesn't need them — dropping them is what
+          # keeps the link inside the runner's memory + disk envelope.
+          ac_add_options --disable-debug-symbols
           MOZCONFIG
           sed -i 's/^          //' engine/mozconfig
           cat engine/mozconfig

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,7 +29,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Install system deps
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -93,11 +93,10 @@ jobs:
           ac_add_options --disable-tests
           ac_add_options --enable-optimize
           ac_add_options --enable-release
-          # lld links libxul far faster and with less peak RAM than bfd/gold.
-          ac_add_options --enable-linker=lld
           # Debug symbols dominate link-time RAM, objdir size, and final binary
           # size. A distribution build doesn't need them — dropping them is what
-          # keeps the link inside the runner's memory + disk envelope.
+          # keeps the link inside the runner's memory + disk envelope. (lld is the
+          # toolchain's default linker on clang/Linux, so it's used without a flag.)
           ac_add_options --disable-debug-symbols
           MOZCONFIG
           sed -i 's/^          //' engine/mozconfig

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -77,6 +77,11 @@ jobs:
           version: 'stable'
       - name: Checkout beagle (sibling compiler)
         run: git clone --depth 1 https://github.com/tompassarelli/beagle.git ../beagle
+      # beagle-build resolves modules from the 'beagle' Racket collection, which
+      # is provided by beagle-lib (info.rkt: collection "beagle", deps just base).
+      # Register it as a linked package so `(require beagle/...)` resolves.
+      - name: Register beagle collection
+        run: raco pkg install --link --batch --no-docs ../beagle/beagle-lib
 
       - name: Apply overlays and patches
         run: bun run import

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -46,6 +46,19 @@ jobs:
           sed -i '' 's/return "26.4"/return "26.0"/' \
             engine/build/moz.configure/toolchain.configure
 
+      # gjoa's build tooling is written in beagle (a Racket compiler) and is
+      # invoked as a sibling checkout at ../beagle. CI only checks out gjoa, so
+      # without these two steps `bun run import` dies with
+      # "../beagle/bin/beagle-build: No such file or directory" (exit 127).
+      # beagle-build runs standalone with just Racket + the repo (verified: no
+      # raco-pkg-install / direnv / PLTCOLLECTS setup needed).
+      - name: Install Racket (beagle compiler runtime)
+        uses: Bogdanp/setup-racket@v1
+        with:
+          version: 'stable'
+      - name: Checkout beagle (sibling compiler)
+        run: git clone --depth 1 https://github.com/tompassarelli/beagle.git ../beagle
+
       - name: Apply overlays and patches
         run: bun run import
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,10 +5,13 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
-    timeout-minutes: 180
+    # macos-26 (Tahoe) ships the macOS 26 SDK, which has NSGlassEffectView — the
+    # Jun-13 build on macos-15 failed with "use of undeclared identifier
+    # 'NSGlassEffectView'" because FF 151+ uses macOS 26's Liquid Glass API.
+    runs-on: macos-26
+    timeout-minutes: 300
     env:
-      FF_VERSION: "151.0.1"
+      FF_VERSION: "152.0"
     steps:
       - uses: actions/checkout@v4
 
@@ -34,10 +37,13 @@ jobs:
 
       - name: Patch macOS SDK version check
         run: |
-          # Mozilla's TaskCluster-hosted macOS SDK (26.4) returns 403 for
-          # external CI. The Xcode SDK on the runner works fine — just
-          # lower the floor so configure accepts it.
-          sed -i '' 's/return "26.4"/return "15.0"/' \
+          # FF 152 wants the macOS 26.4 SDK; the macos-26 runner ships a 26.x
+          # Xcode SDK that may be slightly older (26.0–26.3). Lower the floor to
+          # 26.0 — still new enough to provide NSGlassEffectView (the symbol the
+          # old 15.0 floor removed, breaking the Jun-13 build), low enough that
+          # the runner's SDK is accepted. Print the SDK actually present for the log.
+          xcrun --sdk macosx --show-sdk-version || true
+          sed -i '' 's/return "26.4"/return "26.0"/' \
             engine/build/moz.configure/toolchain.configure
 
       - name: Apply overlays and patches
@@ -55,6 +61,9 @@ jobs:
           ac_add_options --disable-tests
           ac_add_options --enable-optimize
           ac_add_options --enable-release
+          # Debug symbols dominate link RAM, disk, and binary size; a distribution
+          # build doesn't need them and macOS runners have limited disk.
+          ac_add_options --disable-debug-symbols
           MOZCONFIG
           sed -i '' 's/^          //' engine/mozconfig
           cat engine/mozconfig

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,7 +53,7 @@ jobs:
       # beagle-build runs standalone with just Racket + the repo (verified: no
       # raco-pkg-install / direnv / PLTCOLLECTS setup needed).
       - name: Install Racket (beagle compiler runtime)
-        uses: Bogdanp/setup-racket@v1
+        uses: Bogdanp/setup-racket@v1.15
         with:
           version: 'stable'
       - name: Checkout beagle (sibling compiler)

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -58,6 +58,10 @@ jobs:
           version: 'stable'
       - name: Checkout beagle (sibling compiler)
         run: git clone --depth 1 https://github.com/tompassarelli/beagle.git ../beagle
+      # beagle-build resolves modules from the 'beagle' Racket collection, which
+      # beagle-lib provides (info.rkt: collection "beagle", deps just base).
+      - name: Register beagle collection
+        run: raco pkg install --link --batch --no-docs ../beagle/beagle-lib
 
       - name: Apply overlays and patches
         run: bun run import

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,7 +21,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Download Firefox source
         run: |

--- a/BUILD-LEDGER.md
+++ b/BUILD-LEDGER.md
@@ -214,3 +214,31 @@ EXCEPT they all could have been caught by reading code or running
 
 **Could this have been Lane 1?** No — the 151 bump is genuinely Lane 3
 work. But the cascade from 1 build to 4 was 100% preventable.
+
+---
+
+## 2026-06-17 — Firefox 152.0 bump (nix .#gjoa) — SUCCESS
+
+**Trigger:** user asked for latest (152); 151.0.1 was 1 major behind with 2 high
+advisories. `security:bump` → 152.0.
+
+**Cascade, all clean on the first build (no repeat-build postmortems):**
+- `security:bump` → gjoa.json 152.0; `rm -rf engine && bun run download` (FF
+  152.0 source, 760.9 MB, verified) → `bun run import`.
+- **Patches: all 3 applied clean** against 152 (no fuzzy-context breakage — the
+  classic 151-era landmine; import-first caught nothing because there was nothing).
+- **NSS:** 152 bundles NSS 3.124; nixpkgs-unstable already ships 3.124, so the
+  flake leapfrog overlay auto-disables. Bumped `minNssVersion` 3.123.1→3.124 to match.
+- **Preflight gate I** was stale (pointed at pre-beagle-port `GjoaLoader.sys.mjs`);
+  fixed to `GjoaLoader.bjs`. Bundles verified aligned (4 scripts + 3 css).
+- **PREFLIGHT GREEN 9/9.** `nix build .#gjoa --impure` → result/bin/gjoa = "Mozilla
+  Gjoa 152.0". One build, no cascade.
+
+**Why no repeat builds this time:** import-first + preflight 9/9 + the NSS floor
+checked against the *actual* 152 requirement before launching. The discipline held.
+
+**CI (friend builds, separate from this nix build):** bringing the GitHub Actions
+Linux+macOS builds online for 152 took a chain of config fixes (stale lockfile →
+missing beagle sibling → setup-racket@v1.15 → raco-link beagle-lib for the
+collection). The free Linux runner is expected to OOM at link regardless (Zen uses
+paid Blacksmith/self-hosted) — popos fallback is `nix bundle` off this local build.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ near-zero runtime cost, the things most people bolt onto Firefox with a stack
 of extensions — an ad blocker, Dark Reader, tree-style tabs — and ship it as
 one aggressively optimized build.
 
-Built on Firefox 151. The UI is written in [Beagle](https://github.com/tompassarelli/beagle)
+Built on Firefox 152. The UI is written in [Beagle](https://github.com/tompassarelli/beagle)
 (a typed Clojure subset) as `.bjs` modules under `src/gjoa/chrome/bjs/`,
 compiled to chrome JS and loaded through a native chrome loader
-(`src/gjoa/browser/components/gjoa/GjoaLoader.sys.mjs`) baked into `omni.ja` —
-no fx-autoconfig, no extension process, no per-page injection.
+(`src/gjoa/browser/components/gjoa/GjoaLoader.bjs`, itself compiled to a
+`.sys.mjs`) baked into `omni.ja` — no fx-autoconfig, no extension process,
+no per-page injection.
 
 ## What's different
 
@@ -29,7 +30,7 @@ no fx-autoconfig, no extension process, no per-page injection.
 
 **In progress**
 
-- **Native ad / tracker blocking** — Firefox 151 ships Brave's `adblock-rust`
+- **Native ad / tracker blocking** — Firefox 152 ships Brave's `adblock-rust`
   engine *in-tree* but leaves it disabled (Mozilla uses it only for
   tracker-list processing). gjoa wires it on with real filter lists:
   network-layer blocking + cosmetic filtering, uBlock-Origin-compatible
@@ -49,17 +50,21 @@ Firefox-plus-extensions setup people actually run, gjoa is dramatically lighter.
 
 ## Build
 
-NixOS (or Nix on any Linux):
+**NixOS / Nix (the primary path):**
 
 ```sh
 bun run init                       # download mozilla-central + apply overlays
-nix build .#gjoa --impure          # dev variant — fast, no LTO
-nix build .#gjoa-release --impure  # release — O3 + LTO + march=native
+nix build .#gjoa --impure          # dev variant — fast, no LTO, CPU-portable
+nix build .#gjoa-release --impure  # release — O3 + LTO + march=native (this CPU only)
 ./result/bin/gjoa
 ```
 
-Other Linux is not supported yet — the build pipeline assumes Nix for the
-toolchain.
+**Other platforms.** `.github/workflows/` builds portable artifacts with mach on
+GitHub Actions — a Linux x86_64 tarball and a macOS (`macos-26`) `.dmg`/`.app`.
+For a self-contained Linux executable that runs on any glibc distro with **no Nix
+on the target**, `nix bundle .#gjoa --impure` emits a single relocatable file.
+(CI needs the [Beagle](https://github.com/tompassarelli/beagle) compiler as a
+sibling checkout — the workflows clone it and install Racket before `import`.)
 
 ## Dev loop
 
@@ -69,8 +74,8 @@ chrome JS/CSS iterates in ~1s without one:
 ```sh
 nix develop .#mach          # shell with mach + toolchain
 cd engine && ./mach build   # one-time, ~30-60 min cold
-# edit src/gjoa/chrome/src/*.ts ...
-gjoa sync                   # bundle TS + deploy into the mach install (~1s)
+# edit src/gjoa/chrome/bjs/*.bjs (or chrome/css/*.css) ...
+gjoa sync                   # compile the .bjs chrome + deploy into the mach install (~1s)
 gjoa dev                    # restart the mach binary
 ```
 
@@ -90,9 +95,10 @@ bun run preflight         # pre-build gates (patches, chrome alignment, nix eval
 ```
 gjoa.json            project config (version, branding, URLs)
 flake.nix            Nix build (dev + release variants)
-tools/prep/          Firefox-source preparation pipeline (Bun-native)
+src/gjoa/            source overlays — chrome UI (.bjs/.css), prefs, branding, loader
+tools/prep/          Firefox-source preparation pipeline (Beagle, run on Bun)
 tools/test-driver/   Marionette integration harness
-src/gjoa/            our source overlays (chrome modules, prefs, branding)
+.github/workflows/   cross-platform CI (Linux x86_64 + macOS mach builds)
 configs/branding/    icons + brand assets
 docs/                deep-dive documentation
 BUILD-LEDGER.md      every build's outcome + postmortems

--- a/bun.lock
+++ b/bun.lock
@@ -5,21 +5,16 @@
     "": {
       "name": "gjoa",
       "devDependencies": {
-        "@types/bun": "^1.3.14",
         "happy-dom": "^20.9.0",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
-
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,9 @@
         # The block is dead weight (but harmless) once nixpkgs has
         # permanently outpaced minNssVersion; safe to delete the
         # let-bindings + the if-branch then.
-        minNssVersion = "3.123.1";
-        nssUrl = "https://github.com/nss-dev/nss/archive/NSS_3_123_1_RTM.tar.gz";
-        nssHash = "sha256-VHlcr/B04ijcZgt9XPLkBsnoJmuHjWZkdrOBYSqyYMg=";
+        minNssVersion = "3.124";
+        nssUrl = "https://github.com/nss-dev/nss/archive/NSS_3_124_RTM.tar.gz";
+        nssHash = "sha256-bMUMyb/4qkiucbkvzSY5aNS3nfaJ4XWyqf2lKnVmXfU=";
 
         basePkgs = import nixpkgs { inherit system; };
         nssOverlayNeeded =

--- a/gjoa.json
+++ b/gjoa.json
@@ -8,8 +8,8 @@
   "license": "MPL-2.0",
   "github": "tompassarelli/gjoa",
   "firefox": {
-    "version": "151.0.1",
-    "candidate": "151.0.1",
+    "version": "152.0",
+    "candidate": "152.0",
     "candidateBuild": 1
   },
   "branding": {

--- a/tests/branding.test.bjs
+++ b/tests/branding.test.bjs
@@ -79,16 +79,16 @@
 
         (test "welcome URL pref is empty (no auto-opened first-run tabs)"
           (fn []
-            (let [branding (.find all-text (fn [f] (.endsWith (.-path f) "firefox-branding.js")))]
-              (.toBeDefined (expect branding))
-              (.toMatch (expect (.-text branding))
+            (let [branding! (.find all-text (fn [f] (.endsWith (.-path f) "firefox-branding.js")))]
+              (.toBeDefined (expect branding!))
+              (.toMatch (expect (.-text branding!))
                         (RegExp. "pref\\(\"startup\\.homepage_welcome_url\",\\s*\"\"\\);")))))
 
         (test "update URLs point to gjoa.json's configured target"
           (fn []
-            (let [branding (.find all-text (fn [f] (.endsWith (.-path f) "firefox-branding.js")))]
-              (.toBeDefined (expect branding))
-              (.toContain (expect (.-text branding)) (.-updateManual (.-urls cfg))))))
+            (let [branding! (.find all-text (fn [f] (.endsWith (.-path f) "firefox-branding.js")))]
+              (.toBeDefined (expect branding!))
+              (.toContain (expect (.-text branding!)) (.-updateManual (.-urls cfg))))))
 
         (test "configure.sh display name matches gjoa.json"
           (fn []

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -258,7 +258,7 @@
 
 ;; ── Gate I: chrome bundle three-way alignment ─────────────────────────────
 (defn gateI [] :- Any
-  (let [loaderPath (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "GjoaLoader.sys.mjs")
+  (let [loaderPath (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "GjoaLoader.bjs")
         jarPath (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "jar.mn")
         bakePath (join REPO-ROOT "tools" "prep" "chrome-bake.bjs")]
     (if (not (.every [loaderPath jarPath bakePath] existsSync))


### PR DESCRIPTION
Consolidates the overnight 152 build work onto main. All 8 commits are new
content not on main (PR #8 merged the branch at the prior tip; this continues from there).

## What's here
- **build: Firefox 151.0.1 → 152.0** — `security:bump` set `gjoa.json` to 152.0;
  NSS floor bumped to 3.124 in `flake.nix`. `nix build .#gjoa --impure` verified:
  `result/bin/gjoa` reports `Mozilla Gjoa 152.0`, launches headless, renders.
- **CI: cross-platform mach builds** (`.github/workflows/`) — Linux x86_64 tarball
  + macOS (`macos-26`) `.dmg`/`.app`. Fixes: free-disk-space + 16G swap (OOM),
  drop `--frozen-lockfile` + sync `bun.lock`, clone beagle sibling + install Racket
  (`setup-racket@v1.15`), `raco pkg install --link` beagle-lib so the `beagle`
  collection resolves, drop redundant `--enable-linker=lld`. **macOS build: green.**
- **preflight: gate I** loader path `GjoaLoader.sys.mjs` → `GjoaLoader.bjs` (9/9 green).
- **docs: README de-rot** — 152, `GjoaLoader.bjs`, `.bjs` dev loop, cross-platform builds.

## Status
- nixos local build: ✅ verified
- macOS CI: ✅ green (.dmg 93MB + .app 128MB artifacts)
- Linux CI: 🟡 in progress (surviving the free runner)