### PR TITLE
fix(vim): leader-key undefined killed all hotkeys (default config)

### DIFF
--- a/src/gjoa/chrome/bjs/tabs/vim.bjs
+++ b/src/gjoa/chrome/bjs/tabs/vim.bjs
@@ -430,9 +430,15 @@
 
 
         leader-key (fn []
-          (when (pref-bool "gjoa.keys.useLeader" false)
+          ;; Must return nil (not undefined) when leader mode is off: the keydown
+          ;; handler gates on `(not= leader nil)`, which compiles to `!== null`.
+          ;; A bare `when` falls through to `undefined`, and `undefined !== null`
+          ;; is true — that wrongly routes every key into leader mode (where
+          ;; `e.key === undefined` never matches), silently killing all hotkeys.
+          (if (pref-bool "gjoa.keys.useLeader" false)
             (let [v (pref-str "gjoa.keys.leader" " ")]
-              (if (= (.-length v) 0) nil v))))
+              (if (= (.-length v) 0) nil v))
+            nil))
 
         leader-timeout-ms (fn [] :- Int
           (pref-int "gjoa.keys.leader_timeout" 1500))

--- a/tests/integration/vim-hotkeys.bjs
+++ b/tests/integration/vim-hotkeys.bjs
@@ -1,0 +1,61 @@
+#lang beagle/js
+;; Regression: vim hotkeys must fire with the DEFAULT config (leader off).
+;;
+;; Bug (found 2026-06-17): `leader-key` was `(when useLeader …)`, which falls
+;; through to `undefined` when leader mode is off (the default). The keydown
+;; handler gates on `(not= leader nil)` → compiled `leader !== null`, and
+;; `undefined !== null` is TRUE — so every keystroke was routed into leader
+;; mode with `leader === undefined`, where `e.key === undefined` never matches.
+;; Result: ALL direct vim hotkeys silently did nothing. Fix: return `nil`
+;; explicitly. This test drives REAL key events (trusted, via Marionette
+;; PerformActions) on a neutral page and asserts the hotkeys open their pickers.
+(ns gjoa.tests.integration.vim-hotkeys
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true expect wait-for sleep]]))
+(define-mode strict)
+
+(declare-extern [Error] Any)
+
+(def setup-js :- String
+  "
+  // Neutral content page; focus the gjoa panel (chrome, allowed by the handler).
+  const tab = gBrowser.addTab('about:blank', {
+    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+  });
+  gBrowser.selectedTab = tab;
+  // Default config: leader OFF (the regressing case).
+  Services.prefs.setBoolPref('gjoa.keys.useLeader', false);
+  const panel = document.getElementById('gjoa-tab-panel');
+  if (panel) { panel.setAttribute('tabindex', '0'); panel.focus(); }
+  return !!panel;
+")
+
+(def pickerOpen-js :- String
+  "return !!document.querySelector('[class*=picker], [id*=picker], .gjoa-search-input');")
+
+(def closePicker-js :- String
+  "try { document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape',bubbles:true,cancelable:true})); } catch(e){} return 1;")
+
+(defn key-action [ch :- String] :- Any
+  [{:type "key" :id "kbd"
+    :actions [{:type "keyDown" :value ch} {:type "keyUp" :value ch}]}])
+
+(js/export (def tests :- Any
+  [(deftest "vim 't' (tabs) fires with leader off" [mn]
+     (await-true "return !!document.querySelector(\"#gjoa-tab-panel\");" 10000)
+     (js/await (sleep 600))
+     (expect (chrome-eval setup-js) "no #gjoa-tab-panel to focus")
+     (chrome-eval closePicker-js)
+     (js/await (.performActions mn (key-action "t")))
+     (await-true pickerOpen-js 4000)
+     (expect (chrome-eval pickerOpen-js) "real 't' did not open the tabs picker (leader_key regression)"))
+
+   (deftest "vim ':' (ex-command) fires with leader off" [mn]
+     (await-true "return !!document.querySelector(\"#gjoa-tab-panel\");" 10000)
+     (js/await (sleep 200))
+     (chrome-eval setup-js)
+     (chrome-eval closePicker-js)
+     (js/await (.performActions mn (key-action ":")))
+     (await-true pickerOpen-js 4000)
+     (expect (chrome-eval pickerOpen-js) "real ':' did not open the ex-command picker (leader_key regression)"))]))
+
+(js/export-default tests)


### PR DESCRIPTION
## The bug
`leader-key` was `(when (pref-bool "gjoa.keys.useLeader" false) …)`. With leader
mode off (the **default**), `when` returns `undefined`. The keydown handler gates
on `(not= leader nil)` → compiled `leader !== null`, and `undefined !== null` is
`true` — so every keystroke entered the leader branch with `leader === undefined`,
where `e.key === undefined` never matches. **All direct vim hotkeys silently did
nothing** (t, :, x, o, h/l, j/k…). A nil-vs-undefined emit mismatch — not a 152 change.

## Fix
Return `nil` explicitly when leader mode is off → handler takes the direct-dispatch path.

## How it was found / verified
Drove `result/bin/gjoa` headless via Marionette with **real** key events:
- `useLeader=false` → real `t` opened nothing (the bug)
- `useLeader=true`, leader `g` → `g`,`t` opened the tabs picker (leader path works
  only when `leader_key` returns a real value)

Adds `tests/integration/vim-hotkeys.bjs` (real keys → pickers open with leader off)
as a regression guard. Preflight 9/9 green.