### PR TITLE
feat(adblock): M1 — native ad/tracker blocking ON by default

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -66,7 +66,7 @@
 ;; tools/chrome-bundle/build.config entries (minus the gjoa-hello.uc.js
 ;; smoke-test bundle, which we don't ship).
 (def PROD-SCRIPTS :- Any
-  ["gjoa-security.uc.js" "gjoa-drawer.uc.js" "gjoa-tabs.uc.js" "gjoa-dark-mode.uc.js"])
+  ["gjoa-security.uc.js" "gjoa-drawer.uc.js" "gjoa-tabs.uc.js" "gjoa-dark-mode.uc.js" "gjoa-blocking.uc.js"])
 (def PROD-STYLES :- Any
   ["gjoa.uc.css" "gjoa-tabs.uc.css" "gjoa-which-key.uc.css"])
 

--- a/src/gjoa/browser/components/gjoa/jar.mn
+++ b/src/gjoa/browser/components/gjoa/jar.mn
@@ -20,6 +20,7 @@ browser.jar:
   content/gjoa/scripts/gjoa-drawer.uc.js (content/scripts/gjoa-drawer.uc.js)
   content/gjoa/scripts/gjoa-tabs.uc.js (content/scripts/gjoa-tabs.uc.js)
   content/gjoa/scripts/gjoa-dark-mode.uc.js (content/scripts/gjoa-dark-mode.uc.js)
+  content/gjoa/scripts/gjoa-blocking.uc.js (content/scripts/gjoa-blocking.uc.js)
   content/gjoa/styles/gjoa.uc.css (content/styles/gjoa.uc.css)
   content/gjoa/styles/gjoa-tabs.uc.css (content/styles/gjoa-tabs.uc.css)
   content/gjoa/styles/gjoa-which-key.uc.css (content/styles/gjoa-which-key.uc.css)

--- a/src/gjoa/chrome/bjs/blocking/index.bjs
+++ b/src/gjoa/chrome/bjs/blocking/index.bjs
@@ -1,0 +1,83 @@
+#lang beagle/js
+;; gjoa native ad/tracker blocking — chrome-side module (Lane 1, hot-reloads via
+;; `gjoa sync`). The actual engine + list loading is the C++ content classifier +
+;; the RS-client overlay (Lane 2, in omni.ja) — chrome JS can't touch the service
+;; directly. This module is the user-facing half:
+;;   - mirrors gjoa.contentblock.enabled onto the engine's protection.enabled, so
+;;     a single gjoa pref turns blocking on/off;
+;;   - manages the per-site allow-list (gjoa.contentblock.user.allow-hosts CSV);
+;;     the overlay observes that pref and rebuilds the synthetic @@ exception
+;;     engine, so a toggle here unblocks the current site without a restart;
+;;   - exposes window.gjoaBlocking for the drawer menu to drive.
+(ns gjoa.blocking.index
+  (:require [gjoa.macros :refer [pref-bool pref-str set-pref-bool! set-pref-str! on1!]]))
+(define-mode strict)
+
+(declare-extern [window Services console gBrowser] Any)
+
+(def PREF-ENABLED :- String "gjoa.contentblock.enabled")
+(def PREF-ALLOW-HOSTS :- String "gjoa.contentblock.user.allow-hosts")
+(def PREF-PROTECTION :- String "privacy.trackingprotection.content.protection.enabled")
+
+(def state :- Any {:unsub nil})
+
+(defn enabled? [] :- Boolean (pref-bool PREF-ENABLED true))
+
+(defn parse-hosts [csv :- String] :- Any
+  (let [t (.trim csv)]
+    (if (= (.-length t) 0) []
+      (.filter (.map (.split t ",") #(.trim %)) #(> (.-length %) 0)))))
+
+(defn allow-hosts [] :- Any (parse-hosts (pref-str PREF-ALLOW-HOSTS "")))
+
+(defn current-host [] :- String
+  (try
+    (let [b (.-selectedBrowser gBrowser)
+          u (when b (.-currentURI b))]
+      (if (and u (.-host u)) (.-host u) ""))
+    (catch Any _e "")))
+
+(defn host-allowed? [h :- String] :- Boolean
+  (and (> (.-length h) 0) (> (.indexOf (allow-hosts) h) -1)))
+
+;; Toggle a host in the allow-list. Returns true if the host is now ALLOWED
+;; (blocking off for it). Rejects empty / comma-bearing hosts (CSV safety). The
+;; overlay observes PREF-ALLOW-HOSTS and rebuilds the engine — no restart.
+(defn toggle-host [h :- String] :- Boolean
+  (if (or (= (.-length h) 0) (> (.indexOf h ",") -1))
+    false
+    (let [hosts (allow-hosts)
+          idx (.indexOf hosts h)
+          was-allowed (> idx -1)]
+      (if was-allowed (.splice hosts idx 1) (.push hosts h))
+      (set-pref-str! PREF-ALLOW-HOSTS (.join hosts ","))
+      (.savePrefFile (.-prefs Services) nil)
+      (not was-allowed))))
+
+;; Mirror the gjoa enable pref onto the engine's master switch.
+(defn apply! [] :- Any (set-pref-bool! PREF-PROTECTION (enabled?)))
+
+(defn toggle [] :- Boolean
+  (let [n (not (enabled?))]
+    (set-pref-bool! PREF-ENABLED n)
+    n))
+
+(defn destroy! [] :- Any
+  (let [u (.-unsub state)] (when u (u)))
+  (set! (.-unsub state) nil))
+
+(defn init-! [] :- Any
+  (apply!)
+  (let [obs {:observe (fn [_s _t _d] (apply!))}]
+    (.addObserver (.-prefs Services) PREF-ENABLED obs)
+    (set! (.-unsub state) #(.removeObserver (.-prefs Services) PREF-ENABLED obs)))
+  (set! (.-gjoaBlocking window)
+    {:enabled enabled?
+     :toggle toggle
+     :currentHost current-host
+     :hostAllowed host-allowed?
+     :toggleHost toggle-host})
+  (on1! window "unload" destroy!)
+  (.log console (str "gjoa-blocking: initialized (enabled=" (enabled?) ")")))
+
+(init-!)

--- a/src/gjoa/defaults/pref/adblock-prefs.bjs
+++ b/src/gjoa/defaults/pref/adblock-prefs.bjs
@@ -1,0 +1,34 @@
+#lang beagle/js
+;; gjoa native ad/tracker blocking — default prefs.
+;; Shipped as DEFAULTS by compiling this file and appending its pref() output
+;; onto the branding pref file (firefox-branding.js) in tools/prep/branding.bjs
+;; — the only pref channel packaged into omni.ja without a Mozilla-source patch.
+;; (`;;` comments don't survive the beagle→js emit; rationale lives here.)
+(ns gjoa.defaults.pref.adblock)
+(define-mode strict)
+(declare-extern [pref] Any)
+
+;; Master switch for the in-engine adblock-rust content classifier. ON by
+;; default — native, third-party ad/tracker blocking with no extension. The C++
+;; service only constructs our RS-client overlay (which loads the lists) when
+;; this is true AND list_names is non-empty, so the two are co-dependent.
+(pref "privacy.trackingprotection.content.protection.enabled" true)
+
+;; Which stored lists the engine uses for BLOCKING. Each token must match a
+;; setFilterListData() name our overlay pushes: easylist + easyprivacy (the
+;; fetched lists) and gjoa-allow (the synthetic per-site exception list, always
+;; present so the allow engine exists even when empty). MUST be non-empty or the
+;; overlay is never invoked.
+(pref "privacy.trackingprotection.content.protection.list_names" "easylist,easyprivacy,gjoa-allow")
+
+;; We want blocking, not annotation — keep the annotation pathway off (empty
+;; annotation.list_names ⇒ no annotation engines regardless).
+(pref "privacy.trackingprotection.content.annotation.enabled" false)
+
+;; gjoa-side UI state. enabled mirrors protection.enabled via the blocking chrome
+;; module; allow-hosts is the CSV the overlay turns into @@ exception rules.
+(pref "gjoa.contentblock.enabled" true)
+(pref "gjoa.contentblock.user.allow-hosts" "")
+
+;; Keep the overlay's logging quiet by default (Error/Warn only).
+(pref "privacy.trackingprotection.content.remote_settings.loglevel" "Warn")

--- a/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
@@ -1,0 +1,205 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// gjoa OVERLAY of Mozilla's ContentClassifierRemoteSettingsClient.
+//
+// The in-tree adblock-rust content classifier (nsIContentClassifierService) is
+// C++ and has NO contract id — the ONLY way JS gets the service handle is to BE
+// the "RemoteSettings client" the C++ service constructs and calls init(service)
+// on (ContentClassifierService::InitRSClient). Mozilla's stock client pulls from
+// a RemoteSettings collection that doesn't exist (ships no dump), so the stock
+// production path loads ZERO lists. We keep the exact class shell + registration
+// (classID / QueryInterface / init/shutdown so components.conf + the C++ caller
+// resolve) and replace the *sourcing*: load EasyList + EasyPrivacy from a profile
+// cache (fetched on first run, refreshed when stale), push them via
+// service.setFilterListData + applyFilterLists, and synthesize a per-site
+// allow-list from a gjoa pref. No RemoteSettings server, no Mozilla collection.
+//
+// This is a Lane-2 overlay (lands in omni.ja via `bun run import` + mach build).
+// On a Firefox version bump this file may need re-syncing if Mozilla changes the
+// client/service contract.
+
+const lazy = {};
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return console.createInstance({
+    maxLogLevelPref:
+      "privacy.trackingprotection.content.remote_settings.loglevel",
+    prefix: "gjoa-adblock",
+  });
+});
+
+// The lists gjoa ships blocking with. Each `name` MUST be a token in the
+// privacy.trackingprotection.content.protection.list_names default pref.
+const LISTS = [
+  { name: "easylist", url: "https://easylist.to/easylist/easylist.txt" },
+  { name: "easyprivacy", url: "https://easylist.to/easylist/easyprivacy.txt" },
+];
+
+const CACHE_DIR = "gjoa-adblock";
+const ALLOW_PREF = "gjoa.contentblock.user.allow-hosts";
+const ALLOW_LIST_NAME = "gjoa-allow";
+// Refresh a cached list when older than this (EasyList itself expires in 4 days).
+const STALE_MS = 4 * 24 * 60 * 60 * 1000;
+
+/**
+ * gjoa's drop-in replacement for the content-classifier RemoteSettings client.
+ * Registered under @mozilla.org/content-classifier-rs-client;1 (components.conf,
+ * unchanged) so the C++ service constructs us and calls init(service).
+ */
+export class ContentClassifierRemoteSettingsClient {
+  classID = Components.ID("{C7DDDBF2-8BC4-41A1-AC90-5144BEC5ABDF}");
+  QueryInterface = ChromeUtils.generateQI([
+    "nsIContentClassifierRemoteSettingsClient",
+  ]);
+
+  #service = null;
+  #initialized = false;
+  #allowObserver = null;
+
+  constructor() {}
+
+  /**
+   * Called by the C++ ContentClassifierService with itself as `service`.
+   * Loads lists from cache (cache-first so blocking is live within ms), builds
+   * the per-site allow-list, applies, then kicks a background staleness refresh.
+   */
+  async init(service) {
+    if (!service) {
+      throw new Error("Missing required argument service");
+    }
+    if (this.#initialized) {
+      return;
+    }
+    this.#initialized = true;
+    this.#service = service;
+
+    try {
+      await this.#loadAllLists(service);
+    } catch (e) {
+      lazy.log.error("init: list load failed", e);
+    } finally {
+      // Always apply so the engine builds from whatever loaded (and so any
+      // caller waiting on the engine doesn't hang).
+      service.applyFilterLists();
+    }
+
+    // Rebuild the synthetic allow-list whenever the user's allow-hosts change.
+    this.#allowObserver = {
+      observe: () => {
+        try {
+          this.#rebuildAllowList(service);
+          service.applyFilterLists();
+        } catch (e) {
+          lazy.log.error("allow-list rebuild failed", e);
+        }
+      },
+    };
+    Services.prefs.addObserver(ALLOW_PREF, this.#allowObserver);
+
+    // Background: refresh any stale cached list without blocking startup.
+    this.#refreshStale(service).catch(e =>
+      lazy.log.error("background refresh failed", e)
+    );
+  }
+
+  shutdown() {
+    if (this.#allowObserver) {
+      Services.prefs.removeObserver(ALLOW_PREF, this.#allowObserver);
+      this.#allowObserver = null;
+    }
+    this.#service = null;
+    this.#initialized = false;
+  }
+
+  #cacheDir() {
+    const prof = Services.dirsvc.get("ProfD", Ci.nsIFile).path;
+    return PathUtils.join(prof, CACHE_DIR);
+  }
+
+  async #loadAllLists(service) {
+    const dir = this.#cacheDir();
+    await IOUtils.makeDirectory(dir, { ignoreExisting: true });
+
+    for (const { name, url } of LISTS) {
+      const path = PathUtils.join(dir, `${name}.txt`);
+      let bytes = null;
+      try {
+        if (await IOUtils.exists(path)) {
+          bytes = await IOUtils.read(path);
+        } else {
+          // First run, no cache: fetch now so blocking works on first launch.
+          bytes = await this.#fetchAndCache(url, path);
+        }
+      } catch (e) {
+        lazy.log.error(`load "${name}" failed`, e);
+      }
+      if (bytes && bytes.length) {
+        service.setFilterListData(name, bytes);
+        lazy.log.info(`loaded "${name}" (${bytes.length} bytes)`);
+      } else {
+        lazy.log.warn(`"${name}" empty/unavailable — not blocking from it`);
+      }
+    }
+
+    this.#rebuildAllowList(service);
+  }
+
+  // Build the gjoa-allow list (uBO @@ exceptions) from the user's allow-hosts
+  // pref and push it under ALLOW_LIST_NAME (a token in list_names).
+  #rebuildAllowList(service) {
+    const csv = Services.prefs.getStringPref(ALLOW_PREF, "");
+    const hosts = csv
+      .split(",")
+      .map(h => h.trim())
+      .filter(Boolean);
+    const text = hosts.map(h => `@@||${h}^$document`).join("\n") + "\n";
+    service.setFilterListData(
+      ALLOW_LIST_NAME,
+      new TextEncoder().encode(text)
+    );
+    if (hosts.length) {
+      lazy.log.info(`allow-list: ${hosts.length} host(s) exempted`);
+    }
+  }
+
+  async #fetchAndCache(url, path) {
+    const resp = await fetch(url, { cache: "no-store" });
+    if (!resp.ok) {
+      throw new Error(`fetch ${url} -> HTTP ${resp.status}`);
+    }
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    await IOUtils.write(path, buf);
+    lazy.log.info(`fetched + cached ${url} (${buf.length} bytes)`);
+    return buf;
+  }
+
+  async #refreshStale(service) {
+    const dir = this.#cacheDir();
+    let changed = false;
+    for (const { name, url } of LISTS) {
+      const path = PathUtils.join(dir, `${name}.txt`);
+      try {
+        let stale = true;
+        if (await IOUtils.exists(path)) {
+          const info = await IOUtils.stat(path);
+          stale = Date.now() - info.lastModified > STALE_MS;
+        }
+        if (stale) {
+          const bytes = await this.#fetchAndCache(url, path);
+          if (bytes && bytes.length) {
+            service.setFilterListData(name, bytes);
+            changed = true;
+          }
+        }
+      } catch (e) {
+        lazy.log.warn(`refresh "${name}" failed (keeping cache)`, e);
+      }
+    }
+    if (changed) {
+      service.applyFilterLists();
+      lazy.log.info("refreshed stale list(s) + reapplied");
+    }
+  }
+}

--- a/tests/integration/adblock-production.bjs
+++ b/tests/integration/adblock-production.bjs
@@ -1,0 +1,99 @@
+#lang beagle/js
+;; M1 production-path validation: blocking works via the SHIPPED defaults +
+;; the RS-client overlay — NOT the content.testing/test_list_urls path. Proves
+;; the actual user-facing path: default prefs (protection.enabled, list_names)
+;; trigger the C++ service -> our overlay -> setFilterListData/applyFilterLists.
+;;
+;; Offline-deterministic: we seed the profile cache (<ProfD>/gjoa-adblock/*.txt)
+;; from the local /tmp lists BEFORE restart, so the overlay's cache-first load
+;; short-circuits its network fetch.
+;;
+;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
+;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "adblock M1"
+(ns gjoa.tests.integration.adblock-production
+  (:require [gjoa.tests.dsl :refer [deftest expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON console Promise] Any)
+
+(def TOP :- String "https://example.com/")
+(def MUST-BLOCK :- Any ["https://www.googletagservices.com/favicon.ico"
+                        "https://www.google-analytics.com/favicon.ico"])
+(def MUST-SKIP :- Any ["https://doubleclick.net/favicon.ico"
+                       "https://pagead2.googlesyndication.com/favicon.ico"])
+(def ALLOWED :- Any ["https://example.net/favicon.ico"
+                     "https://upload.wikimedia.org/favicon.ico"])
+
+(def PROBE-JS :- String
+  (str "\n"
+       "  const [u, resolve] = arguments;\n"
+       "  const t = setTimeout(() => resolve('timeout'), 15000);\n"
+       "  fetch(u, { mode: 'no-cors', cache: 'no-store' })\n"
+       "    .then(() => { clearTimeout(t); resolve('loaded'); })\n"
+       "    .catch(() => { clearTimeout(t); resolve('blocked'); });\n"))
+
+(def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  setTimeout(() => finish(false), 25000);\n"))
+
+(js/export (def tests :- Any
+  [(deftest "adblock M1: production defaults block via the overlay (no test mode)" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     ;; Confirm we are NOT relying on the test path, then seed the cache from
+     ;; the local lists so the overlay loads offline-deterministically.
+     (let [seeded (js/await (.executeAsyncScript mn
+                    (str "\n"
+                         "  const [resolve] = arguments;\n"
+                         "  (async () => {\n"
+                         "    const testing = Services.prefs.getBoolPref('privacy.trackingprotection.content.testing', false);\n"
+                         "    const enabled = Services.prefs.getBoolPref('privacy.trackingprotection.content.protection.enabled', false);\n"
+                         "    const names = Services.prefs.getCharPref('privacy.trackingprotection.content.protection.list_names', '');\n"
+                         "    const dir = Services.dirsvc.get('ProfD', Ci.nsIFile).path;\n"
+                         "    const cache = PathUtils.join(dir, 'gjoa-adblock');\n"
+                         "    await IOUtils.makeDirectory(cache, { ignoreExisting: true });\n"
+                         "    for (const [name, src] of [['easylist','/tmp/gjoa-easylist.txt'],['easyprivacy','/tmp/gjoa-easyprivacy.txt']]) {\n"
+                         "      const bytes = await IOUtils.read(src);\n"
+                         "      await IOUtils.write(PathUtils.join(cache, name + '.txt'), bytes);\n"
+                         "    }\n"
+                         "    resolve(JSON.stringify({ testing, enabled, names }));\n"
+                         "  })().catch(e => resolve('ERR:' + e));\n")))]
+       (expect (not (.startsWith seeded "ERR:")) (str "seed failed: " seeded))
+       (.log console (str "\n[M1-PROD] shipped prefs: " seeded))
+       (let [p (.parse JSON seeded)]
+         (expect-eq (.-testing p) false "content.testing is set — not validating the PRODUCTION path")
+         (expect-eq (.-enabled p) true "protection.enabled default is not ON — adblock-prefs not shipped")
+         (expect (> (.-length (.-names p)) 0) "protection.list_names default is empty — overlay would never run"))
+
+       ;; Restart so the C++ service inits, constructs our overlay, which reads
+       ;; the seeded cache + setFilterListData/applyFilterLists.
+       (let [client (js/await (.restartGjoa ctx))]
+         (js/await (.setContext client "chrome"))
+         (js/await (.executeAsyncScript client "const [r]=arguments; setTimeout(()=>r(true), 5000);"))
+         (let [navOk (js/await (.executeAsyncScript client NAV-JS [TOP]))]
+           (expect navOk (str "top page " TOP " did not load (network?)"))
+           (js/await (.setContext client "content"))
+           (let [probe (fn [url] (.executeAsyncScript client PROBE-JS [url]))
+                 mustBlockR (js/await (.all Promise (.map MUST-BLOCK probe)))
+                 mustSkipR (js/await (.all Promise (.map MUST-SKIP probe)))
+                 allowedR (js/await (.all Promise (.map ALLOWED probe)))
+                 nBlocked (.-length (.filter mustBlockR #(= % "blocked")))
+                 nSkipBlocked (.-length (.filter mustSkipR #(= % "blocked")))
+                 nOverblock (.-length (.filter allowedR #(= % "blocked")))]
+             (.log console (str "[M1-PROD] must-block -> " (.stringify JSON mustBlockR) " (" nBlocked "/" (.-length MUST-BLOCK) ")"))
+             (.log console (str "[M1-PROD] option-scoped must-skip -> " (.stringify JSON mustSkipR)))
+             (.log console (str "[M1-PROD] controls -> " (.stringify JSON allowedR)))
+             (expect-eq nBlocked (.-length MUST-BLOCK)
+                        (str "PRODUCTION path failed to block via overlay (defaults + setFilterListData): " (.stringify JSON mustBlockR)
+                             " — the overlay/prefs/list_names wiring is broken, NOT the engine"))
+             (expect-eq nSkipBlocked 0 (str "over-applied option-scoped rule: " (.stringify JSON mustSkipR)))
+             (expect-eq nOverblock 0 (str "control over-blocked: " (.stringify JSON allowedR))))))))]))
+
+(js/export-default tests)

--- a/tests/integration/adblock-validate.bjs
+++ b/tests/integration/adblock-validate.bjs
@@ -1,0 +1,90 @@
+#lang beagle/js
+;; M0 VALIDATION (not a permanent test): does the in-engine adblock-rust actually
+;; block REAL ad/tracker domains on a real page when fed the FULL EasyList +
+;; EasyPrivacy (137k rules, 3.6 MB) — vs. the smoke test's single rigged rule.
+;; This is the cheapest end-to-end check before spending the M2 compile: it tells
+;; us whether "the dormant engine already works" holds at production scale, incl.
+;; whether a 3.6 MB list parses at startup without choking.
+;;
+;; Precondition: /tmp/gjoa-adblock-lists.txt = cat(easylist, easyprivacy).
+;;   GJOA_BIN=$PWD/result/bin/gjoa bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "adblock M0"
+(ns gjoa.tests.integration.adblock-validate
+  (:require [gjoa.tests.dsl :refer [deftest expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON console Promise] Any)
+
+(def LIST-FILE :- String "file:///tmp/gjoa-adblock-lists.txt")
+(def TOP :- String "https://example.com/")
+;; A no-cors fetch is classified third-party + xmlhttprequest. These hosts have
+;; rules that MATCH that (bare ||host^, or $xmlhttprequest,third-party) → must block:
+(def MUST-BLOCK :- Any ["https://www.googletagservices.com/favicon.ico"   ; ||googletagservices.com^ (bare)
+                        "https://www.google-analytics.com/favicon.ico"]) ; ||...^$script,third-party,xmlhttprequest
+;; These hosts' ONLY rules are option-scoped to contexts our probe doesn't hit
+;; ($popup / $domain=other) → engine must CORRECTLY skip them (proves precise
+;; option handling, not blunt host blocking):
+(def MUST-SKIP :- Any ["https://doubleclick.net/favicon.ico"              ; ||doubleclick.net^$popup
+                       "https://pagead2.googlesyndication.com/favicon.ico"]) ; $domain=blogto.com|youtube.com
+;; Unlisted hosts → must load (no over-block):
+(def ALLOWED :- Any ["https://example.net/favicon.ico"
+                     "https://upload.wikimedia.org/favicon.ico"])
+
+(def PROBE-JS :- String
+  (str "\n"
+       "  const [u, resolve] = arguments;\n"
+       "  const t = setTimeout(() => resolve('timeout'), 15000);\n"
+       "  fetch(u, { mode: 'no-cors', cache: 'no-store' })\n"
+       "    .then(() => { clearTimeout(t); resolve('loaded'); })\n"
+       "    .catch(() => { clearTimeout(t); resolve('blocked'); });\n"))
+
+(def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  setTimeout(() => finish(false), 25000);\n"))
+
+(js/export (def tests :- Any
+  [(deftest "adblock M0: full EasyList+EasyPrivacy blocks real ad/tracker hosts" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     ;; enable the engine in production-shaped mode, pointed at the full lists
+     (js/await (.executeScript mn
+       (str "\n"
+            "  const [u] = arguments;\n"
+            "  Services.prefs.setBoolPref('privacy.trackingprotection.content.testing', true);\n"
+            "  Services.prefs.setBoolPref('privacy.trackingprotection.content.annotation.enabled', false);\n"
+            "  Services.prefs.setCharPref('privacy.trackingprotection.content.protection.test_list_urls', u);\n"
+            "  Services.prefs.setBoolPref('privacy.trackingprotection.content.protection.enabled', true);\n"
+            "  Services.prefs.savePrefFile(null);\n")
+       [LIST-FILE]))
+     ;; restart so the service inits at startup + parses the 3.6 MB list
+     (let [client (js/await (.restartGjoa ctx))]
+       (js/await (.setContext client "chrome"))
+       ;; generous beat for a 137k-rule parse at startup
+       (js/await (.executeAsyncScript client "const [r]=arguments; setTimeout(()=>r(true), 5000);"))
+       (let [navOk (js/await (.executeAsyncScript client NAV-JS [TOP]))]
+         (expect navOk (str "top page " TOP " did not load (network?)"))
+         (js/await (.setContext client "content"))
+         (let [probe (fn [url] (.executeAsyncScript client PROBE-JS [url]))
+               mustBlockR (js/await (.all Promise (.map MUST-BLOCK probe)))
+               mustSkipR (js/await (.all Promise (.map MUST-SKIP probe)))
+               allowedR (js/await (.all Promise (.map ALLOWED probe)))
+               nBlocked (.-length (.filter mustBlockR #(= % "blocked")))
+               nSkipBlocked (.-length (.filter mustSkipR #(= % "blocked")))
+               nOverblock (.-length (.filter allowedR #(= % "blocked")))]
+           (.log console (str "\n[M0-VALIDATE] must-block (matching rules) -> " (.stringify JSON mustBlockR) " (" nBlocked "/" (.-length MUST-BLOCK) ")"))
+           (.log console (str "[M0-VALIDATE] option-scoped must-skip ($popup/$domain) -> " (.stringify JSON mustSkipR)))
+           (.log console (str "[M0-VALIDATE] controls -> " (.stringify JSON allowedR)))
+           (expect-eq nBlocked (.-length MUST-BLOCK)
+                      (str "engine failed to block a MATCHING real ad rule: " (.stringify JSON mustBlockR)))
+           (expect-eq nSkipBlocked 0
+                      (str "engine over-applied an option-scoped rule (must honor $popup/$domain): " (.stringify JSON mustSkipR)))
+           (expect-eq nOverblock 0
+                      (str "control host over-blocked: " (.stringify JSON allowedR)))))))]))
+
+(js/export-default tests)

--- a/tools/chrome-bundle/build-config.bjs
+++ b/tools/chrome-bundle/build-config.bjs
@@ -88,4 +88,12 @@
                     "// @description    Chrome-level dark mode: native color-scheme override + optional CSS inversion filter"
                     "// @include        main"
                     "// ==/UserScript=="]
+                   "\n")}
+   {:out "gjoa-blocking.uc.js"
+    :files [(str B "/blocking/index.js")]
+    :banner (.join ["// ==UserScript=="
+                    "// @name           Gjoa Blocking"
+                    "// @description    Native ad/tracker blocking: engine enable/disable + per-site allow-list"
+                    "// @include        main"
+                    "// ==/UserScript=="]
                    "\n")}]))

--- a/tools/prep/branding.bjs
+++ b/tools/prep/branding.bjs
@@ -170,7 +170,7 @@
         (throw (Error. (str "branding pref file missing at " branding-pref-file " — Mozilla's unofficial "
                             "template no longer ships pref/firefox-branding.js, so gjoa default prefs "
                             "would not be packaged. Register a pref file explicitly before relying on this."))))
-      (let [gjoa-pref-files ["perf-prefs" "dark-mode-prefs"]
+      (let [gjoa-pref-files ["perf-prefs" "dark-mode-prefs" "adblock-prefs"]
             tmp-dir (join REPO-ROOT ".beagle-tools" ".pref-build")
             _ (mkdirSync tmp-dir {:recursive true})
             pref-blocks (atom "\n\n// ===== gjoa default prefs (appended by tools/prep/branding.bjs) =====\n")]

--- a/tools/prep/chrome-bake.bjs
+++ b/tools/prep/chrome-bake.bjs
@@ -32,7 +32,8 @@
   ["gjoa-security.uc.js"
    "gjoa-drawer.uc.js"
    "gjoa-tabs.uc.js"
-   "gjoa-dark-mode.uc.js"])
+   "gjoa-dark-mode.uc.js"
+   "gjoa-blocking.uc.js"])
 (def STYLES :- Any
   ["gjoa.uc.css"
    "gjoa-tabs.uc.css"


### PR DESCRIPTION
Wires in-tree adblock-rust into default-on third-party blocking via an RS-client overlay (the service has no contract id, so we BE the client). Loads EasyList+EasyPrivacy from profile cache → setFilterListData/applyFilterLists. VERIFIED on the built mach binary: production defaults block real ad hosts, honor $popup/$domain options, no over-block. Lane 2 (overlay+prefs, omni.ja) + Lane 1 (UI module). First-party=excluded, scriptlets=deferred-curated-only.