### PR TITLE
feat(adblock): M1 global blocking toggle in drawer menu

### DIFF
--- a/src/gjoa/chrome/bjs/drawer/sidebar-button.bjs
+++ b/src/gjoa/chrome/bjs/drawer/sidebar-button.bjs
@@ -77,15 +77,18 @@
                                          (when (and native (.-click native))
                                            (.click native))))
                                      (catch Any e
-                                       (.error console "gjoa: customize sidebar failed" e)))))]
+                                       (.error console "gjoa: customize sidebar failed" e)))))
+                block-item (mi "Disable Blocking"
+                             #(when (.-gjoaBlocking window) (.toggle (.-gjoaBlocking window))))]
 
             (set! (.-id compact-item) "gjoa-toggle-compact")
             (set! (.-id collapse-item) "gjoa-collapse-layout")
             (set! (.-id sidebar-item) "gjoa-toggle-sidebar")
             (set! (.-id layout-item) "gjoa-toggle-tab-layout")
             (set! (.-id customize-item) "gjoa-customize-sidebar")
+            (set! (.-id block-item) "gjoa-toggle-blocking")
 
-            (.append menu compact-item collapse-item sidebar-item layout-item (sep) customize-item)
+            (.append menu compact-item collapse-item sidebar-item layout-item (sep) block-item customize-item)
 
             (let [popup-set (by-id "mainPopupSet")]
               (when popup-set
@@ -110,6 +113,9 @@
                                                                 (> (.-width (.getBoundingClientRect sidebar-main)) 0)))]
                                         (attr! sidebar-item "label" (if sidebar-open "Disable Sidebar" "Enable Sidebar")))
                                       (attr! layout-item "label" (if vertical "Horizontal Tabs" "Vertical Tabs"))
+                                      (when (.-gjoaBlocking window)
+                                        (attr! block-item "label"
+                                          (if (.enabled (.-gjoaBlocking window)) "Disable Blocking" "Enable Blocking")))
                                       (when (.isCompactVertical compact) (.pinSidebar compact))
                                       (when (.isCompactHorizontal compact) (.pinToolbox compact))))
 

--- a/tests/integration/adblock-ui.bjs
+++ b/tests/integration/adblock-ui.bjs
@@ -1,0 +1,32 @@
+#lang beagle/js
+;; M1 UI check: the gjoa-blocking chrome module loads, exposes window.gjoaBlocking,
+;; the drawer menu item exists, and the global toggle actually flips the engine's
+;; protection.enabled gate (the validated blocking switch). No restart needed.
+(ns gjoa.tests.integration.adblock-ui
+  (:require [gjoa.tests.dsl :refer [deftest expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON console] Any)
+
+(js/export (def tests :- Any
+  [(deftest "adblock M1: blocking module + global toggle flips the engine gate" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (let [r (js/await (.executeScript mn
+               (str "\n"
+                    "  const w = Services.wm.getMostRecentWindow('navigator:browser');\n"
+                    "  const gb = w.gjoaBlocking;\n"
+                    "  const item = w.document.getElementById('gjoa-toggle-blocking');\n"
+                    "  const P = 'privacy.trackingprotection.content.protection.enabled';\n"
+                    "  const before = Services.prefs.getBoolPref(P, false);\n"
+                    "  if (gb) gb.toggle();\n"
+                    "  const after = Services.prefs.getBoolPref(P, false);\n"
+                    "  if (gb) gb.toggle();\n"
+                    "  const restored = Services.prefs.getBoolPref(P, false);\n"
+                    "  return JSON.stringify({ hasApi: !!gb, hasItem: !!item, before, after, restored });\n")))
+           d (.parse JSON r)]
+       (.log console (str "\n[M1-UI] " r " (menu item is install!-gated on a native sidebar-button, absent headless — verified in the bundle instead)"))
+       (expect (.-hasApi d) "window.gjoaBlocking missing — the gjoa-blocking chrome module did not load")
+       (expect-eq (.-before d) true "protection.enabled not ON before toggle")
+       (expect-eq (.-after d) false "toggle did not turn the engine gate OFF — global toggle broken")
+       (expect-eq (.-restored d) true "second toggle did not restore the gate")))]))
+
+(js/export-default tests)


### PR DESCRIPTION
Drawer menu Disable/Enable item -> window.gjoaBlocking.toggle -> the validated protection.enabled gate. Verified on the mach binary (module loads + toggle flips the gate). Per-site stays M2 (needs FFI source context).