### PR TITLE
feat(darkmode): engine-level luminance inversion at style-resolution time

### DIFF
--- a/BUILD-LEDGER.md
+++ b/BUILD-LEDGER.md
@@ -317,3 +317,37 @@ adversarial agent review of the native layer: 0 real bugs.
    binary (startup-ordering). The shipped paths (M0 running-load, M1 RS restart-load)
    both pass on mach. M2 code is additive and never touches
    `Init()`/`LoadFilterLists()`/the network path.
+
+## 2026-06-17 — Engine-level dark mode (P0 + P1) — SUCCESS
+
+**Type:** two `./mach build` (mach incremental, ~27 min each). **Trigger:**
+replace the crude compositor `filter:invert` with a **style-resolution-stage
+luminance inversion** — the "cranked to 9000" dark mode.
+
+**Design first (workflow `darkmode-engine-design`):** 3 research agents +
+synthesis + adversarial critique. The critique **caught a fatal flaw before any
+build** — the obvious hook (the forced-colors *specified*-stage tweak) has no
+concrete color to rescale; the correct hook is the **computed-stage** conversion
+(`Color::to_computed_color`'s Absolute arm). Verified against the tree.
+
+**P0 (one build):** the Servo cascade hook + a Rust port of
+`RelativeLuminanceUtils::Adjust` (target = 1 - Y, hue/sat/alpha-preserving),
+gated on a per-document `nsPresContext::mColorInversion` flag (mirrors
+forced-colors). Pre-build adversarial compile-review: green. **Validated on the
+binary:** white→black, black→white; flag-off untouched; raster media untouched
+for free (it's not a style color). Zero per-frame cost (cached in ComputedValues).
+
+**P1 (one build):** pref-change restyle (`gjoa.darkmode.invert.enabled` →
+`UpdateColorInversion` → RecascadeSubtree) so toggling **live-restyles open tabs
+without reload**; the chrome "engine" mode (force prefers-color-scheme:light then
+flip the flag, so native-dark sites aren't double-darkened). **Validated:** live
+toggle inverts an already-loaded box.
+
+**Persistence:** `patches/0009-dark-mode-engine-color-inversion.patch` (+86, the
+4 modified upstream files); chrome bits are src/gjoa overlays. `git apply --check`
+clean on pristine FF152; preflight gate A green. **Lesson re-applied:** engine
+edits are gitignored — persisted as a patch immediately so CI gets them.
+
+**Deferred (Phase 2/3):** shadows/gradients/SVG fill-stroke (`ColorFunction` arm
++ the compound longhands), an explicit RuleCache invert-key dependency, optional
+LAB-fidelity algorithm, then retire the `filter` fallback + Dark Reader.

--- a/patches/0009-dark-mode-engine-color-inversion.patch
+++ b/patches/0009-dark-mode-engine-color-inversion.patch
@@ -1,0 +1,195 @@
+# gjoa-patch:
+#   baseline-firefox: 152.0
+#   touches:
+#     - servo/components/style/values/specified/color.rs
+#     - servo/components/style/device/gecko.rs
+#     - layout/base/nsPresContext.h
+#     - layout/base/nsPresContext.cpp
+#
+Engine-level dark mode: luminance-invert absolute colors at style-resolution
+time (the performant successor to the compositor filter:invert).
+
+- specified/color.rs: invert_color_luminance() ports gfx RelativeLuminanceUtils
+  ::Adjust (WCAG, hue/sat/alpha-preserving) with target = 1 - luminance; hooked
+  in Color::to_computed_color's Absolute arm, gated on device.color_inversion().
+  Cached in ComputedValues -> zero per-frame cost; raster media untouched.
+- device/gecko.rs: color_inversion() accessor (mirrors forced_colors()).
+- nsPresContext.{h,cpp}: per-document mColorInversion flag + UpdateColorInversion
+  (content-only; chrome excluded), called at construction and on change of the
+  gjoa.darkmode.invert.enabled pref (live toggle via RecascadeSubtree).
+
+The "engine" dark-mode mode (src/gjoa chrome) forces prefers-color-scheme:light
+then flips this flag, so sites render light and the engine inverts to dark.
+
+diff --git a/layout/base/nsPresContext.cpp b/layout/base/nsPresContext.cpp
+index b2394c6..a7e963f 100644
+--- a/layout/base/nsPresContext.cpp
++++ b/layout/base/nsPresContext.cpp
+@@ -327,6 +327,7 @@ nsPresContext::nsPresContext(dom::Document* aDocument, nsPresContextType aType)
+ 
+   UpdateFontVisibility();
+   UpdateForcedColors(/* aNotify = */ false);
++  UpdateColorInversion(/* aNotify = */ false);
+ }
+ 
+ static const char* gExactCallbackPrefs[] = {
+@@ -340,6 +341,7 @@ static const char* gExactCallbackPrefs[] = {
+     "layout.css.text-autospace.enabled",
+     "layout.css.text-transform.uppercase-eszett.enabled",
+     "privacy.trackingprotection.enabled",
++    "gjoa.darkmode.invert.enabled",
+     nullptr,
+ };
+ 
+@@ -532,6 +534,11 @@ void nsPresContext::PreferenceChanged(const char* aPrefName) {
+   }
+ 
+   nsDependentCString prefName(aPrefName);
++  if (prefName.EqualsLiteral("gjoa.darkmode.invert.enabled")) {
++    // gjoa engine-level dark mode: recompute the flag and restyle this doc.
++    UpdateColorInversion();
++    return;
++  }
+   if (prefName.EqualsLiteral("layout.css.dpi") ||
+       prefName.EqualsLiteral("layout.css.devPixelsPerPx")) {
+     int32_t oldAppUnitsPerDevPixel = mDeviceContext->AppUnitsPerDevPixel();
+@@ -775,6 +782,26 @@ void nsPresContext::UpdateForcedColors(bool aNotify) {
+   }
+ }
+ 
++// gjoa engine-level dark mode: derive the per-document color-inversion flag.
++// Content-only (chrome keeps its own theme); skipped for image documents.
++void nsPresContext::UpdateColorInversion(bool aNotify) {
++  bool old = mColorInversion;
++  mColorInversion = [&] {
++    if (Document()->IsBeingUsedAsImage()) {
++      return false;
++    }
++    if (PrefSheetPrefs().mIsChrome) {
++      return false;
++    }
++    return Preferences::GetBool("gjoa.darkmode.invert.enabled", false);
++  }();
++  if (aNotify && mColorInversion != old) {
++    MediaFeatureValuesChanged(
++        MediaFeatureChange::ForPreferredColorSchemeOrForcedColorsChange(),
++        MediaFeatureChangePropagation::JustThisDocument);
++  }
++}
++
+ bool nsPresContext::ForcingColors() const {
+   return mForcedColors == StyleForcedColors::Active;
+ }
+diff --git a/layout/base/nsPresContext.h b/layout/base/nsPresContext.h
+index 13aa714..2794d77 100644
+--- a/layout/base/nsPresContext.h
++++ b/layout/base/nsPresContext.h
+@@ -362,6 +362,10 @@ class nsPresContext : public nsISupports,
+   }
+ 
+   mozilla::StyleForcedColors ForcedColors() const { return mForcedColors; }
++
++  // gjoa engine-level dark mode: whether content absolute colors are
++  // luminance-inverted for this document (content-only; chrome excluded).
++  bool ColorInversion() const { return mColorInversion; }
+   bool ForcingColors() const;
+ 
+   mozilla::ColorScheme DefaultBackgroundColorScheme() const;
+@@ -565,6 +569,7 @@ class nsPresContext : public nsISupports,
+   void SetInRDMPane(bool aInRDMPane);
+   void UpdateInnerSizeSpoofedForRFP();
+   void UpdateForcedColors(bool aNotify = true);
++  void UpdateColorInversion(bool aNotify = true);
+ 
+  public:
+   float GetFullZoom() { return mFullZoom; }
+@@ -1440,6 +1445,8 @@ class nsPresContext : public nsISupports,
+   FontVisibility mFontVisibility = FontVisibility::Unknown;
+   mozilla::dom::PrefersColorSchemeOverride mOverriddenOrEmbedderColorScheme;
+   mozilla::StyleForcedColors mForcedColors;
++  // gjoa engine-level dark mode flag (content-only). See UpdateColorInversion.
++  bool mColorInversion = false;
+ 
+  protected:
+   virtual ~nsPresContext();
+diff --git a/servo/components/style/device/gecko.rs b/servo/components/style/device/gecko.rs
+index 7ed8c2c..54ffa6f 100644
+--- a/servo/components/style/device/gecko.rs
++++ b/servo/components/style/device/gecko.rs
+@@ -389,6 +389,14 @@ impl Device {
+             .map_or(ForcedColors::None, |pc| pc.mForcedColors)
+     }
+ 
++    /// gjoa engine-level dark mode: whether absolute colors should be
++    /// luminance-inverted for this document. Per-document, content-only (chrome
++    /// is excluded in nsPresContext::UpdateColorInversion).
++    #[inline]
++    pub fn color_inversion(&self) -> bool {
++        self.pres_context().map_or(false, |pc| pc.mColorInversion)
++    }
++
+     /// Computes a system color and returns it as an nscolor.
+     pub(crate) fn system_nscolor(
+         &self,
+diff --git a/servo/components/style/values/specified/color.rs b/servo/components/style/values/specified/color.rs
+index 9c55023..a335fa7 100644
+--- a/servo/components/style/values/specified/color.rs
++++ b/servo/components/style/values/specified/color.rs
+@@ -860,6 +860,41 @@ impl Color {
+     }
+ }
+ 
++/// gjoa engine-level dark mode: invert a color's WCAG relative luminance
++/// (Y -> 1 - Y) while preserving hue, saturation, and alpha. Mirrors
++/// gfx/src/RelativeLuminanceUtils.h::Adjust, operating on the legacy nscolor so
++/// the result is byte-identical to the C++ primitive.
++fn invert_color_luminance(color: &AbsoluteColor) -> AbsoluteColor {
++    let c = color.to_nscolor();
++    let r = (c & 0xff) as u8;
++    let g = ((c >> 8) & 0xff) as u8;
++    let b = ((c >> 16) & 0xff) as u8;
++    let a = (c >> 24) & 0xff;
++    let compute = |u: u8| -> f32 {
++        let f = u as f32 / 255.0;
++        if f <= 0.03928 {
++            f / 12.92
++        } else {
++            ((f + 0.055) / 1.055).powf(2.4)
++        }
++    };
++    let decompute = |x: f32| -> u32 {
++        let s = if x <= 0.03928 / 12.92 {
++            x * 12.92
++        } else {
++            1.055 * x.powf(1.0 / 2.4) - 0.055
++        };
++        (s * 255.0).round().max(0.0).min(255.0) as u32
++    };
++    let (lr, lg, lb) = (compute(r), compute(g), compute(b));
++    let lum = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
++    let target = 1.0 - lum;
++    let factor = (target + 0.05) / (lum + 0.05);
++    let adj = |l: f32| -> u32 { decompute(((l + 0.05) * factor - 0.05).max(0.0)) };
++    let nc = (a << 24) | (adj(lb) << 16) | (adj(lg) << 8) | adj(lr);
++    AbsoluteColor::from_nscolor(nc)
++}
++
+ impl Color {
+     /// Converts this Color into a ComputedColor.
+     ///
+@@ -890,6 +925,15 @@ impl Color {
+             Color::Absolute(ref absolute) => {
+                 let mut color = absolute.color;
+                 adjust_absolute_color!(color);
++                // gjoa engine-level dark mode: invert absolute colors at
++                // computed time (cached in ComputedValues, zero per-frame cost).
++                // currentColor/system stay symbolic and resolve against these
++                // already-inverted values.
++                if let Some(ctx) = context {
++                    if ctx.device().color_inversion() {
++                        color = invert_color_luminance(&color);
++                    }
++                }
+                 ComputedColor::Absolute(color)
+             },
+             Color::ColorFunction(ref color_function) => {

--- a/src/gjoa/chrome/bjs/dark-mode/index.bjs
+++ b/src/gjoa/chrome/bjs/dark-mode/index.bjs
@@ -19,6 +19,8 @@
 (def PREF-ENABLED :- String "gjoa.darkmode.enabled")
 (def PREF-MODE :- String "gjoa.darkmode.mode")
 (def PREF-CONTENT-OVERRIDE :- String "layout.css.prefers-color-scheme.content-override")
+;; gjoa engine-level dark mode flag (read by nsPresContext::UpdateColorInversion).
+(def PREF-INVERT :- String "gjoa.darkmode.invert.enabled")
 
 (def FILTER-CSS-ID :- String "gjoa-darkmode-filter-style")
 (def FILTER-CSS :- String
@@ -29,9 +31,13 @@
 
 (def state :- Any {:filter-el nil :unsub nil})
 
-;; Force (or release) dark color-scheme on web content. 0 = dark, 2 = no override.
-(defn force-content-scheme [on :- Boolean] :- Any
-  (set-pref-int! PREF-CONTENT-OVERRIDE (if on 0 2)))
+;; content-override: 0 = dark, 1 = light, 2 = no override.
+(defn set-content-override! [v :- Any] :- Any
+  (set-pref-int! PREF-CONTENT-OVERRIDE v))
+
+;; Toggle the engine-level luminance-inversion flag (read by nsPresContext).
+(defn set-invert! [on :- Boolean] :- Any
+  (set-pref-bool! PREF-INVERT on))
 
 (defn apply-filter! [] :- Any
   (when (not (.-filter-el state))
@@ -60,13 +66,20 @@
 (defn apply! [] :- Any
   (let [en (enabled?)
         m (mode-)]
-    (if (or (not en) (= m "off"))
-      (do (set-chrome-scheme! false)
-          (force-content-scheme false)
-          (remove-filter!))
-      (do (set-chrome-scheme! true)
-          (force-content-scheme true)
-          (if (= m "filter") (apply-filter!) (remove-filter!))))))
+    (cond
+      (or (not en) (= m "off"))
+        (do (set-chrome-scheme! false) (set-content-override! 2) (set-invert! false) (remove-filter!))
+      ;; "engine": force LIGHT so sites render their light theme, then the engine
+      ;; inverts every absolute color to dark at style-resolution time — cached,
+      ;; raster-safe, no per-frame compositor filter.
+      (= m "engine")
+        (do (set-chrome-scheme! true) (set-content-override! 1) (set-invert! true) (remove-filter!))
+      ;; "filter": legacy compositor invert (Lane-1 fallback, superseded by engine).
+      (= m "filter")
+        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (apply-filter!))
+      ;; "auto": native dark via prefers-color-scheme: dark.
+      :else
+        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (remove-filter!)))))
 
 ;; Public toggle API (for a future toolbar button), exposed on window.
 (defn toggle [] :- Boolean
@@ -76,7 +89,7 @@
 
 (defn cycle-mode [] :- String
   (let [cur (mode-)
-        nxt (cond (= cur "auto") "filter" (= cur "filter") "off" :else "auto")]
+        nxt (cond (= cur "auto") "engine" (= cur "engine") "off" :else "auto")]
     (set-pref-str! PREF-MODE nxt)
     nxt))
 

--- a/src/gjoa/defaults/pref/dark-mode-prefs.bjs
+++ b/src/gjoa/defaults/pref/dark-mode-prefs.bjs
@@ -15,8 +15,17 @@
 ;; Mode selector:
 ;;   "auto"   — forces prefers-color-scheme: dark; sites with native dark
 ;;              support automatically use it. No visual filter.
-;;   "filter" — applies SVG inversion filter at the browser compositor level
-;;              for sites without native dark mode. Counter-inverts images/video.
+;;   "engine" — forces prefers-color-scheme: light, then the ENGINE inverts every
+;;              absolute color to dark at style-resolution time (cascade hook in
+;;              servo, cached in ComputedValues, raster media untouched). The
+;;              performant successor to "filter".
+;;   "filter" — legacy compositor-level SVG invert for sites without native dark.
+;;              Counter-inverts images/video. Superseded by "engine".
 ;;   "off"    — dark mode disabled (same as enabled=false; exists so the mode
 ;;              pref can be cycled without touching the enabled toggle).
 (pref "gjoa.darkmode.mode" "auto")
+
+;; Engine-level luminance-inversion flag. Set by the dark-mode chrome module for
+;; "engine" mode; read by nsPresContext::UpdateColorInversion to drive the Servo
+;; cascade hook. Default off; the chrome module owns it.
+(pref "gjoa.darkmode.invert.enabled" false)

--- a/tests/integration/darkmode-invert.bjs
+++ b/tests/integration/darkmode-invert.bjs
@@ -1,0 +1,93 @@
+#lang beagle/js
+;; Dark-mode P0 validation: the engine-level luminance inversion. With
+;; gjoa.darkmode.invert.enabled set BEFORE navigation, a fresh content
+;; presContext reads the flag and the Servo cascade inverts every absolute
+;; color at computed time. We inject a white-bg / black-text box and assert its
+;; COMPUTED colors come back inverted (white -> black, black -> white) — proving
+;; the hook fires, caches, and reaches getComputedStyle. No content setTimeout
+;; (frozen in headless); waits are runner-side via await-true.
+;;
+;; Precondition: tools/test-driver/cosmetic-fixture-server.mjs serving :8975
+;; (any http content doc works; we just need a real content process).
+;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
+;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "darkmode P0"
+(ns gjoa.tests.integration.darkmode-invert
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON console] Any)
+
+(def TOP :- String "http://127.0.0.1:8975/")
+
+(def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  setTimeout(() => finish(false), 15000);\n"))
+
+;; Inject a box with explicit white bg + black text, return its computed colors.
+(def PROBE :- String
+  (str "\n"
+       "  const d = document.createElement('div');\n"
+       "  d.id = 'dm-box';\n"
+       "  d.style.backgroundColor = 'rgb(255, 255, 255)';\n"
+       "  d.style.color = 'rgb(0, 0, 0)';\n"
+       "  d.textContent = 'x';\n"
+       "  document.body.appendChild(d);\n"
+       "  const cs = getComputedStyle(d);\n"
+       "  return JSON.stringify({ bg: cs.backgroundColor, fg: cs.color });\n"))
+
+(js/export (def tests :- Any
+  [(deftest "darkmode P0: engine inverts absolute colors at computed time" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     ;; Flag must be set BEFORE navigation — P0 reads it at presContext construction.
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', true); return 'on';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk (str "fixture " TOP " did not load — is cosmetic-fixture-server.mjs on :8975?"))
+       (js/await (.setContext mn "content"))
+       (let [r (chrome-eval PROBE)
+             d (.parse JSON r)]
+         (.log console (str "\n[DM-P0] injected white-bg/black-text box -> " r))
+         (expect-eq (.-bg d) "rgb(0, 0, 0)"
+                    "white background was NOT inverted to black — the cascade color-inversion hook did not fire")
+         (expect-eq (.-fg d) "rgb(255, 255, 255)"
+                    "black text was NOT inverted to white — inversion hook did not fire"))))
+   ;; Control: with the flag OFF, the same box stays un-inverted.
+   (deftest "darkmode P0: flag off leaves colors untouched" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false); return 'off';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk (str "fixture " TOP " did not load"))
+       (js/await (.setContext mn "content"))
+       (let [r (chrome-eval PROBE)
+             d (.parse JSON r)]
+         (.log console (str "[DM-P0] flag off -> " r))
+         (expect-eq (.-bg d) "rgb(255, 255, 255)"
+                    "flag off but background changed — inversion leaked when disabled"))))
+   ;; P1: flipping the pref on an ALREADY-loaded tab must live-restyle it
+   ;; (nsPresContext::UpdateColorInversion via the pref-change callback).
+   (deftest "darkmode P1: live toggle restyles an already-loaded tab" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false); return 'off';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk (str "fixture " TOP " did not load"))
+       (js/await (.setContext mn "content"))
+       ;; inject the box while invert is OFF — it renders un-inverted
+       (let [before (.parse JSON (chrome-eval PROBE))]
+         (.log console (str "\n[DM-P1] before toggle -> bg=" (.-bg before)))
+         (expect-eq (.-bg before) "rgb(255, 255, 255)" "box should start un-inverted"))
+       ;; flip the flag ON without reloading — engine must restyle the live doc
+       (js/await (.setContext mn "chrome"))
+       (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', true); return 'on';")
+       (js/await (.setContext mn "content"))
+       ;; poll (runner-side) until the existing box becomes inverted
+       (await-true "const d=document.getElementById('dm-box'); return !!(d && getComputedStyle(d).backgroundColor === 'rgb(0, 0, 0)');" 8000)
+       (.log console "[DM-P1] live toggle restyled the existing box to inverted")))]))
+
+(js/export-default tests)


### PR DESCRIPTION
## Engine-level dark mode — the performant successor to `filter:invert`

Inverts absolute colors **during the Servo cascade** (computed-value time), not at the compositor. Cached in `ComputedValues` → **zero per-frame cost**; raster media (`<img>`/`<video>`/`<canvas>`/bg-image bitmaps) is **untouched for free** — no counter-invert hack. Structurally faster than both the old compositor filter and Dark Reader (no CSSOM/injected sheets/MutationObserver).

### Design
Researched + designed via a multi-agent workflow whose adversarial critique **caught a fatal flaw before any build**: the obvious hook (the forced-colors *specified*-stage tweak) has no concrete color to rescale — the correct hook is the **computed-stage** conversion. Verified against the tree.

### What's here
- **`patches/0009`** — `Color::to_computed_color`'s `Absolute` arm luminance-inverts (port of `gfx RelativeLuminanceUtils::Adjust`, target `1−Y`, hue/sat/alpha-preserving), gated on a per-document `nsPresContext::mColorInversion` flag (mirrors forced-colors), recomputed at construction + on the `gjoa.darkmode.invert.enabled` pref change → **live restyle, no reload**.
- **chrome "engine" mode** — forces `prefers-color-scheme: light` then flips the flag, so sites render light and the engine inverts to dark → **native-dark sites aren't double-darkened**. Supersedes the `filter` fallback (kept as a legacy option).
- **tests** — P0 (computed-time inversion + flag-off control) + P1 (live toggle restyles an open tab). **All green on the built binary.**

### Validated
```
[DM-P0] invert ON -> bg rgb(0,0,0), fg rgb(255,255,255)   PASS
[DM-P0] flag OFF  -> untouched                            PASS
[DM-P1] live toggle -> existing box inverted, no reload   PASS
```
Persistence: `git apply --check` clean on pristine FF152, preflight gate A green.

### Deferred (Phase 2/3)
Shadows/gradients/SVG fill-stroke (`ColorFunction` arm + compound longhands), an explicit RuleCache invert-key dependency, optional LAB-fidelity algorithm, then retire the `filter` fallback + Dark Reader entirely. Opt-in (`gjoa.darkmode.mode = "engine"`), default unchanged — safe to land.