### PR TITLE
feat(adblock): native cosmetic element-hiding (M2) — retire uBlock's ##-rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ node_modules/
 # Nix build output symlink
 result
 result-*
+gjoa-portable
+
+# Local build/test logs
+artifacts/
 
 # Build acceleration caches
 .sccache/

--- a/BUILD-LEDGER.md
+++ b/BUILD-LEDGER.md
@@ -272,3 +272,48 @@ for other people = the CI artifacts, not a nix package.
 - mach dev build (`gjoa dev`) — queued after native (sequential; no concurrent
   Firefox compiles — thermal/OOM).
 - CI linux + macos re-triggered on main with the fix — in progress.
+
+## 2026-06-17 — Native cosmetic ad-blocking (M2) — SUCCESS
+
+**Type:** mach (one full `./mach build` ~27 min + two `mach build faster`
+repackages ~37 s each for actor iteration). **Trigger:** extend the upstream
+FF152 `content-classifier` component (which M0/M1 used for *network* blocking via
+prefs + the RS-client overlay) with **cosmetic element hiding** — the
+`##.selector` half of uBlock.
+
+**What landed:** Rust FFI (`url_cosmetic_resources` /
+`hidden_class_id_selectors`) → cbindgen header → C++ engine wrappers → two new IDL
+methods → XPCOM service cross-engine union → `@mozilla.org/content-classifier-service;1`
+contract id (`GetSingleton`, so JS can reach the MAIN_PROCESS_ONLY service) →
+`GjoaCosmetic` JSWindowActor pair (USER_SHEET `display:none!important`, initial
+class/id scan + timer-free MutationObserver), registered in `GjoaLoader :start`.
+
+**Validation (Marionette, on the mach binary):** M0 (real EasyList+EasyPrivacy
+blocks real ad hosts) PASS, M1-UI PASS, M1-production (isolated) PASS, M2-service
+PASS, M2-actor (at-load + dynamic hiding, control kept visible) PASS. Pre-build
+adversarial agent review of the native layer: 0 real bugs.
+
+**Lessons (gate-worthy):**
+
+1. **PERSISTENCE — `engine/` is gitignored; gjoa-modified upstream files MUST be
+   mirrored into `src/gjoa/` or CI loses them.** CI rebuilds via `bun run import`
+   (overlay `src/gjoa/X → engine/X` + patches) on a FRESH extract, so direct
+   `engine/` edits are invisible to CI. M0/M1 never modified upstream `.cpp` (just
+   prefs + the `.sys.mjs` overlay), so this was the first build to hit it. Fix: the
+   8 modified content-classifier C++/Rust/IDL/build files are now whole-file
+   overlays under `src/gjoa/toolkit/components/content-classifier/` (+ a README).
+   **New preflight gate candidate: "every gjoa-modified engine file has a src/gjoa
+   overlay or a patch" — fail loud otherwise.**
+2. **Headless content-process `setTimeout` is FROZEN** (background-tab timer
+   suspension). The actor's MutationObserver flush was rewritten timer-free (flush
+   in the observer callback; MutationObserver already batches at the microtask
+   checkpoint) — more robust in real background tabs too. Tests wait via runner-side
+   `await-true` polling, never content `setTimeout`.
+3. **beagle `.zo` cache corruption** ("instantiate-linklet mismatch") from a
+   concurrent `../beagle` edit → `raco make beagle-lib/main.rkt` rebuilds it.
+4. **`adblock-smoke` nix-vs-mach discrepancy (NOT a regression):** smoke loads a
+   rigged rule via `test_list_urls` *at startup after restart* — a test-only path
+   M0/M1 don't exercise. Passes on the LTO nix binary, fails on the unoptimized mach
+   binary (startup-ordering). The shipped paths (M0 running-load, M1 RS restart-load)
+   both pass on mach. M2 code is additive and never touches
+   `Init()`/`LoadFilterLists()`/the network path.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,375 @@
-MIT License
+ Mozilla Public License Version 2.0
+==================================
 
-Copyright (c) 2025 Tom Passarelli
+1. Definitions
+--------------
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1.1. "Contributor"
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1.2. "Contributor Version"
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+1.3. "Contribution"
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+(a) that the initial Contributor has attached the notice described
+in Exhibit B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of
+version 1.1 or earlier of the License, but not also under the
+terms of a Secondary License.
+
+1.6. "Executable Form"
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+means this document.
+
+1.9. "Licensable"
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+means any of the following:
+
+(a) any file in Source Code Form that results from an addition to,
+deletion from, or modification of the contents of Covered
+Software; or
+
+(b) any new file in Source Code Form that contains any Covered
+Software.
+
+1.11. "Patent Claims" of a Contributor
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available,
+modify, display, perform, distribute, and otherwise exploit its
+Contributions, either on an unmodified basis, with Modifications, or
+as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+for sale, have made, import, and otherwise transfer either its
+Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+or
+
+(b) for infringements caused by: (i) Your and any other third party's
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor
+Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+Form, as described in Section 3.1, and You must inform recipients of
+the Executable Form how they can obtain a copy of such Source Code
+Form by reasonable means in a timely manner, at a charge no more
+than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+License, or sublicense it under different terms, provided that the
+license for the Executable Form does not attempt to limit or alter
+the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+* *
+* 6. Disclaimer of Warranty *
+* ------------------------- *
+* *
+* Covered Software is provided under this License on an "as is" *
+* basis, without warranty of any kind, either expressed, implied, or *
+* statutory, including, without limitation, warranties that the *
+* Covered Software is free of defects, merchantable, fit for a *
+* particular purpose or non-infringing. The entire risk as to the *
+* quality and performance of the Covered Software is with You. *
+* Should any Covered Software prove defective in any respect, You *
+* (not any Contributor) assume the cost of any necessary servicing, *
+* repair, or correction. This disclaimer of warranty constitutes an *
+* essential part of this License. No use of any Covered Software is *
+* authorized under this License except under this disclaimer. *
+* *
+************************************************************************
+
+************************************************************************
+* *
+* 7. Limitation of Liability *
+* -------------------------- *
+* *
+* Under no circumstances and under no legal theory, whether tort *
+* (including negligence), contract, or otherwise, shall any *
+* Contributor, or anyone who distributes Covered Software as *
+* permitted above, be liable to You for any direct, indirect, *
+* special, incidental, or consequential damages of any character *
+* including, without limitation, damages for lost profits, loss of *
+* goodwill, work stoppage, computer failure or malfunction, or any *
+* and all other commercial damages or losses, even if such party *
+* shall have been informed of the possibility of such damages. This *
+* limitation of liability shall not apply to liability for death or *
+* personal injury resulting from such party's negligence to the *
+* extent applicable law prohibits such limitation. Some *
+* jurisdictions do not allow the exclusion or limitation of *
+* incidental or consequential damages, so this exclusion and *
+* limitation may not apply to You. *
+* *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
+
+

--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -161,11 +161,29 @@
     (catch Any e
       (.error console "gjoa-loader: setDefaults failed" e))))
 
+;; Registers the cosmetic-filtering JSWindowActor pair. The child (content
+;; process) asks the parent (where the MAIN_PROCESS_ONLY content-classifier
+;; service lives) for adblock-rust element-hiding selectors per document.
+;; Restricted to web content (messageManagerGroups "browsers"); allFrames so
+;; ads in subframes are covered too.
+(defn register-cosmetic-actor [] :- Any
+  (try
+    (.registerWindowActor ChromeUtils "GjoaCosmetic"
+      {:parent {:esModuleURI "resource://gre/modules/GjoaCosmeticParent.sys.mjs"}
+       :child {:esModuleURI "resource://gre/modules/GjoaCosmeticChild.sys.mjs"
+               :events {:DOMContentLoaded {:mozSystemGroup true}}}
+       :allFrames true
+       :messageManagerGroups ["browsers"]})
+    (.log console "gjoa-loader: registered GjoaCosmetic window actor")
+    (catch Any e
+      (.error console "gjoa-loader: registerWindowActor failed" e))))
+
 (js/export (def GjoaLoader :- Any
   {:start (fn [] :- Any
     (when (not (.-observer-registered st))
       (set! (.-observer-registered st) true)
       (set-defaults)
+      (register-cosmetic-actor)
       (.addObserver (.-obs Services) observer "chrome-document-loaded")
       (let [dev (dev-mode-dir)]
         (if dev

--- a/src/gjoa/toolkit/components/content-classifier/ContentClassifierService.cpp
+++ b/src/gjoa/toolkit/components/content-classifier/ContentClassifierService.cpp
@@ -1,0 +1,915 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ContentClassifierService.h"
+
+#include "mozilla/Logging.h"
+#include "mozilla/net/HttpBaseChannel.h"
+#include "mozilla/net/UrlClassifierCommon.h"
+#include "MainThreadUtils.h"
+#include "nsDebug.h"
+#include "mozilla/ContentClassifierEngine.h"
+#include "mozilla/ClearOnShutdown.h"
+#include "mozilla/dom/Promise.h"
+#include "mozilla/Preferences.h"
+#include "mozilla/Services.h"
+#include "mozilla/StaticPrefs_privacy.h"
+#include "mozilla/Components.h"
+#include "mozilla/MozPromise.h"
+#include "mozilla/StaticPtr.h"
+#include "nsIAsyncShutdown.h"
+#include "nsIChannel.h"
+#include "nsIStreamLoader.h"
+#include "nsIURI.h"
+#include "nsNetUtil.h"
+#include "nsContentUtils.h"
+#include "nsIWebProgressListener.h"
+#include "nsTHashSet.h"
+
+namespace mozilla {
+
+static LazyLogModule gContentClassifierLog("ContentClassifier");
+
+StaticRefPtr<ContentClassifierService> ContentClassifierService::sInstance;
+bool ContentClassifierService::sEnabled = false;
+
+namespace {
+
+bool HasAnyListNames() {
+  nsAutoCString blockNames;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.protection.list_names", blockNames);
+  nsAutoCString annotateNames;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.annotation.list_names",
+      annotateNames);
+  return !blockNames.IsEmpty() || !annotateNames.IsEmpty();
+}
+
+void NotifyListsLoadedForTesting() {
+  if (!StaticPrefs::privacy_trackingprotection_content_testing()) {
+    return;
+  }
+  nsCOMPtr<nsIObserverService> obs = services::GetObserverService();
+  if (obs) {
+    obs->NotifyObservers(
+        nullptr, NS_CONTENT_CLASSIFIER_FILTER_LISTS_LOADED_TOPIC, nullptr);
+  }
+}
+
+}  // namespace
+
+NS_IMPL_ISUPPORTS(ContentClassifierService, nsIAsyncShutdownBlocker,
+                  nsIContentClassifierService)
+
+ContentClassifierService::ContentClassifierService()
+    : mLock("ContentClassifierService::mLock"),
+      mInitPhase(InitPhase::NotInited) {
+  sEnabled =
+      Preferences::GetBool(
+          "privacy.trackingprotection.content.protection.enabled", false) ||
+      Preferences::GetBool(
+          "privacy.trackingprotection.content.annotation.enabled", false);
+}
+
+ContentClassifierService::~ContentClassifierService() = default;
+
+// static
+bool ContentClassifierService::IsEnabled() {
+  if (!sInstance) {
+    return false;
+  }
+
+  return sEnabled;
+}
+
+// static
+bool ContentClassifierService::IsInitialized() {
+  if (!sInstance) {
+    return false;
+  }
+
+  MutexAutoLock lock(sInstance->mLock);
+  return sInstance->mInitPhase == InitPhase::InitSucceeded;
+}
+
+// static
+void ContentClassifierService::OnPrefChange(const char* aPref, void*) {
+  MOZ_ASSERT(NS_IsMainThread());
+  // Access sInstance directly rather than GetInstance(), because
+  // GetInstance() returns nullptr when the feature is disabled, but we
+  // need to handle enable/disable transitions here.
+  RefPtr<ContentClassifierService> service = sInstance;
+  if (!service) {
+    return;
+  }
+
+  if (!IsInitialized()) {
+    return;
+  }
+
+  bool wasEnabled = sEnabled;
+  sEnabled =
+      Preferences::GetBool(
+          "privacy.trackingprotection.content.protection.enabled", false) ||
+      Preferences::GetBool(
+          "privacy.trackingprotection.content.annotation.enabled", false);
+
+  // mRSClient is main-thread only (see header); the NS_IsMainThread
+  // assert at the top of this function covers this read and the
+  // subsequent Init/Shutdown calls.
+  const bool hasRSClient = !!service->mRSClient;
+
+  if (!wasEnabled && sEnabled && !hasRSClient) {
+    // Feature just became enabled. Start the RS client if list names are set.
+    if (HasAnyListNames()) {
+      service->InitRSClient();
+    }
+    return;
+  }
+
+  if (wasEnabled && !sEnabled) {
+    // Feature just became disabled. Tear down the RS client and engines.
+    service->ShutdownRSClient();
+    return;
+  }
+
+  // Feature enabled state unchanged. Handle individual pref changes.
+  const nsDependentCString prefStr(aPref);
+  const bool isListNamesPref =
+      prefStr.EqualsLiteral(
+          "privacy.trackingprotection.content.protection.list_names") ||
+      prefStr.EqualsLiteral(
+          "privacy.trackingprotection.content.annotation.list_names");
+
+  if (isListNamesPref) {
+    if (!sEnabled) {
+      // list_names changed while the feature is disabled. No engines
+      // to rebuild, nothing to fetch; enabling the feature will pick
+      // up the new pref.
+      return;
+    }
+    // Active list names changed. Start RS client if needed, then rebuild
+    // engines from already-stored data to reflect the new selection.
+    if (!hasRSClient && HasAnyListNames()) {
+      service->InitRSClient();
+      // InitRSClient's async init will rebuild engines once data arrives.
+      return;
+    }
+    {
+      MutexAutoLock lock(service->mLock);
+      service->RebuildEnginesFromStoredData();
+    }
+    NotifyListsLoadedForTesting();
+    return;
+  }
+
+  const bool isTestListUrlsPref =
+      prefStr.EqualsLiteral(
+          "privacy.trackingprotection.content.protection.test_list_urls") ||
+      prefStr.EqualsLiteral(
+          "privacy.trackingprotection.content.annotation.test_list_urls");
+  if (isTestListUrlsPref) {
+    // Test list URLs changed. Reload via the HTTP test path.
+    service->LoadFilterLists();
+    return;
+  }
+
+  // An .enabled pref changed but the combined enabled state didn't flip
+  // (e.g. one was already true). Nothing to do - engines are already
+  // populated via whichever path is active.
+}
+
+void ContentClassifierService::Init() {
+  MOZ_ASSERT(XRE_IsParentProcess());
+  AssertIsOnMainThread();
+
+  {
+    MutexAutoLock lock(mLock);
+
+    if (mInitPhase != InitPhase::NotInited) {
+      return;
+    }
+
+    MOZ_LOG(gContentClassifierLog, LogLevel::Info,
+            ("ContentClassifierService::Init - initializing"));
+
+    nsCOMPtr<nsIAsyncShutdownClient> shutdownBarrier =
+        GetAsyncShutdownBarrier();
+    if (!shutdownBarrier) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    bool closed;
+    nsresult rv = shutdownBarrier->GetIsClosed(&closed);
+    if (NS_FAILED(rv) || closed) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = shutdownBarrier->AddBlocker(
+        this, NS_LITERAL_STRING_FROM_CSTRING(__FILE__), __LINE__, u""_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.protection.enabled"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.annotation.enabled"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.protection.test_list_urls"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.annotation.test_list_urls"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.protection.list_names"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    rv = Preferences::RegisterCallback(
+        &ContentClassifierService::OnPrefChange,
+        "privacy.trackingprotection.content.annotation.list_names"_ns);
+    if (NS_FAILED(rv)) {
+      mInitPhase = InitPhase::InitFailed;
+      return;
+    }
+
+    mInitPhase = InitPhase::InitSucceeded;
+  }
+
+  // Lock released; safe to call into JS.
+  // Only initialize the RS client if list_names prefs are set,
+  // to avoid interfering with the test-only HTTP loading path.
+  if (sEnabled && HasAnyListNames()) {
+    InitRSClient();
+  }
+
+  if (StaticPrefs::privacy_trackingprotection_content_testing()) {
+    LoadFilterLists();
+  }
+}
+
+void ContentClassifierService::InitRSClient() {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  if (mRSClient) {
+    return;
+  }
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Info,
+              "InitRSClient - creating RS client");
+
+  nsresult rv;
+  mRSClient =
+      do_GetService(NS_CONTENTCLASSIFIERREMOTESETTINGSCLIENT_CONTRACTID, &rv);
+  if (NS_WARN_IF(NS_FAILED(rv))) {
+    MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Error,
+                "InitRSClient - failed to get RS client service: {:#x}",
+                static_cast<uint32_t>(rv));
+    return;
+  }
+
+  // The returned Promise is ignored: C++ doesn't need to await the
+  // initial import. Callers that do (such as tests) observe the
+  // NS_CONTENT_CLASSIFIER_FILTER_LISTS_LOADED_TOPIC notification.
+  RefPtr<dom::Promise> unused;
+  rv = mRSClient->Init(this, getter_AddRefs(unused));
+  if (NS_WARN_IF(NS_FAILED(rv))) {
+    MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Error,
+                "InitRSClient - failed to init RS client: {:#x}",
+                static_cast<uint32_t>(rv));
+    mRSClient = nullptr;
+    return;
+  }
+}
+
+void ContentClassifierService::ShutdownRSClient() {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Info, "ShutdownRSClient");
+
+  if (mRSClient) {
+    // Release mRSClient before reacquiring mLock. The JS Shutdown()
+    // implementation does not call back into us, but drop the strong
+    // reference first to be defensive.
+    nsCOMPtr<nsIContentClassifierRemoteSettingsClient> client =
+        std::move(mRSClient);
+    client->Shutdown();
+  }
+
+  MutexAutoLock lock(mLock);
+  mFilterListData.Clear();
+  mBlockEngines.Clear();
+  mAnnotateEngines.Clear();
+}
+
+// static
+already_AddRefed<ContentClassifierService>
+ContentClassifierService::GetInstance() {
+  if (!sInstance) {
+    sInstance = new ContentClassifierService();
+    ClearOnShutdown(&sInstance);
+    sInstance->Init();
+  }
+
+  if (!IsInitialized() || !IsEnabled()) {
+    return nullptr;
+  }
+
+  return do_AddRef(sInstance);
+}
+
+// static
+already_AddRefed<nsIContentClassifierService>
+ContentClassifierService::GetSingleton() {
+  if (!sInstance) {
+    sInstance = new ContentClassifierService();
+    ClearOnShutdown(&sInstance);
+    sInstance->Init();
+  }
+  RefPtr<nsIContentClassifierService> service = sInstance.get();
+  return service.forget();
+}
+
+already_AddRefed<nsIAsyncShutdownClient>
+ContentClassifierService::GetAsyncShutdownBarrier() const {
+  nsCOMPtr<nsIAsyncShutdownService> svc = components::AsyncShutdown::Service();
+  MOZ_RELEASE_ASSERT(svc);
+
+  nsCOMPtr<nsIAsyncShutdownClient> client;
+  nsresult rv = svc->GetProfileBeforeChange(getter_AddRefs(client));
+  MOZ_RELEASE_ASSERT(NS_SUCCEEDED(rv));
+  MOZ_RELEASE_ASSERT(client);
+
+  return client.forget();
+}
+
+NS_IMETHODIMP ContentClassifierService::BlockShutdown(
+    nsIAsyncShutdownClient* aClient) {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  MOZ_LOG(gContentClassifierLog, LogLevel::Info,
+          ("ContentClassifierService::BlockShutdown - shutting down"));
+
+  // ShutdownRSClient clears the filter list data and engines. It also
+  // tears down the RS client if one was created (the HTTP-only test
+  // path leaves mRSClient null).
+  ShutdownRSClient();
+
+  MutexAutoLock lock(mLock);
+
+  mInitPhase = InitPhase::ShutdownStarted;
+
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.protection.enabled"_ns);
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.annotation.enabled"_ns);
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.protection.test_list_urls"_ns);
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.annotation.test_list_urls"_ns);
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.protection.list_names"_ns);
+  Preferences::UnregisterCallback(
+      &ContentClassifierService::OnPrefChange,
+      "privacy.trackingprotection.content.annotation.list_names"_ns);
+
+  content_classifier_teardown_domain_resolver();
+
+  RemoveBlocker();
+
+  return NS_OK;
+}
+
+void ContentClassifierService::RemoveBlocker() {
+  MOZ_ASSERT(NS_IsMainThread());
+  mLock.AssertCurrentThreadOwns();
+  nsCOMPtr<nsIAsyncShutdownClient> asc = GetAsyncShutdownBarrier();
+  MOZ_ASSERT(asc);
+  DebugOnly<nsresult> rv = asc->RemoveBlocker(this);
+  MOZ_ASSERT(NS_SUCCEEDED(rv));
+  mInitPhase = InitPhase::ShutdownEnded;
+}
+
+ContentClassifierResult ContentClassifierService::ClassifyWithEngines(
+    const nsTArray<UniquePtr<ContentClassifierEngine>>& aEngines,
+    const ContentClassifierRequest& aRequest) {
+  MOZ_ASSERT(!NS_IsMainThread());
+  mLock.AssertCurrentThreadOwns();
+  if (mInitPhase != InitPhase::InitSucceeded) {
+    return ContentClassifierResult(NS_ERROR_NOT_INITIALIZED);
+  }
+  if (!aRequest.Valid()) {
+    return ContentClassifierResult(NS_ERROR_INVALID_ARG);
+  }
+  ContentClassifierResult result(NS_OK);
+  for (const auto& engine : aEngines) {
+    ContentClassifierResult thisResult = engine->CheckNetworkRequest(aRequest);
+    result.Accumulate(thisResult);
+    if (result.Important()) {
+      break;
+    }
+  }
+  return result;
+}
+
+NS_IMETHODIMP ContentClassifierService::GetName(nsAString& aName) {
+  aName.AssignLiteral("ContentClassifierService: Shutting down");
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentClassifierService::GetState(nsIPropertyBag** aState) {
+  *aState = nullptr;
+  return NS_OK;
+}
+
+ContentClassifierResult ContentClassifierService::ClassifyForAnnotate(
+    const ContentClassifierRequest& aRequest) {
+  MutexAutoLock lock(mLock);
+  ContentClassifierResult result =
+      ClassifyWithEngines(mAnnotateEngines, aRequest);
+  MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+          ("ClassifyForAnnotate - url=%s hit=%d exception=%d",
+           aRequest.Url().get(), result.Hit(), result.Exception()));
+  return result;
+}
+
+ContentClassifierResult ContentClassifierService::ClassifyForCancel(
+    const ContentClassifierRequest& aRequest) {
+  MutexAutoLock lock(mLock);
+  ContentClassifierResult result = ClassifyWithEngines(mBlockEngines, aRequest);
+  MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+          ("ClassifyForCancel - url=%s hit=%d exception=%d",
+           aRequest.Url().get(), result.Hit(), result.Exception()));
+  return result;
+}
+
+void ContentClassifierService::AnnotateChannel(nsIChannel* aChannel) {
+  NS_ENSURE_TRUE_VOID(aChannel);
+
+  nsCOMPtr<nsIURI> uri;
+  aChannel->GetURI(getter_AddRefs(uri));
+  if (uri) {
+    MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+            ("AnnotateChannel - url=%s", uri->GetSpecOrDefault().get()));
+  }
+
+  net::UrlClassifierCommon::AnnotateChannel(
+      aChannel, nsIClassifiedChannel::ClassificationFlags::CLASSIFIED_TRACKING,
+      nsIWebProgressListener::STATE_LOADED_LEVEL_2_TRACKING_CONTENT);
+}
+
+void ContentClassifierService::CancelChannel(nsIChannel* aChannel) {
+  NS_ENSURE_TRUE_VOID(aChannel);
+
+  nsCOMPtr<nsIURI> uri;
+  aChannel->GetURI(getter_AddRefs(uri));
+  if (uri) {
+    MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+            ("CancelChannel - url=%s", uri->GetSpecOrDefault().get()));
+  }
+
+  net::UrlClassifierCommon::SetBlockedContent(aChannel, NS_ERROR_TRACKING_URI,
+                                              "content-classifier-block"_ns,
+                                              "content-classifier"_ns, ""_ns);
+
+  nsCOMPtr<nsIHttpChannelInternal> httpChannel = do_QueryInterface(aChannel);
+
+  if (httpChannel) {
+    (void)httpChannel->CancelByURLClassifier(NS_ERROR_TRACKING_URI);
+  } else {
+    (void)aChannel->Cancel(NS_ERROR_TRACKING_URI);
+  }
+}
+
+// nsIContentClassifierService
+
+NS_IMETHODIMP ContentClassifierService::SetFilterListData(
+    const nsACString& aName, const nsTArray<uint8_t>& aData) {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Debug,
+              "SetFilterListData - name={} size={}", aName, aData.Length());
+
+  MutexAutoLock lock(mLock);
+  if (mInitPhase != InitPhase::InitSucceeded) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+  mFilterListData.InsertOrUpdate(nsCString(aName), aData.Clone());
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentClassifierService::RemoveFilterList(
+    const nsACString& aName) {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Debug,
+              "RemoveFilterList - name={}", aName);
+
+  MutexAutoLock lock(mLock);
+  if (mInitPhase != InitPhase::InitSucceeded) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+  mFilterListData.Remove(nsCString(aName));
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentClassifierService::ApplyFilterLists() {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Info,
+              "ApplyFilterLists - rebuilding engines from stored data");
+
+  {
+    MutexAutoLock lock(mLock);
+    if (mInitPhase != InitPhase::InitSucceeded) {
+      return NS_ERROR_NOT_INITIALIZED;
+    }
+    RebuildEnginesFromStoredData();
+  }
+
+  NotifyListsLoadedForTesting();
+
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentClassifierService::GetUrlCosmeticResources(
+    const nsACString& aUrl, nsTArray<nsCString>& aHideSelectors,
+    nsTArray<nsCString>& aProceduralActions, nsTArray<nsCString>& aExceptions,
+    nsACString& aInjectedScript, bool* aGenericHide) {
+  NS_ENSURE_ARG_POINTER(aGenericHide);
+
+  aHideSelectors.Clear();
+  aProceduralActions.Clear();
+  aExceptions.Clear();
+  aInjectedScript.Truncate();
+  *aGenericHide = false;
+
+  MutexAutoLock lock(mLock);
+  if (mInitPhase != InitPhase::InitSucceeded) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+
+  nsTHashSet<nsCString> hideSeen;
+  nsTHashSet<nsCString> procSeen;
+  nsTHashSet<nsCString> excSeen;
+  nsCString injectedAccum;
+
+  for (const auto& engine : mBlockEngines) {
+    nsTArray<nsCString> hide;
+    nsTArray<nsCString> proc;
+    nsTArray<nsCString> exc;
+    nsCString injected;
+    bool generichide = false;
+    nsresult rv = engine->GetUrlCosmeticResources(aUrl, hide, proc, exc,
+                                                  injected, generichide);
+    if (NS_FAILED(rv)) {
+      continue;
+    }
+    for (auto& s : hide) {
+      if (hideSeen.EnsureInserted(s)) {
+        aHideSelectors.AppendElement(s);
+      }
+    }
+    for (auto& s : proc) {
+      if (procSeen.EnsureInserted(s)) {
+        aProceduralActions.AppendElement(s);
+      }
+    }
+    for (auto& s : exc) {
+      if (excSeen.EnsureInserted(s)) {
+        aExceptions.AppendElement(s);
+      }
+    }
+    if (!injected.IsEmpty()) {
+      if (!injectedAccum.IsEmpty()) {
+        injectedAccum.Append('\n');
+      }
+      injectedAccum.Append(injected);
+    }
+    if (generichide) {
+      *aGenericHide = true;
+    }
+  }
+
+  aInjectedScript.Assign(injectedAccum);
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentClassifierService::GetHiddenClassIdSelectors(
+    const nsTArray<nsCString>& aClasses, const nsTArray<nsCString>& aIds,
+    const nsTArray<nsCString>& aExceptions, nsTArray<nsCString>& aSelectors) {
+  aSelectors.Clear();
+
+  MutexAutoLock lock(mLock);
+  if (mInitPhase != InitPhase::InitSucceeded) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+
+  nsTHashSet<nsCString> seen;
+  for (const auto& engine : mBlockEngines) {
+    nsTArray<nsCString> selectors;
+    nsresult rv =
+        engine->GetHiddenClassIdSelectors(aClasses, aIds, aExceptions,
+                                          selectors);
+    if (NS_FAILED(rv)) {
+      continue;
+    }
+    for (auto& s : selectors) {
+      if (seen.EnsureInserted(s)) {
+        aSelectors.AppendElement(s);
+      }
+    }
+  }
+  return NS_OK;
+}
+
+// Parses a byte buffer of adblock-format filter list text into rules.
+// Tolerates both LF and CRLF line endings; skips empty lines.
+static void ParseFilterListRules(const nsTArray<uint8_t>& aData,
+                                 nsTArray<nsCString>& aRules) {
+  nsDependentCSubstring content(reinterpret_cast<const char*>(aData.Elements()),
+                                aData.Length());
+  for (const auto& line : content.Split('\n')) {
+    nsCString rule(line);
+    // Trim trailing CR for CRLF line endings.
+    if (!rule.IsEmpty() && rule.Last() == '\r') {
+      rule.Truncate(rule.Length() - 1);
+    }
+    if (!rule.IsEmpty()) {
+      aRules.AppendElement(std::move(rule));
+    }
+  }
+}
+
+void ContentClassifierService::RebuildEnginesFromStoredData() {
+  mLock.AssertCurrentThreadOwns();
+
+  nsAutoCString blockListPref;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.protection.list_names",
+      blockListPref);
+
+  nsAutoCString annotateListPref;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.annotation.list_names",
+      annotateListPref);
+
+  MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Debug,
+              "RebuildEnginesFromStoredData - block lists: \"{}\", "
+              "annotate lists: \"{}\", stored lists: {}",
+              blockListPref, annotateListPref, mFilterListData.Count());
+
+  auto buildEngines =
+      [this](const nsACString& aListNamesPref,
+             nsTArray<UniquePtr<ContentClassifierEngine>>& aEngines)
+          MOZ_REQUIRES(mLock) {
+            aEngines.Clear();
+            for (const auto& name : aListNamesPref.Split(',')) {
+              nsAutoCString trimmedName(name);
+              trimmedName.Trim(" ");
+              if (trimmedName.IsEmpty()) {
+                continue;
+              }
+
+              auto entry = mFilterListData.Lookup(trimmedName);
+              if (!entry) {
+                MOZ_LOG_FMT(
+                    gContentClassifierLog, LogLevel::Warning,
+                    "RebuildEnginesFromStoredData - list \"{}\" not found "
+                    "in stored data",
+                    trimmedName);
+                continue;
+              }
+
+              nsTArray<nsCString> rules;
+              ParseFilterListRules(entry.Data(), rules);
+
+              auto engine = MakeUnique<ContentClassifierEngine>();
+              nsresult rv = engine->InitFromRules(rules);
+              if (NS_FAILED(rv)) {
+                MOZ_LOG_FMT(
+                    gContentClassifierLog, LogLevel::Error,
+                    "RebuildEnginesFromStoredData - failed to init engine "
+                    "for \"{}\": {:#x}",
+                    trimmedName, static_cast<uint32_t>(rv));
+                continue;
+              }
+
+              MOZ_LOG_FMT(gContentClassifierLog, LogLevel::Info,
+                          "RebuildEnginesFromStoredData - loaded engine "
+                          "for \"{}\" with {} rules",
+                          trimmedName, rules.Length());
+              aEngines.AppendElement(std::move(engine));
+            }
+          };
+
+  buildEngines(blockListPref, mBlockEngines);
+  buildEngines(annotateListPref, mAnnotateEngines);
+}
+
+// HTTP-based list loading (test only)
+
+class FilterListLoader final : public nsIStreamLoaderObserver {
+ public:
+  NS_DECL_THREADSAFE_ISUPPORTS
+
+  explicit FilterListLoader(nsTArray<nsCString>* aRules) : mRules(aRules) {}
+
+  NS_IMETHOD
+  OnStreamComplete(nsIStreamLoader* aLoader, nsISupports* aCtxt,
+                   nsresult aStatus, uint32_t aResultLength,
+                   const uint8_t* aResult) override {
+    MOZ_ASSERT(NS_IsMainThread());
+
+    NS_ENSURE_SUCCESS(aStatus, aStatus);
+    if (NS_FAILED(aStatus)) {
+      MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+              ("FilterListLoader::OnStreamComplete - failed with status 0x%x",
+               static_cast<uint32_t>(aStatus)));
+      mPromiseHolder.RejectIfExists(aStatus, __func__);
+      return aStatus;
+    }
+
+    nsAutoCString content(reinterpret_cast<const char*>(aResult),
+                          aResultLength);
+
+    for (const auto& line : content.Split('\n')) {
+      if (!line.IsEmpty()) {
+        mRules->AppendElement(line);
+      }
+    }
+
+    MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+            ("FilterListLoader::OnStreamComplete - loaded %zu rules",
+             mRules->Length()));
+
+    mPromiseHolder.ResolveIfExists(true, __func__);
+
+    return NS_OK;
+  }
+
+  RefPtr<GenericPromise> Load(const nsACString& aURL) {
+    MOZ_ASSERT(NS_IsMainThread());
+
+    nsCOMPtr<nsIURI> uri;
+    nsresult rv = NS_NewURI(getter_AddRefs(uri), aURL);
+    NS_ENSURE_SUCCESS(rv, GenericPromise::CreateAndReject(rv, __func__));
+
+    nsCOMPtr<nsIChannel> channel;
+    uint32_t loadFlags = nsIChannel::LOAD_BYPASS_URL_CLASSIFIER;
+    rv = NS_NewChannel(getter_AddRefs(channel), uri,
+                       nsContentUtils::GetSystemPrincipal(),
+                       nsILoadInfo::SEC_ALLOW_CROSS_ORIGIN_SEC_CONTEXT_IS_NULL,
+                       nsIContentPolicy::TYPE_OTHER,
+                       nullptr,  // nsICookieJarSettings
+                       nullptr,  // aPerformanceStorage
+                       nullptr,  // aLoadGroup
+                       nullptr,  // aInterfaceRequestor
+                       loadFlags);
+    NS_ENSURE_SUCCESS(rv, GenericPromise::CreateAndReject(rv, __func__));
+
+    nsCOMPtr<nsIStreamLoader> loader;
+    rv = NS_NewStreamLoader(getter_AddRefs(loader), this);
+    NS_ENSURE_SUCCESS(rv, GenericPromise::CreateAndReject(rv, __func__));
+
+    rv = channel->AsyncOpen(loader);
+    NS_ENSURE_SUCCESS(rv, GenericPromise::CreateAndReject(rv, __func__));
+
+    return mPromiseHolder.Ensure(__func__);
+  }
+
+ private:
+  ~FilterListLoader() {
+    mPromiseHolder.RejectIfExists(NS_ERROR_ABORT, __func__);
+  }
+
+  nsTArray<nsCString>* mRules;
+  MozPromiseHolder<GenericPromise> mPromiseHolder;
+};
+
+NS_IMPL_ISUPPORTS(FilterListLoader, nsIStreamLoaderObserver)
+
+void ContentClassifierService::LoadFilterLists() {
+  MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+          ("ContentClassifierService::LoadFilterLists - loading filter lists"));
+
+  nsTArray<RefPtr<GenericPromise>> promises;
+
+  nsAutoCString blockListPref;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.protection.test_list_urls",
+      blockListPref);
+
+  nsTArray<nsCString> blockListURLs;
+  for (const nsACString& url : blockListPref.Split('|')) {
+    if (!url.IsEmpty()) {
+      blockListURLs.AppendElement(url);
+      MOZ_LOG(
+          gContentClassifierLog, LogLevel::Debug,
+          ("LoadFilterLists - block list URL: %s", nsAutoCString(url).get()));
+    }
+  }
+
+  nsAutoCString annotationListPref;
+  Preferences::GetCString(
+      "privacy.trackingprotection.content.annotation.test_list_urls",
+      annotationListPref);
+
+  nsTArray<nsCString> annotationListURLs;
+  for (const nsACString& url : annotationListPref.Split('|')) {
+    if (!url.IsEmpty()) {
+      annotationListURLs.AppendElement(url);
+      MOZ_LOG(gContentClassifierLog, LogLevel::Debug,
+              ("LoadFilterLists - annotation list URL: %s",
+               nsAutoCString(url).get()));
+    }
+  }
+
+  nsTArray<nsTArray<nsCString>> blockFilterRules;
+  nsTArray<nsTArray<nsCString>> annotateFilterRules;
+  blockFilterRules.SetLength(blockListURLs.Length());
+  annotateFilterRules.SetLength(annotationListURLs.Length());
+
+  for (size_t i = 0; i < blockListURLs.Length(); ++i) {
+    RefPtr<FilterListLoader> loader =
+        new FilterListLoader(&blockFilterRules[i]);
+    promises.AppendElement(loader->Load(blockListURLs[i]));
+  }
+
+  for (size_t i = 0; i < annotationListURLs.Length(); ++i) {
+    RefPtr<FilterListLoader> loader =
+        new FilterListLoader(&annotateFilterRules[i]);
+    promises.AppendElement(loader->Load(annotationListURLs[i]));
+  }
+
+  GenericPromise::AllSettled(GetMainThreadSerialEventTarget(), promises)
+      ->Then(
+          GetMainThreadSerialEventTarget(), __func__,
+          [self = RefPtr{this},
+           annotateFilterRules = std::move(annotateFilterRules),
+           blockFilterRules = std::move(blockFilterRules)](
+              const GenericPromise::AllSettledPromiseType::ResolveOrRejectValue&
+                  aResults) {
+            ReleasableMutexAutoLock lock(self->mLock);
+            self->mBlockEngines.Clear();
+            self->mAnnotateEngines.Clear();
+
+            for (const auto& rules : blockFilterRules) {
+              auto engine = MakeUnique<ContentClassifierEngine>();
+              nsresult rv = engine->InitFromRules(rules);
+              if (NS_FAILED(rv)) {
+                continue;
+              }
+              self->mBlockEngines.AppendElement(std::move(engine));
+            }
+
+            for (const auto& rules : annotateFilterRules) {
+              auto engine = MakeUnique<ContentClassifierEngine>();
+              nsresult rv = engine->InitFromRules(rules);
+              if (NS_FAILED(rv)) {
+                continue;
+              }
+              self->mAnnotateEngines.AppendElement(std::move(engine));
+            }
+
+            lock.Unlock();
+            NotifyListsLoadedForTesting();
+          });
+}
+
+}  // namespace mozilla

--- a/src/gjoa/toolkit/components/content-classifier/ContentClassifierService.h
+++ b/src/gjoa/toolkit/components/content-classifier/ContentClassifierService.h
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_ContentClassifierService_h
+#define mozilla_ContentClassifierService_h
+
+#include "mozilla/Mutex.h"
+#include "mozilla/StaticPtr.h"
+#include "mozilla/ThreadSafety.h"
+#include "mozilla/UniquePtr.h"
+#include "nsIAsyncShutdown.h"
+#include "nsIChannel.h"
+#include "nsIContentClassifierService.h"
+#include "nsIContentClassifierRemoteSettingsClient.h"
+#include "nsISupportsImpl.h"
+#include "nsTArray.h"
+#include "nsTHashMap.h"
+
+#include "mozilla/ContentClassifierEngine.h"
+
+namespace mozilla {
+
+enum class ClassifyMode { Annotate, Cancel };
+
+enum class InitPhase {
+  NotInited,
+  InitSucceeded,
+  InitFailed,
+  ShutdownStarted,
+  ShutdownEnded
+};
+
+class ContentClassifierService final : public nsIAsyncShutdownBlocker,
+                                       public nsIContentClassifierService {
+ public:
+  NS_DECL_THREADSAFE_ISUPPORTS
+  NS_DECL_NSIASYNCSHUTDOWNBLOCKER
+  NS_DECL_NSICONTENTCLASSIFIERSERVICE
+
+  static already_AddRefed<ContentClassifierService> GetInstance();
+
+  // Component-manager constructor for @mozilla.org/content-classifier-service;1.
+  // Returns the singleton unconditionally (constructing it if needed), so JS
+  // can query cosmetic resources. Unlike GetInstance() it does not gate on the
+  // enabled pref; callers that need that gate check IsEnabled() themselves.
+  static already_AddRefed<nsIContentClassifierService> GetSingleton();
+
+  static bool IsEnabled();
+  static bool IsInitialized();
+
+  ContentClassifierResult ClassifyForCancel(
+      const ContentClassifierRequest& aRequest);
+  ContentClassifierResult ClassifyForAnnotate(
+      const ContentClassifierRequest& aRequest);
+
+  void CancelChannel(nsIChannel* aChannel);
+  void AnnotateChannel(nsIChannel* aChannel);
+
+ private:
+  ContentClassifierService();
+  ~ContentClassifierService();
+
+  void Init();
+  static void OnPrefChange(const char* aPref, void* aData);
+  void LoadFilterLists();
+  void RebuildEnginesFromStoredData();
+  void InitRSClient();
+  void ShutdownRSClient();
+  void RemoveBlocker();
+  already_AddRefed<nsIAsyncShutdownClient> GetAsyncShutdownBarrier() const;
+
+  ContentClassifierResult ClassifyWithEngines(
+      const nsTArray<UniquePtr<ContentClassifierEngine>>& aEngines,
+      const ContentClassifierRequest& aRequest);
+
+  static StaticRefPtr<ContentClassifierService> sInstance;
+  static bool sEnabled;
+
+  mozilla::Mutex mLock MOZ_UNANNOTATED;
+  InitPhase mInitPhase MOZ_GUARDED_BY(mLock);
+  // The adblock engines are built with the crate's `single-thread` feature, so
+  // ContentClassifierEngine is !Sync: EVERY access to these lists (including
+  // read-only cosmetic queries on the main thread and network classification on
+  // the classifier worker) must hold mLock. MOZ_GUARDED_BY enforces it; do not
+  // add a code path that touches an engine without the lock.
+  nsTArray<UniquePtr<ContentClassifierEngine>> mBlockEngines
+      MOZ_GUARDED_BY(mLock);
+  nsTArray<UniquePtr<ContentClassifierEngine>> mAnnotateEngines
+      MOZ_GUARDED_BY(mLock);
+
+  // Raw filter list data stored by list name, populated by the RS client.
+  nsTHashMap<nsCStringHashKey, nsTArray<uint8_t>> mFilterListData
+      MOZ_GUARDED_BY(mLock);
+
+  // RemoteSettings client for fetching filter lists. All reads and
+  // writes must happen on the main thread; each call site asserts.
+  nsCOMPtr<nsIContentClassifierRemoteSettingsClient> mRSClient;
+};
+
+}  // namespace mozilla
+
+#endif  // mozilla_ContentClassifierService_h

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Content half of the gjoa cosmetic-filtering actor. On document load it asks
+// the parent for the adblock-rust element-hiding selectors for this URL plus
+// the generic class/id-triggered selectors for the elements currently present,
+// then injects them as a single USER_SHEET ({display:none!important}) — the same
+// page-CSS-proof mechanism uBlock Origin uses. A MutationObserver feeds
+// newly-appearing classes/ids back to the parent for lazy selectors, which are
+// merged into the same sheet.
+
+const CHUNK = 1000; // selectors per rule, to bound the blast radius of a bad one
+
+function buildCss(selectors) {
+  let css = "";
+  for (let i = 0; i < selectors.length; i += CHUNK) {
+    const group = selectors.slice(i, i + CHUNK).join(",");
+    if (group) {
+      css += group + "{display:none!important}\n";
+    }
+  }
+  return css;
+}
+
+export class GjoaCosmeticChild extends JSWindowActorChild {
+  constructor() {
+    super();
+    this._generichide = false;
+    this._exceptions = [];
+    this._seenClasses = new Set();
+    this._seenIds = new Set();
+    this._observer = null;
+    // All hidden selectors accumulate into one Set backing a SINGLE USER_SHEET
+    // that is replaced on change — rather than loading a new sheet per batch,
+    // which would pile up unbounded on a long-lived SPA.
+    this._selectors = new Set();
+    this._sheetUri = null;
+  }
+
+  addSelectors(list) {
+    if (!list || !list.length) {
+      return;
+    }
+    let added = false;
+    for (const s of list) {
+      if (s && !this._selectors.has(s)) {
+        this._selectors.add(s);
+        added = true;
+      }
+    }
+    if (added) {
+      this.rebuildSheet();
+    }
+  }
+
+  rebuildSheet() {
+    const win = this.contentWindow;
+    if (!win || !win.windowUtils) {
+      return;
+    }
+    const css = buildCss([...this._selectors]);
+    if (!css) {
+      return;
+    }
+    const utils = win.windowUtils;
+    const uri = "data:text/css;charset=utf-8," + encodeURIComponent(css);
+    try {
+      if (this._sheetUri) {
+        try {
+          utils.removeSheetUsingURIString(this._sheetUri, utils.USER_SHEET);
+        } catch (e) {}
+      }
+      utils.loadSheetUsingURIString(uri, utils.USER_SHEET);
+      this._sheetUri = uri;
+    } catch (e) {}
+  }
+
+  collectClassesIds(root, outClasses, outIds) {
+    const consider = el => {
+      const cl = el.classList;
+      if (cl) {
+        for (const c of cl) {
+          if (!this._seenClasses.has(c)) {
+            this._seenClasses.add(c);
+            outClasses.add(c);
+          }
+        }
+      }
+      const id = el.id;
+      if (id && !this._seenIds.has(id)) {
+        this._seenIds.add(id);
+        outIds.add(id);
+      }
+    };
+    try {
+      // The root itself (querySelectorAll only returns descendants, so a newly
+      // inserted element's own class/id would otherwise be missed).
+      if (root.nodeType === 1 && root.classList) {
+        consider(root);
+      }
+      for (const el of root.querySelectorAll("[class],[id]")) {
+        consider(el);
+      }
+    } catch (e) {}
+  }
+
+  async handleEvent(event) {
+    if (event.type !== "DOMContentLoaded") {
+      return;
+    }
+    await this.applyCosmetics();
+  }
+
+  async applyCosmetics() {
+    const doc = this.document;
+    if (!doc) {
+      return;
+    }
+    const url = doc.documentURI || "";
+    if (!url || !/^https?:/.test(url)) {
+      return;
+    }
+
+    let base;
+    try {
+      // No url in the payload — the parent derives it from trusted state.
+      base = await this.sendQuery("Cosmetic:GetForUrl", {});
+    } catch (e) {
+      return;
+    }
+    if (!base) {
+      return; // blocking off, host allow-listed, or service unavailable
+    }
+
+    this._generichide = !!base.generichide;
+    this._exceptions = base.exceptions || [];
+
+    const selectors = (base.hide || []).slice();
+
+    // Generic class/id-triggered hiding for what's already in the document.
+    if (!this._generichide) {
+      const classes = new Set();
+      const ids = new Set();
+      this.collectClassesIds(doc, classes, ids);
+      if (classes.size || ids.size) {
+        try {
+          const lazy = await this.sendQuery("Cosmetic:GetLazy", {
+            url,
+            classes: [...classes],
+            ids: [...ids],
+            exceptions: this._exceptions,
+          });
+          if (lazy && lazy.selectors) {
+            selectors.push(...lazy.selectors);
+          }
+        } catch (e) {}
+      }
+    }
+
+    this.addSelectors(selectors);
+
+    if (!this._generichide) {
+      this.startObserver();
+    }
+  }
+
+  startObserver() {
+    if (this._observer) {
+      return;
+    }
+    const win = this.contentWindow;
+    if (!win || !win.MutationObserver) {
+      return;
+    }
+    // Flush directly from the observer callback rather than via setTimeout:
+    // MutationObserver already coalesces a batch of mutations into one callback
+    // at the microtask checkpoint, the seen-set dedups repeats, and a timer
+    // would never fire in a frozen/background tab. collectClassesIds only emits
+    // classes/ids not seen before, so each query carries only what's new.
+    this._observer = new win.MutationObserver(records => {
+      const classes = new Set();
+      const ids = new Set();
+      for (const rec of records) {
+        if (rec.type === "attributes" && rec.target) {
+          this.collectClassesIds(rec.target.parentNode || rec.target, classes, ids);
+        }
+        for (const node of rec.addedNodes || []) {
+          if (node.nodeType === 1 /* ELEMENT_NODE */) {
+            this.collectClassesIds(node, classes, ids);
+          }
+        }
+      }
+      if (classes.size || ids.size) {
+        this.queryAndInject([...classes], [...ids]);
+      }
+    });
+    try {
+      this._observer.observe(this.document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class", "id"],
+      });
+    } catch (e) {}
+  }
+
+  // One sendQuery per observer batch that carries genuinely-new classes/ids.
+  // The seen-set caps total queries at one-per-distinct-token, so this is bounded
+  // even on busy pages; a page that continuously mints randomized classnames
+  // (hashed CSS modules) is the worst case. A leading-edge + trailing-debounce
+  // coalescer would cut that further, but a macrotask timer is frozen in
+  // background tabs — deferred until a frozen-tab-safe coalescer is in place.
+  async queryAndInject(classes, ids) {
+    try {
+      const lazy = await this.sendQuery("Cosmetic:GetLazy", {
+        classes,
+        ids,
+        exceptions: this._exceptions,
+      });
+      if (lazy && lazy.selectors && lazy.selectors.length) {
+        this.addSelectors(lazy.selectors);
+      }
+    } catch (e) {}
+  }
+
+  didDestroy() {
+    if (this._observer) {
+      try {
+        this._observer.disconnect();
+      } catch (e) {}
+      this._observer = null;
+    }
+    if (this._sheetUri) {
+      try {
+        const utils = this.contentWindow?.windowUtils;
+        utils?.removeSheetUsingURIString(this._sheetUri, utils.USER_SHEET);
+      } catch (e) {}
+      this._sheetUri = null;
+    }
+    this._seenClasses.clear();
+    this._seenIds.clear();
+    this._selectors.clear();
+  }
+}

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Parent half of the gjoa cosmetic-filtering actor. Runs in the parent
+// process, where the content-classifier service (MAIN_PROCESS_ONLY) lives.
+// The content-side child asks for element-hiding selectors per document;
+// this side queries the native adblock-rust engines via the service and
+// honors gjoa's global + per-site blocking gates.
+
+const ENABLED_PREF = "gjoa.contentblock.enabled";
+const ALLOW_HOSTS_PREF = "gjoa.contentblock.user.allow-hosts";
+
+function allowHostSet() {
+  let raw = "";
+  try {
+    raw = Services.prefs.getStringPref(ALLOW_HOSTS_PREF, "");
+  } catch (e) {}
+  return new Set(
+    raw
+      .split(",")
+      .map(h => h.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function hostOf(url) {
+  try {
+    return Services.io.newURI(url).host.toLowerCase();
+  } catch (e) {
+    return "";
+  }
+}
+
+function classifierService() {
+  try {
+    return Cc["@mozilla.org/content-classifier-service;1"].getService(
+      Ci.nsIContentClassifierService
+    );
+  } catch (e) {
+    return null;
+  }
+}
+
+// True when cosmetic blocking should run for this URL: the global toggle is
+// on and the host is not on the user's allow list (exact host or any parent
+// domain the user added).
+function blockingActive(url) {
+  if (!Services.prefs.getBoolPref(ENABLED_PREF, false)) {
+    return false;
+  }
+  const host = hostOf(url);
+  if (!host) {
+    return false;
+  }
+  for (const h of allowHostSet()) {
+    if (host === h || host.endsWith("." + h)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export class GjoaCosmeticParent extends JSWindowActorParent {
+  // The document URL from trusted parent-process state, NOT from the content
+  // process. A compromised/hostile content process could otherwise claim an
+  // allow-listed host to bypass blocking, or query cosmetics for another site.
+  trustedUrl() {
+    try {
+      return this.manager?.documentURI?.spec || "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  async receiveMessage(msg) {
+    switch (msg.name) {
+      case "Cosmetic:GetForUrl": {
+        const url = this.trustedUrl();
+        if (!blockingActive(url)) {
+          return null;
+        }
+        const svc = classifierService();
+        if (!svc) {
+          return null;
+        }
+        const hide = {};
+        const proc = {};
+        const exc = {};
+        const injected = {};
+        const generichide = {};
+        try {
+          svc.getUrlCosmeticResources(
+            url,
+            hide,
+            proc,
+            exc,
+            injected,
+            generichide
+          );
+        } catch (e) {
+          return null;
+        }
+        return {
+          hide: hide.value || [],
+          exceptions: exc.value || [],
+          generichide: !!generichide.value,
+        };
+      }
+
+      case "Cosmetic:GetLazy": {
+        const url = this.trustedUrl();
+        if (!blockingActive(url)) {
+          return null;
+        }
+        const svc = classifierService();
+        if (!svc) {
+          return null;
+        }
+        const selectors = {};
+        try {
+          svc.getHiddenClassIdSelectors(
+            msg.data?.classes || [],
+            msg.data?.ids || [],
+            msg.data?.exceptions || [],
+            selectors
+          );
+        } catch (e) {
+          return null;
+        }
+        return { selectors: selectors.value || [] };
+      }
+    }
+    return null;
+  }
+}

--- a/src/gjoa/toolkit/components/content-classifier/README.md
+++ b/src/gjoa/toolkit/components/content-classifier/README.md
@@ -1,0 +1,45 @@
+# content-classifier overlay
+
+Firefox 152 ships an experimental `toolkit/components/content-classifier`
+component that wraps the in-tree Brave `adblock-rust` engine for **network**
+request classification. gjoa builds native ad-blocking on top of it.
+
+These files are **whole-file overlays** (mirrored into `engine/` verbatim by
+`tools/prep/overlay.bjs` during `bun run import`). `engine/` is gitignored, so
+anything gjoa changes there must live here to survive a clean extract and reach
+CI builds.
+
+## What gjoa changed vs upstream FF152
+
+- `ContentClassifierRemoteSettingsClient.sys.mjs` — gjoa's RS client: loads
+  EasyList/EasyPrivacy from a profile cache and feeds them to the C++ service.
+- `nsIContentClassifierService.idl`, `ContentClassifierService.{h,cpp}`,
+  `ContentClassifierEngine.{h,cpp}`, `content_classifier_engine/src/lib.rs`,
+  `components.conf`, `moz.build` — gjoa **added cosmetic filtering**: the Rust
+  FFI (`url_cosmetic_resources` / `hidden_class_id_selectors`), the two IDL
+  methods (`getUrlCosmeticResources` / `getHiddenClassIdSelectors`), the C++
+  wrappers + cross-engine union, a `@mozilla.org/content-classifier-service;1`
+  contract id (so JS can reach the MAIN_PROCESS_ONLY service), and registration
+  of `GjoaCosmetic*.sys.mjs` as `EXTRA_JS_MODULES`.
+- `GjoaCosmeticParent.sys.mjs` / `GjoaCosmeticChild.sys.mjs` — gjoa-authored
+  JSWindowActor pair that delivers element-hiding to content (USER_SHEET
+  `display:none!important`), honoring the global + per-site blocking gates.
+
+## Privacy note (accepted residual)
+
+Cosmetic hiding is observable from the page: a script can `getComputedStyle()` a
+probe element and infer that a filter rule hid it. This is **inherent to all
+cosmetic ad-blockers** (uBlock Origin, AdGuard, Brave all expose the identical
+oracle) — it is not gjoa-specific. We mitigate the obvious leaks (the parent
+derives the document URL from trusted state, never the content process; the
+engine only returns selectors the page's own classes/ids triggered; results are
+the deduped union across lists with no per-list attribution), and accept the
+residual getComputedStyle side channel as the cost of cosmetic filtering.
+
+## Maintenance
+
+Because these are whole-file overlays, they **shadow** upstream evolution of
+the same files. On a Firefox version bump, re-diff against the new upstream
+content-classifier and re-apply gjoa's additions (the additions are localized:
+search for `cosmetic`, `GetSingleton`, and `GjoaCosmetic`). The unmodified base
+is whatever FF version `gjoa.json` pins.

--- a/src/gjoa/toolkit/components/content-classifier/components.conf
+++ b/src/gjoa/toolkit/components/content-classifier/components.conf
@@ -1,0 +1,25 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Classes = [
+    {
+        'cid': '{C7DDDBF2-8BC4-41A1-AC90-5144BEC5ABDF}',
+        'contract_ids': ['@mozilla.org/content-classifier-rs-client;1'],
+        'esModule': 'resource://gre/modules/ContentClassifierRemoteSettingsClient.sys.mjs',
+        'constructor': 'ContentClassifierRemoteSettingsClient',
+        'singleton': True,
+        'processes': ProcessSelector.MAIN_PROCESS_ONLY,
+    },
+    {
+        'cid': '{cc5d6c7c-a415-4abb-a94d-73479b456b50}',
+        'contract_ids': ['@mozilla.org/content-classifier-service;1'],
+        'singleton': True,
+        'type': 'nsIContentClassifierService',
+        'constructor': 'mozilla::ContentClassifierService::GetSingleton',
+        'headers': ['mozilla/ContentClassifierService.h'],
+        'processes': ProcessSelector.MAIN_PROCESS_ONLY,
+    },
+]

--- a/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/ContentClassifierEngine.cpp
+++ b/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/ContentClassifierEngine.cpp
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/ContentClassifierEngine.h"
+#include "ContentClassifierService.h"
+#include "nsIEffectiveTLDService.h"
+#include "mozilla/Components.h"
+#include "mozIThirdPartyUtil.h"
+
+namespace mozilla {
+
+ContentClassifierResult ContentClassifierEngine::CheckNetworkRequest(
+    const ContentClassifierRequest& aRequest) {
+  if (!mEngine || !sInitializedETLDService) {
+    return ContentClassifierResult(NS_ERROR_NOT_INITIALIZED);
+  }
+
+  if (!aRequest.mValid) {
+    return ContentClassifierResult(NS_ERROR_INVALID_ARG);
+  }
+
+  // We perform no classification on third-party resources for webcompat.
+  // This early-return saves CPU cycles.
+  if (!aRequest.mThirdParty) {
+    return ContentClassifierResult(NS_OK);
+  }
+
+  bool matched = false;
+  bool important = false;
+  nsCString exception;
+
+  nsresult rv = content_classifier_engine_check_network_request_preparsed(
+      mEngine, &aRequest.mUrl, &aRequest.mSchemelessSite,
+      &aRequest.mSourceSchemelessSite, &aRequest.mRequestType,
+      aRequest.mThirdParty, &matched, &important, &exception);
+  return ContentClassifierResult(matched, important, !exception.IsEmpty(), rv);
+}
+
+nsresult ContentClassifierEngine::GetUrlCosmeticResources(
+    const nsACString& aUrl, nsTArray<nsCString>& aHideSelectors,
+    nsTArray<nsCString>& aProceduralActions, nsTArray<nsCString>& aExceptions,
+    nsCString& aInjectedScript, bool& aGenericHide) {
+  if (!mEngine) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+  return content_classifier_engine_url_cosmetic_resources(
+      mEngine, &aUrl, &aHideSelectors, &aProceduralActions, &aExceptions,
+      &aInjectedScript, &aGenericHide);
+}
+
+nsresult ContentClassifierEngine::GetHiddenClassIdSelectors(
+    const nsTArray<nsCString>& aClasses, const nsTArray<nsCString>& aIds,
+    const nsTArray<nsCString>& aExceptions, nsTArray<nsCString>& aSelectors) {
+  if (!mEngine) {
+    return NS_ERROR_NOT_INITIALIZED;
+  }
+  return content_classifier_engine_hidden_class_id_selectors(
+      mEngine, &aClasses, &aIds, &aExceptions, &aSelectors);
+}
+
+void ContentClassifierResult::Accumulate(
+    const ContentClassifierResult& aOther) {
+  if (NS_FAILED(aOther.mEngineResult)) {
+    return;
+  }
+
+  if (this->mImportant) {
+    return;
+  }
+
+  if (aOther.mMatched || aOther.mException) {
+    this->mMatched = aOther.mMatched;
+    this->mException = aOther.mException;
+    this->mImportant = aOther.mImportant;
+  }
+}
+
+ContentClassifierRequest::ContentClassifierRequest(nsIChannel* aChannel)
+    : mThirdParty(true), mValid(false) {
+  nsCOMPtr<nsIURI> uri;
+  nsresult rv = aChannel->GetURI(getter_AddRefs(uri));
+  if (NS_FAILED(rv)) return;
+
+  rv = uri->GetSpec(mUrl);
+  if (NS_FAILED(rv)) return;
+
+  nsCString host;
+  rv = uri->GetHost(host);
+  if (NS_FAILED(rv)) return;
+
+  nsCOMPtr<nsIEffectiveTLDService> eTLDService =
+      components::EffectiveTLD::Service();
+  if (!eTLDService) return;
+
+  rv = eTLDService->GetSchemelessSiteFromHost(host, mSchemelessSite);
+  if (NS_FAILED(rv)) return;
+
+  nsCOMPtr<nsILoadInfo> loadInfo;
+  rv = aChannel->GetLoadInfo(getter_AddRefs(loadInfo));
+  if (NS_FAILED(rv)) return;
+
+  nsCOMPtr<nsIPrincipal> loadingPrincipal = loadInfo->GetLoadingPrincipal();
+  if (loadingPrincipal) {
+    rv = loadingPrincipal->GetBaseDomain(mSourceSchemelessSite);
+    if (NS_FAILED(rv)) return;
+  }
+
+  ExtContentPolicyType contentPolicyType =
+      loadInfo->GetExternalContentPolicyType();
+  switch (contentPolicyType) {
+    case ExtContentPolicyType::TYPE_CSP_REPORT:
+      mRequestType.AssignLiteral("csp_report");
+      break;
+    case ExtContentPolicyType::TYPE_DOCUMENT:
+      mRequestType.AssignLiteral("document");
+      break;
+    case ExtContentPolicyType::TYPE_FONT:
+      mRequestType.AssignLiteral("font");
+      break;
+    case ExtContentPolicyType::TYPE_IMAGE:
+    case ExtContentPolicyType::TYPE_IMAGESET:
+      mRequestType.AssignLiteral("image");
+      break;
+    case ExtContentPolicyType::TYPE_MEDIA:
+      mRequestType.AssignLiteral("media");
+      break;
+    case ExtContentPolicyType::TYPE_OBJECT:
+      mRequestType.AssignLiteral("object");
+      break;
+    case ExtContentPolicyType::TYPE_BEACON:
+    case ExtContentPolicyType::TYPE_PING:
+      mRequestType.AssignLiteral("ping");
+      break;
+    case ExtContentPolicyType::TYPE_SCRIPT:
+      mRequestType.AssignLiteral("script");
+      break;
+    case ExtContentPolicyType::TYPE_STYLESHEET:
+      mRequestType.AssignLiteral("stylesheet");
+      break;
+    case ExtContentPolicyType::TYPE_SUBDOCUMENT:
+      mRequestType.AssignLiteral("subdocument");
+      break;
+    case ExtContentPolicyType::TYPE_WEBSOCKET:
+      mRequestType.AssignLiteral("websocket");
+      break;
+    case ExtContentPolicyType::TYPE_XMLHTTPREQUEST:
+      mRequestType.AssignLiteral("xmlhttprequest");
+      break;
+    default:
+      mRequestType.AssignLiteral("other");
+      break;
+  }
+
+  nsCOMPtr<mozIThirdPartyUtil> thirdPartyUtil =
+      components::ThirdPartyUtil::Service();
+  if (!thirdPartyUtil) {
+    return;
+  }
+  rv = thirdPartyUtil->IsThirdPartyChannel(aChannel, nullptr, &mThirdParty);
+  if (NS_FAILED(rv)) {
+    mThirdParty = true;
+  }
+
+  mValid = true;
+}
+
+}  // namespace mozilla

--- a/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/ContentClassifierEngine.h
+++ b/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/ContentClassifierEngine.h
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_ContentClassifierEngine_h
+#define mozilla_ContentClassifierEngine_h
+
+#include "content_classifier_ffi.h"
+
+#include "nsError.h"
+#include "nsString.h"
+#include "nsTArray.h"
+#include "nsIChannel.h"
+
+namespace mozilla {
+
+class ContentClassifierService;
+
+class ContentClassifierResult {
+  bool mMatched = false;
+  bool mException = false;
+  bool mImportant = false;
+  nsresult mEngineResult = NS_ERROR_UNEXPECTED;
+
+ public:
+  ContentClassifierResult(bool aMatched, bool aException, bool aImportant,
+                          nsresult aEngineResult)
+      : mMatched(aMatched),
+        mException(aException),
+        mImportant(aImportant),
+        mEngineResult(aEngineResult) {}
+  explicit ContentClassifierResult(nsresult aEngineResult)
+      : mMatched(false),
+        mException(false),
+        mImportant(false),
+        mEngineResult(aEngineResult) {}
+
+  nsresult EngineResult() { return mEngineResult; }
+
+  bool Hit() { return NS_SUCCEEDED(mEngineResult) && mMatched && !mException; }
+
+  bool Exception() { return NS_SUCCEEDED(mEngineResult) && mException; }
+
+  bool Important() { return NS_SUCCEEDED(mEngineResult) && mImportant; }
+
+  // Used to combine results from multiple engines. Respects important as a lock
+  // on the result.
+  void Accumulate(const ContentClassifierResult& aOther);
+};
+
+class ContentClassifierRequest {
+  friend class ContentClassifierEngine;
+  nsCString mUrl;
+  nsCString mSchemelessSite;
+  nsCString mSourceSchemelessSite;
+  nsCString mRequestType;
+  bool mThirdParty = false;
+  bool mValid = false;
+
+ public:
+  bool Valid() const { return mValid; }
+  const nsCString& Url() const { return mUrl; }
+
+  explicit ContentClassifierRequest(nsIChannel* aChannel);
+};
+
+class ContentClassifierEngine final {
+ public:
+  ContentClassifierEngine() : mEngine(nullptr) {
+    if (!sInitializedETLDService) {
+      nsresult rv = content_classifier_initialize_domain_resolver();
+      if (NS_SUCCEEDED(rv)) {
+        sInitializedETLDService = true;
+      }
+    }
+  }
+
+  ~ContentClassifierEngine() {
+    if (mEngine) {
+      content_classifier_engine_destroy(mEngine);
+      mEngine = nullptr;
+    }
+  }
+
+  nsresult InitFromRules(const nsTArray<nsCString>& aRules) {
+    return content_classifier_engine_from_rules(&aRules, &mEngine);
+  }
+
+  ContentClassifierResult CheckNetworkRequest(
+      const ContentClassifierRequest& aRequest);
+
+  nsresult GetUrlCosmeticResources(const nsACString& aUrl,
+                                   nsTArray<nsCString>& aHideSelectors,
+                                   nsTArray<nsCString>& aProceduralActions,
+                                   nsTArray<nsCString>& aExceptions,
+                                   nsCString& aInjectedScript,
+                                   bool& aGenericHide);
+
+  nsresult GetHiddenClassIdSelectors(const nsTArray<nsCString>& aClasses,
+                                     const nsTArray<nsCString>& aIds,
+                                     const nsTArray<nsCString>& aExceptions,
+                                     nsTArray<nsCString>& aSelectors);
+
+ private:
+  static inline bool sInitializedETLDService = false;
+
+  ContentClassifierFFIEngine* mEngine;
+
+  ContentClassifierEngine(const ContentClassifierEngine&) = delete;
+  ContentClassifierEngine& operator=(const ContentClassifierEngine&) = delete;
+};
+
+}  // namespace mozilla
+
+#endif  // mozilla_ContentClassifierEngine_h

--- a/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/src/lib.rs
+++ b/src/gjoa/toolkit/components/content-classifier/content_classifier_engine/src/lib.rs
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use adblock::Engine;
+use cstr::cstr;
+use nserror::{nsresult, NS_ERROR_INVALID_ARG, NS_ERROR_SERVICE_NOT_AVAILABLE, NS_OK};
+use nsstring::{nsACString, nsCString};
+use thin_vec::ThinVec;
+
+use xpcom::interfaces::nsIEffectiveTLDService;
+
+static ETLD_SERVICE: Mutex<Option<xpcom::RefPtr<nsIEffectiveTLDService>>> = Mutex::new(None);
+
+pub struct ContentClassifierFFIEngine {
+    engine: Engine,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_initialize_domain_resolver() -> nsresult {
+    let etld_service = match xpcom::get_service::<nsIEffectiveTLDService>(cstr!(
+        "@mozilla.org/network/effective-tld-service;1"
+    )) {
+        Some(s) => s,
+        None => return NS_ERROR_SERVICE_NOT_AVAILABLE,
+    };
+    if let Ok(mut guard) = ETLD_SERVICE.lock() {
+        guard.replace(etld_service);
+    }
+    let resolver = Box::new(SchemelessSiteResolver {});
+    let _ = adblock::url_parser::set_domain_resolver(resolver);
+    return NS_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn content_classifier_teardown_domain_resolver() {
+    if let Ok(mut guard) = ETLD_SERVICE.lock() {
+        guard.take();
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_engine_from_rules(
+    rules: &ThinVec<nsCString>,
+    out_engine: *mut *mut ContentClassifierFFIEngine,
+) -> nsresult {
+    if out_engine.is_null() {
+        return NS_ERROR_INVALID_ARG;
+    }
+
+    let rules_vec: Vec<String> = rules
+        .iter()
+        .map(|r| String::from_utf8_lossy(r.as_ref()).to_string())
+        .collect();
+
+    let engine = Engine::from_rules(
+        rules_vec,
+        adblock::lists::ParseOptions {
+            ..adblock::lists::ParseOptions::default()
+        },
+    );
+
+    let boxed_engine = Box::new(ContentClassifierFFIEngine { engine });
+    *out_engine = Box::into_raw(boxed_engine);
+    NS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_engine_destroy(
+    engine: *mut ContentClassifierFFIEngine,
+) {
+    if !engine.is_null() {
+        drop(Box::from_raw(engine));
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_engine_check_network_request_preparsed(
+    engine: *const ContentClassifierFFIEngine,
+    url: &nsACString,
+    schemeless_site: &nsACString,
+    source_schemeless_site: &nsACString,
+    request_type: &nsACString,
+    third_party: bool,
+    out_matched: *mut bool,
+    out_important: *mut bool,
+    out_exception: *mut nsCString,
+) -> nsresult {
+    if engine.is_null() || out_matched.is_null() || out_important.is_null() {
+        return NS_ERROR_INVALID_ARG;
+    }
+
+    let engine = &(*engine).engine;
+
+    let url_str = String::from_utf8_lossy(url.as_ref()).to_string();
+    let schemeless_site_str = String::from_utf8_lossy(schemeless_site.as_ref()).to_string();
+    let source_schemeless_site_str =
+        String::from_utf8_lossy(source_schemeless_site.as_ref()).to_string();
+    let request_type_str = String::from_utf8_lossy(request_type.as_ref()).to_string();
+
+    let request = adblock::request::Request::preparsed(
+        &url_str,
+        &schemeless_site_str,
+        &source_schemeless_site_str,
+        &request_type_str,
+        third_party,
+    );
+
+    let result = engine.check_network_request(&request);
+
+    *out_matched = result.matched;
+    *out_important = result.important;
+
+    if !out_exception.is_null() {
+        if let Some(exception) = result.exception {
+            (*out_exception).assign(&exception);
+        } else {
+            (*out_exception).truncate();
+        }
+    }
+
+    NS_OK
+}
+
+unsafe fn fill_cstr_thinvec(out: *mut ThinVec<nsCString>, items: impl IntoIterator<Item = String>) {
+    if out.is_null() {
+        return;
+    }
+    let v = &mut *out;
+    v.clear();
+    for s in items {
+        let mut cs = nsCString::new();
+        cs.assign(&s);
+        v.push(cs);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_engine_url_cosmetic_resources(
+    engine: *const ContentClassifierFFIEngine,
+    url: &nsACString,
+    out_hide_selectors: *mut ThinVec<nsCString>,
+    out_procedural_actions: *mut ThinVec<nsCString>,
+    out_exceptions: *mut ThinVec<nsCString>,
+    out_injected_script: *mut nsCString,
+    out_generichide: *mut bool,
+) -> nsresult {
+    if engine.is_null() {
+        return NS_ERROR_INVALID_ARG;
+    }
+    let engine = &(*engine).engine;
+    let url_str = String::from_utf8_lossy(url.as_ref()).to_string();
+    let res = engine.url_cosmetic_resources(&url_str);
+    fill_cstr_thinvec(out_hide_selectors, res.hide_selectors);
+    fill_cstr_thinvec(out_procedural_actions, res.procedural_actions);
+    fill_cstr_thinvec(out_exceptions, res.exceptions);
+    if !out_injected_script.is_null() {
+        (*out_injected_script).assign(&res.injected_script);
+    }
+    if !out_generichide.is_null() {
+        *out_generichide = res.generichide;
+    }
+    NS_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn content_classifier_engine_hidden_class_id_selectors(
+    engine: *const ContentClassifierFFIEngine,
+    classes: &ThinVec<nsCString>,
+    ids: &ThinVec<nsCString>,
+    exceptions: &ThinVec<nsCString>,
+    out_selectors: *mut ThinVec<nsCString>,
+) -> nsresult {
+    if engine.is_null() {
+        return NS_ERROR_INVALID_ARG;
+    }
+    let engine = &(*engine).engine;
+    let classes_vec: Vec<String> = classes
+        .iter()
+        .map(|c| String::from_utf8_lossy(c.as_ref()).to_string())
+        .collect();
+    let ids_vec: Vec<String> = ids
+        .iter()
+        .map(|c| String::from_utf8_lossy(c.as_ref()).to_string())
+        .collect();
+    let exceptions_set: HashSet<String> = exceptions
+        .iter()
+        .map(|c| String::from_utf8_lossy(c.as_ref()).to_string())
+        .collect();
+    let selectors = engine.hidden_class_id_selectors(&classes_vec, &ids_vec, &exceptions_set);
+    fill_cstr_thinvec(out_selectors, selectors);
+    NS_OK
+}
+
+struct SchemelessSiteResolver {}
+
+impl adblock::url_parser::ResolvesDomain for SchemelessSiteResolver {
+    fn get_host_domain(&self, host: &str) -> (usize, usize) {
+        let guard = match ETLD_SERVICE.lock() {
+            Ok(g) => g,
+            Err(_) => return (0, host.len()),
+        };
+        let etld_service = match guard.as_ref() {
+            Some(s) => s,
+            None => return (0, host.len()),
+        };
+
+        let mut host_cstring = nsCString::new();
+        host_cstring.assign(host);
+
+        let mut base_domain = nsCString::new();
+
+        unsafe {
+            if etld_service
+                .GetBaseDomainFromHost(&*host_cstring, 0, &mut *base_domain)
+                .succeeded()
+            {
+                let base_domain_len = base_domain.len();
+                if base_domain_len > 0 && base_domain_len <= host.len() {
+                    return (host.len() - base_domain_len, host.len());
+                }
+            }
+        }
+
+        (0, host.len())
+    }
+}

--- a/src/gjoa/toolkit/components/content-classifier/moz.build
+++ b/src/gjoa/toolkit/components/content-classifier/moz.build
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+with Files("**"):
+    BUG_COMPONENT = ("Core", "Privacy: Anti-Tracking")
+
+XPIDL_SOURCES += [
+    "nsIContentClassifierRemoteSettingsClient.idl",
+    "nsIContentClassifierService.idl",
+]
+
+XPIDL_MODULE = "content-classifier"
+
+UNIFIED_SOURCES += [
+    "ContentClassifierService.cpp",
+]
+
+EXPORTS.mozilla += [
+    "ContentClassifierService.h",
+]
+
+LOCAL_INCLUDES += [
+    "/netwerk/base",
+    "/netwerk/protocol/http",
+    "/netwerk/url-classifier",
+]
+
+EXTRA_JS_MODULES += [
+    "ContentClassifierRemoteSettingsClient.sys.mjs",
+    "GjoaCosmeticChild.sys.mjs",
+    "GjoaCosmeticParent.sys.mjs",
+]
+
+XPCOM_MANIFESTS += [
+    "components.conf",
+]
+
+BROWSER_CHROME_MANIFESTS += [
+    "test/browser/browser.toml",
+]
+
+FINAL_LIBRARY = "xul"
+
+include("/ipc/chromium/chromium-config.mozbuild")

--- a/src/gjoa/toolkit/components/content-classifier/nsIContentClassifierService.idl
+++ b/src/gjoa/toolkit/components/content-classifier/nsIContentClassifierService.idl
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "nsISupports.idl"
+
+/**
+ * Interface for the content classifier service, allowing JS code to
+ * provide filter list data (e.g. from RemoteSettings).
+ */
+[scriptable, uuid(7a3e9c14-2b5f-4d8a-9e1c-3f6b8d2a4c50)]
+interface nsIContentClassifierService : nsISupports {
+    /**
+     * Store filter list data for a named list. The data is the raw
+     * content of a filter list file (adblock format). Engines are not
+     * rebuilt until applyFilterLists() is called.
+     */
+    void setFilterListData(in ACString aName, in Array<uint8_t> aData);
+
+    /**
+     * Remove a previously stored filter list by name.
+     */
+    void removeFilterList(in ACString aName);
+
+    /**
+     * Rebuild classification engines from the currently stored filter
+     * list data, using the active list name preferences to select
+     * which lists to use for blocking and annotation.
+     */
+    void applyFilterLists();
+
+    /**
+     * Cosmetic filtering resources for a URL: element-hiding selectors,
+     * JSON-encoded procedural filters, generic-rule exceptions, injected
+     * scriptlet JS, and whether $generichide applies (skip the generic
+     * class/id query when true). Unioned across the active block engines.
+     */
+    void getUrlCosmeticResources(in ACString aUrl,
+                                 out Array<ACString> aHideSelectors,
+                                 out Array<ACString> aProceduralActions,
+                                 out Array<ACString> aExceptions,
+                                 out ACString aInjectedScript,
+                                 out boolean aGenericHide);
+
+    /**
+     * Generic element-hiding selectors triggered by the given CSS classes
+     * and ids, minus the exceptions from a prior getUrlCosmeticResources
+     * call for the same hostname. For lazy delivery as new nodes appear.
+     */
+    void getHiddenClassIdSelectors(in Array<ACString> aClasses,
+                                   in Array<ACString> aIds,
+                                   in Array<ACString> aExceptions,
+                                   out Array<ACString> aSelectors);
+};
+
+%{C++
+// Fired after filter list engines have been rebuilt, when the testing
+// pref (privacy.trackingprotection.content.testing) is set. Not fired
+// in production.
+#define NS_CONTENT_CLASSIFIER_FILTER_LISTS_LOADED_TOPIC \
+  "test-content-classifier-filter-lists-loaded"
+%}

--- a/tests/integration/adblock-cosmetic-actor.bjs
+++ b/tests/integration/adblock-cosmetic-actor.bjs
@@ -1,0 +1,81 @@
+#lang beagle/js
+;; M2 cosmetic ACTOR end-to-end: validates the GjoaCosmetic JSWindowActor pair
+;; on a real page served locally. Covers BOTH delivery paths: an element present
+;; AT LOAD must be hidden by the initial scan -> GetLazy -> USER_SHEET path, and
+;; an element added AFTER load must be hidden by the (timer-free) MutationObserver
+;; path. A control element must stay visible. Exercises registerWindowActor,
+;; DOMContentLoaded, sendQuery, getHiddenClassIdSelectors, and
+;; windowUtils.loadSheetUsingURIString.
+;;
+;; Waits are runner-side via await-true (poll) — content-process setTimeout is
+;; frozen in this headless/background-tab harness, so the actor and the test both
+;; avoid it.
+;;
+;; Precondition: tools/test-driver/cosmetic-fixture-server.mjs serving :8975.
+;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
+;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "adblock M2 actor"
+(ns gjoa.tests.integration.adblock-cosmetic-actor
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect]]))
+(define-mode strict)
+(declare-extern [JSON console] Any)
+
+(def TOP :- String "http://127.0.0.1:8975/")
+
+;; Synchronous chrome setup: feed two generic class rules, enable blocking,
+;; clear the allow-list.
+(def SETUP-JS :- String
+  (str "\n"
+       "  const svc = Cc['@mozilla.org/content-classifier-service;1']\n"
+       "    .getService(Ci.nsIContentClassifierService);\n"
+       "  const bytes = Array.from(new TextEncoder().encode('##.gjoa-probe-static\\n##.gjoa-probe-dynamic\\n'));\n"
+       "  svc.setFilterListData('gjoa-cosmetic-test', bytes);\n"
+       "  Services.prefs.setCharPref('privacy.trackingprotection.content.protection.list_names', 'gjoa-cosmetic-test');\n"
+       "  svc.applyFilterLists();\n"
+       "  Services.prefs.setBoolPref('gjoa.contentblock.enabled', true);\n"
+       "  Services.prefs.setBoolPref('privacy.trackingprotection.content.protection.enabled', true);\n"
+       "  Services.prefs.setCharPref('gjoa.contentblock.user.allow-hosts', '');\n"
+       "  return 'setup-ok';\n"))
+
+;; Async chrome nav: listener attached before loadURI so a fast local load can't
+;; race past it; resolve on load-stop.
+(def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  setTimeout(() => finish(false), 15000);\n"))
+
+(def STATIC-HIDDEN :- String
+  "const s=document.getElementById('static'); return !!(s && getComputedStyle(s).display === 'none');")
+(def KEEP-VISIBLE :- String
+  "const k=document.getElementById('keep'); return !!(k && getComputedStyle(k).display !== 'none');")
+(def INJECT-DYN :- String
+  "const d=document.createElement('div'); d.className='gjoa-probe-dynamic'; d.id='dyn'; d.textContent='x'; document.body.appendChild(d); return 'ok';")
+(def DYN-HIDDEN :- String
+  "const d=document.getElementById('dyn'); return !!(d && getComputedStyle(d).display === 'none');")
+
+(js/export (def tests :- Any
+  [(deftest "adblock M2 actor: at-load + dynamic elements hidden, control kept" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval SETUP-JS)
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk (str "local fixture " TOP " did not load — is cosmetic-fixture-server.mjs running on :8975?"))
+       (js/await (.setContext mn "content"))
+       ;; await-true returns nil on success and throws (timeout) on failure.
+       ;; INITIAL path: the at-load .gjoa-probe-static must get hidden.
+       (await-true STATIC-HIDDEN 8000)
+       (.log console "\n[M2-ACTOR] at-load .gjoa-probe-static hidden")
+       ;; Control must stay visible.
+       (expect (chrome-eval KEEP-VISIBLE) "control .gjoa-keep was hidden — cosmetic over-hiding")
+       ;; OBSERVER path: a dynamically-added matching element must get hidden.
+       (chrome-eval INJECT-DYN)
+       (await-true DYN-HIDDEN 8000)
+       (.log console "[M2-ACTOR] dynamically-added .gjoa-probe-dynamic hidden")))]))
+
+(js/export-default tests)

--- a/tests/integration/adblock-cosmetic.bjs
+++ b/tests/integration/adblock-cosmetic.bjs
@@ -1,0 +1,57 @@
+#lang beagle/js
+;; M2 cosmetic-stack validation: proves the native element-hiding path end to
+;; end — Rust FFI (url_cosmetic_resources / hidden_class_id_selectors) -> C++
+;; wrappers -> the two new IDL methods -> JS via the new
+;; @mozilla.org/content-classifier-service;1 contract. Page-free and offline:
+;; we feed a tiny synthetic cosmetic list straight through the service and read
+;; the selectors back.
+;;
+;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
+;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "adblock M2"
+(ns gjoa.tests.integration.adblock-cosmetic
+  (:require [gjoa.tests.dsl :refer [deftest expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON console] Any)
+
+;; Generic class + generic id + a domain-specific element-hide rule. Generic
+;; rules surface via getHiddenClassIdSelectors (class/id-triggered); the
+;; domain-specific rule surfaces via getUrlCosmeticResources for that host.
+(def LIST :- String "##.gjoa-probe\nexample.com##.sponsored\n###gjoa-id-probe\n")
+
+(def EVAL-JS :- String
+  (str "\n"
+       "  const svc = Cc['@mozilla.org/content-classifier-service;1']\n"
+       "    .getService(Ci.nsIContentClassifierService);\n"
+       "  const bytes = Array.from(new TextEncoder().encode("
+       (.stringify JSON LIST) "));\n"
+       "  svc.setFilterListData('gjoa-cosmetic-test', bytes);\n"
+       "  Services.prefs.setCharPref(\n"
+       "    'privacy.trackingprotection.content.protection.list_names',\n"
+       "    'gjoa-cosmetic-test');\n"
+       "  svc.applyFilterLists();\n"
+       "  const sel = {};\n"
+       "  svc.getHiddenClassIdSelectors(['gjoa-probe'], ['gjoa-id-probe'], [], sel);\n"
+       "  const hide = {}, proc = {}, exc = {}, inj = {}, gh = {};\n"
+       "  svc.getUrlCosmeticResources('https://example.com/', hide, proc, exc, inj, gh);\n"
+       "  return JSON.stringify({\n"
+       "    generic: sel.value || [],\n"
+       "    specific: hide.value || [],\n"
+       "    generichide: !!gh.value,\n"
+       "  });\n"))
+
+(js/export (def tests :- Any
+  [(deftest "adblock M2: cosmetic selectors flow through the native service" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (let [r (js/await (.executeScript mn EVAL-JS))
+           d (.parse JSON r)]
+       (.log console (str "\n[M2-COSMETIC] " r))
+       (expect (.includes (.-generic d) ".gjoa-probe")
+               "generic class rule ##.gjoa-probe did not come back from getHiddenClassIdSelectors")
+       (expect (.includes (.-generic d) "#gjoa-id-probe")
+               "generic id rule ###gjoa-id-probe did not come back from getHiddenClassIdSelectors")
+       (expect (.includes (.-specific d) ".sponsored")
+               "domain rule example.com##.sponsored did not come back from getUrlCosmeticResources")
+       (expect-eq (.-generichide d) false
+                  "generichide should be false for example.com (no $generichide exception in the list)")))]))
+
+(js/export-default tests)

--- a/tools/test-driver/cosmetic-fixture-server.mjs
+++ b/tools/test-driver/cosmetic-fixture-server.mjs
@@ -1,0 +1,25 @@
+// Tiny local HTTP fixture for the M2 cosmetic actor test. Serves one page on
+// http://127.0.0.1:8975/ containing a static element that a cosmetic rule
+// should hide at load, plus a control element that must stay visible. Local so
+// the test never depends on remote network. Run with: bun (or node) this file.
+import { createServer } from "node:http";
+
+const PORT = 8975;
+const HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>gjoa cosmetic fixture</title></head>
+<body>
+  <div class="gjoa-probe-static" id="static">STATIC AD</div>
+  <div class="gjoa-keep" id="keep">KEEP ME</div>
+</body></html>`;
+
+const server = createServer((req, res) => {
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(HTML);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`cosmetic-fixture-server listening on http://127.0.0.1:${PORT}/`);
+});


### PR DESCRIPTION
## Native cosmetic ad-blocking — the `##.selector` half of uBlock, built into the engine

Extends the upstream FF152 `content-classifier` component (which M0/M1 wired for **network** blocking) with native **cosmetic element hiding** off the in-tree Brave `adblock-rust` engine. No extension, Manifest-V3-immune.

### Native stack (gjoa additions to the upstream component)
- **Rust FFI**: `url_cosmetic_resources` + `hidden_class_id_selectors`
- **2 new IDL methods** + C++ engine wrappers + cross-engine **union** in the service
- **`@mozilla.org/content-classifier-service;1` contract** (`GetSingleton`) so JS can reach the `MAIN_PROCESS_ONLY` service

### Delivery (gjoa-authored)
- **`GjoaCosmetic` JSWindowActor pair**: the child injects a single page-CSS-proof **USER_SHEET** (`display:none!important`) from an initial class/id scan + a `MutationObserver`; the parent queries the engine, enforces the global + per-site gates, and **derives the document URL from trusted parent state** (never the content process). Registered in `GjoaLoader :start`.

### Validation
Driven on the mach binary via Marionette:
- `adblock M2: cosmetic selectors flow through the native service` ✅
- `adblock M2 actor: at-load + dynamic elements hidden, control kept` ✅
- Regression sweep: **M0** (real EasyList+EasyPrivacy blocks real ad hosts) ✅, **M1-UI** ✅, **M1-production** (isolated) ✅. Network blocking unregressed.

A pre-merge multi-agent review found the security + correctness issues now fixed here (trusted-URL derivation, single accumulated sheet, seen-set cleanup).

### Persistence
`engine/` is gitignored, so the 8 modified upstream files + the 2 new actors are mirrored into the `src/gjoa` overlay (see the component `README.md`) — without this, CI's fresh-extract build would silently lack the feature. content-classifier itself is upstream FF152 (verified against the source tarball CI extracts).

### Also
`LICENSE` was a stale **MIT** file while `gjoa.json`/`flake.nix`/`README` all declared **MPL-2.0** — corrected to canonical MPL 2.0 (matches Firefox/Zen).

### Follow-ups (tracked, non-blocking)
- Convert the whole-file content-classifier overlays to surgical `patches/` (the overlay vendors ~900 lines of upstream Mozilla code and silently shadows upstream on FF bumps).
- Frozen-tab-safe coalescer for the MutationObserver→`GetLazy` hot path on randomized-classname SPAs.