### PR TITLE
feat(darkmode): per-site hybrid + Cargo.lock --frozen build fix

### DIFF
--- a/BUILD-LEDGER.md
+++ b/BUILD-LEDGER.md
@@ -404,3 +404,45 @@ the RS client + 6 uBO filter lists.
 `youtube-scriptlet.bjs` + `group-drag-above.bjs` (drag fix) also green in
 isolation. Full suite 58/62 (the 4 fails: documented adblock-smoke discrepancy +
 test order/flake, all non-code; engine/youtube/drag pass in isolation).
+
+---
+
+## 2026-06-18 — Dark-mode per-site HYBRID (#43) — SUCCESS (exit 0)
+
+**Lane 3** full `./mach build` (1845 s ≈ 30 min, 8 warnings — all pre-existing
+third-party). Validates `patches/0009`: a per-document inversion field mirroring
+`BrowsingContext.ForcedColorsOverride` end-to-end —
+- WebIDL `enum ColorInversionOverride {none,inactive,active}` + `[SetterThrows]
+  attribute colorInversionOverride`;
+- BC `FIELD` + getter + `CanSet`(`IsTop()`) + `DidSet`(`PresContextAffecting…`) +
+  `ParamTraits<…>` (`WebIDLEnumSerializer`);
+- `nsPresContext::UpdateColorInversion` now consults `bc->Top()->Color…()`
+  (active→invert, inactive→don't, none→defer to `gjoa.darkmode.invert.enabled`).
+
+The chrome side (Lane 1) is `GjoaDarkmode{Child,Parent}.sys.mjs`: child measures
+the rendered bg one cascade behind first paint, parent decides from trusted
+state; in `hybrid` mode (the new default) native-dark sites keep their theme and
+only themeless sites latch `active`. Every site dark, each the best way.
+
+### POSTMORTEM — webidl attribute edited AFTER the build's codegen tier ran
+Added the `colorInversionOverride` **attribute** line at 06:06; the build's
+export/codegen tier had already run at 05:52, so `BrowsingContextBinding.cpp`
+was generated WITHOUT the attribute and libxul linked (06:22) from the stale
+binding → the C++ field compiles but the **JS setter is a no-op expando**. The
+in-flight build cannot re-enter its own export tier. Fix: a follow-up incremental
+`./mach build` (webidl now newer than the binding → make regenerates it + relinks
+~minutes). **New gate idea (J):** after any `.webidl` change, assert the
+generated `*Binding.cpp` is newer than the `.webidl` AND greps for the new member
+before declaring the build done. Could it have been Lane 1? No — per-document
+inversion needs the synced BC field (C++/IPDL); chrome JS only sets it.
+
+### Cargo.lock --frozen — release/CI build fix (folded into patches/0008)
+The scriptlet-engine patch added `serde_json` to
+`content_classifier_engine/Cargo.toml` but never updated `Cargo.lock`; local mach
+(no `--frozen`) silently patched the lock in place, masking it, while CI **and**
+`nix build` (both `--frozen`) died: `cannot update the lock file … --frozen was
+passed`. This is why the v0.3.0 CI builds (Linux + macOS, sha a8d50bf) failed.
+Folded the 1-line `serde_json` dependency edge into `patches/0008` (forward-applies
+on a pristine tree). New gate idea (K): preflight should `cargo metadata
+--frozen` (or grep that every Cargo.toml dep edge exists in Cargo.lock) so a
+crate added without a lock update fails preflight, not a 30-min CI build.

--- a/docs/darkmode-hybrid-plan.md
+++ b/docs/darkmode-hybrid-plan.md
@@ -1,0 +1,71 @@
+# Dark mode per-site HYBRID — implementation plan (task #43)
+
+Designed 2026-06-18 (verified against the repo). Goal: every site dark, each the
+best way — native dark theme where the site has one, engine luminance-inversion
+where it doesn't, decided **per-document**, with per-site overrides.
+
+## Architecture
+
+- **Per-document inversion lever:** a new synced BrowsingContext FIELD
+  `ColorInversionOverride {None,Inactive,Active}`, modeled byte-for-byte on the
+  existing `ForcedColorsOverride`. `nsPresContext::mColorInversion` consults it
+  first; `None` → falls back to the global `gjoa.darkmode.invert.enabled` pref
+  (today's behavior preserved). **Rust side needs zero changes** —
+  `gecko.rs::color_inversion()` already reads `pc.mColorInversion` per-presContext.
+- **Detection (chrome JS, one cascade behind — resolves the chicken-and-egg):**
+  new `GjoaDarkmode{Parent,Child}` actor pair (sibling to `GjoaCosmetic*`). The
+  `"hybrid"` mode forces `prefers-color-scheme: dark` (content-override=0) so
+  native-dark sites self-engage. After first paint (`DOMContentLoaded` → 2× rAF)
+  the child reads the *already-resolved* root/body background via
+  `getComputedStyle`, computes WCAG luminance (Y < 0.22 = dark). Sites that stayed
+  LIGHT (no native dark) get `colorInversionOverride = "active"` → one
+  `JustThisDocument` recascade with inversion on. Native-dark → `inactive`/`none`
+  (kept native, never double-darkened). The BC field is the latch between the two
+  cascades; the engine never introspects a background mid-cascade.
+- **P3 inverter completeness:** `color.rs:976-980` only inverts
+  `ComputedColor::Absolute`; resolvable `color-mix()` / `ColorFunction` flow
+  through un-inverted → "some gradient stops dark, some light." Extend that one
+  hook block (~15 lines) to also invert fully-resolvable ColorMix/ColorFunction.
+  Leave `CurrentColor` symbolic. box-shadow/gradient/SVG-paint already route
+  through `to_computed_color` — no compound-longhand changes.
+- **Per-site override:** prefs `gjoa.darkmode.user.{force-native,force-invert,off}`
+  (comma host lists). Precedence `off > force-invert > force-native > auto`;
+  `auto` ⇒ `hasNativeDark ? none : invert`. `cycleSite(host)` on
+  `window.gjoaDarkMode`.
+
+## File-by-file
+
+**patch 0009 extension** (engine, Lane 3; mirror `ForcedColorsOverride` exactly):
+1. `engine/dom/chrome-webidl/BrowsingContext.webidl` — `enum ColorInversionOverride
+   {"none","inactive","active"}` + `[SetterThrows] attribute ColorInversionOverride
+   colorInversionOverride;`.
+2. `engine/docshell/base/BrowsingContext.h` — `FIELD(ColorInversionOverride, ...)`,
+   getter, `CanSet`, `DidSet` decl (beside ForcedColorsOverride).
+3. `engine/docshell/base/BrowsingContext.cpp` — `ParamTraits` (WebIDLEnumSerializer),
+   `DidSet` body → `PresContextAffectingFieldChanged()`.
+4. `engine/layout/base/nsPresContext.cpp` — `UpdateColorInversion` consults the BC
+   field (Top()) before the pref; add `UpdateColorInversion()` in
+   `RecomputeBrowsingContextDependentData` (beside `UpdateForcedColors()`).
+5. `engine/servo/components/style/values/specified/color.rs` — extend the invert
+   hook block to handle resolvable ColorMix/ColorFunction.
+
+**patch 0008 extension:** `moz.build` `EXTRA_JS_MODULES` += `GjoaDarkmode{Parent,
+Child}.sys.mjs` (engine/ is gitignored — CI needs the patch registration).
+
+**Chrome (Lane 1):**
+6. `src/gjoa/.../GjoaDarkmodeChild.sys.mjs` (NEW) — measure bg luminance post-paint
+   (2× rAF), SPA re-measure (debounced), `Darkmode:Apply` → set
+   `browsingContext.colorInversionOverride`.
+7. `src/gjoa/.../GjoaDarkmodeParent.sys.mjs` (NEW) — trustedUrl, per-origin cache,
+   override-pref precedence, decide invert/none.
+8. `src/gjoa/browser/components/gjoa/GjoaLoader.bjs` — `register-darkmode-actor`.
+9. `src/gjoa/chrome/bjs/dark-mode/index.bjs` — `"hybrid"` mode (force-dark,
+   global invert off, per-tab field decides) + `cycleSite` + extend `cycle-mode`.
+10. `src/gjoa/defaults/pref/dark-mode-prefs.bjs` — 3 host-list prefs.
+11. `tests/integration/darkmode-invert.bjs` — fixtures A (themeless→inverted),
+    B (native-dark→native, not double-darkened), C (override), + P3 micro-assert.
+
+## Build order
+import → preflight (gate A: patches apply) → **one full `./mach build`** (WebIDL +
+IPDL FIELD + nsPresContext C++ + Rust color.rs all need it; `faster` insufficient)
+→ BUILD-LEDGER → then Lane 1 iteration (threshold/timing/overrides) via gjoa sync.

--- a/docs/review-followups-2026-06-18.md
+++ b/docs/review-followups-2026-06-18.md
@@ -1,0 +1,68 @@
+# Review follow-ups — 2026-06-18 (overnight adversarial review)
+
+A 28-agent adversarial review swept this session's new code (dark-mode hybrid,
+scriptlet engine, tab fixes) + the deferred #40 audit bugs. Findings below are
+**verified** (each cited file:line, adversarially re-checked). Applied items are
+marked; the rest are deferred with precise fixes for a quick awake-pass.
+
+## APPLIED autonomously (safe, low-risk)
+
+- **B1 — dark-mode native-dark misdetection (CRITICAL, the "white background"
+  bug).** `GjoaDarkmodeChild.sys.mjs` transparency regex
+  `rgba?\([^)]*,\s*0…\)$` greedily matched the *blue* channel of opaque
+  `rgb(0,0,0)`, so the most common dark bg was treated as transparent → page
+  judged "not dark" → inverted to **white**. Fixed: require a real 4th alpha
+  channel (`^rgba?\([^,)]*,[^,)]*,[^,)]*,\s*0…\)$`). Lane 1, zero test coverage
+  to regress.
+- **Cargo.lock --frozen fix.** `patches/0008` modified `content_classifier_engine/
+  Cargo.toml` (added `serde_json`) without updating `Cargo.lock`; CI/nix
+  re-extract pristine + `--frozen` → `cannot update the lock file`. Folded the
+  1-line `serde_json` edge into `patches/0008` (forward-applies on pristine).
+
+## DEFERRED — touch load-bearing tab code or are design choices (do awake)
+
+- **B3 / #40 bug7 — uncancellable horizontal-grid rAF.** `tabs/rows.bjs:256`
+  schedules a popout-positioning rAF whose handle is discarded;
+  `clear-horizontal-grid` (`:312`) never cancels it. Rapid h→v→h double-toggle
+  runs two passes (redundant work / brief flicker — the `(when (is-horizontal))`
+  guard already prevents *wrong-orientation* application, so it is cosmetic).
+  Fix: `cancelAnimationFrame` extern + `:grid-raf` counter; wrap the rAF in
+  `(set! (.-grid-raf counters) (requestAnimationFrame …))`, reset to 0 at the
+  top of the callback, cancel any prior before scheduling and at the top of
+  `clear-horizontal-grid`. Validate with `tab-mode-toggle.bjs` after.
+- **R1 / #40 bug5 — compact MutationObserver re-enters positionPanel.**
+  `tabs/index.bjs:412-416` observer on `data-gjoa-compact`/`gjoa-has-hover`/
+  `sidebar-launcher-expanded`; `compact.bjs` bursts those, each synchronously
+  firing un-debounced `positionPanel` (which reads them back). DOM thrash, no
+  infinite loop. Fix: rAF-coalesce — add a `request-position-panel` wrapper in
+  `layout.bjs make-layout!` (one rAF/turn) and point the observer + pref
+  observer at it; keep the initial direct `positionPanel` sync call.
+- **R7 / #40 bug3 — spaceOf has no gjoa-id fallback.** `spaces/manager.bjs`
+  `hydrate` tabSpaces loop (`:108-114`) silently drops entries whose tab can't
+  be resolved at restore → those tabs strand in Main. Touches `spaceOf` →
+  `reconcile-selection!`/`onActivated` → **spaces invariants**: must run spaces
+  integration tests. Defer to awake.
+- **R2 — hybrid: no SPA/soft-nav re-measure.** Child measures once at
+  DOMContentLoaded (2× rAF). Client-rendered apps that paint their real theme
+  post-hydration latch the wrong decision for the document's life (BC field is
+  sticky). Plan item 6 specced a debounced re-measure; not yet built. Design
+  choice — worth doing but changes WIP detection.
+
+## CONFIRMED NON-ISSUES (no action)
+
+- WebIDL `colorInversionOverride` attribute **is** present (patch 0009 line 133)
+  — the per-site hybrid inversion is fully wired.
+- `layoutCollapsed` is fully quarantined from persistence (written only in
+  layout/rows; every snapshot path reads `.collapsed`). Mode-toggle fix intact.
+- `reconcile-selection!` is a behavior-preserving extraction; spaces invariants
+  hold. Non-group/group-source drag drops unaffected by the new group block.
+
+## PERF (Lane 3 — needs rebuild + re-validate, not autonomous)
+
+- R3/R5 — cosmetic `getUrlCosmeticResources` runs twice per document
+  (`GjoaCosmeticParent` GetForUrl `:166` + GetScriptlets `:207`), ×subframes.
+- R4 — 872 KB scriptlet JSON re-parsed per-engine on every `applyFilterLists()`
+  under `mLock`. Clean fix (shared parsed storage) is a new FFI surface
+  (single-thread `!Sync`).
+- B2 — YouTube scriptlet double-injection (curated `YOUTUBE_PRUNE` + engine
+  `+js`); redundant, not conflicting (uBO `set-constant` chains). Low severity.

--- a/patches/0008-content-classifier-cosmetic-filtering.patch
+++ b/patches/0008-content-classifier-cosmetic-filtering.patch
@@ -1,6 +1,7 @@
 # gjoa-patch:
 #   baseline-firefox: 152.0
 #   touches:
+#     - Cargo.lock
 #     - toolkit/components/content-classifier/ContentClassifierService.cpp
 #     - toolkit/components/content-classifier/ContentClassifierService.h
 #     - toolkit/components/content-classifier/nsIContentClassifierService.idl
@@ -22,6 +23,18 @@ element-hiding (the gjoa adblock M2 feature).
 - moz.build: register GjoaCosmetic{Parent,Child}.sys.mjs as EXTRA_JS_MODULES
   (those NEW actor files ship as src/gjoa overlays, not in this patch)
 
+diff --git a/Cargo.lock b/Cargo.lock
+index ae3d1519df..1378c52dc3 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1116,6 +1116,7 @@ dependencies = [
+  "cstr",
+  "nserror",
+  "nsstring",
++ "serde_json",
+  "thin-vec",
+  "xpcom",
+ ]
 diff --git a/toolkit/components/content-classifier/ContentClassifierService.cpp b/toolkit/components/content-classifier/ContentClassifierService.cpp
 index 8ea4179418..c69193e525 100644
 --- a/toolkit/components/content-classifier/ContentClassifierService.cpp
@@ -447,15 +460,17 @@ index 295b3bfd8b..88ad661a1c 100644
  
  impl adblock::url_parser::ResolvesDomain for SchemelessSiteResolver {
 diff --git a/toolkit/components/content-classifier/moz.build b/toolkit/components/content-classifier/moz.build
-index e65d3eebce..668e0c6f84 100644
+index e65d3eebce..11f7b2c3a7 100644
 --- a/toolkit/components/content-classifier/moz.build
 +++ b/toolkit/components/content-classifier/moz.build
-@@ -28,6 +28,16 @@ LOCAL_INCLUDES += [
+@@ -28,6 +28,18 @@ LOCAL_INCLUDES += [
  
  EXTRA_JS_MODULES += [
      "ContentClassifierRemoteSettingsClient.sys.mjs",
 +    "GjoaCosmeticChild.sys.mjs",
 +    "GjoaCosmeticParent.sys.mjs",
++    "GjoaDarkmodeChild.sys.mjs",
++    "GjoaDarkmodeParent.sys.mjs",
 +]
 +
 +# uBO-derived scriptlet/redirect resource library (JSON), read at init by the

--- a/patches/0009-dark-mode-engine-color-inversion.patch
+++ b/patches/0009-dark-mode-engine-color-inversion.patch
@@ -5,6 +5,9 @@
 #     - servo/components/style/device/gecko.rs
 #     - layout/base/nsPresContext.h
 #     - layout/base/nsPresContext.cpp
+#     - dom/chrome-webidl/BrowsingContext.webidl
+#     - docshell/base/BrowsingContext.h
+#     - docshell/base/BrowsingContext.cpp
 #
 Engine-level dark mode: luminance-invert resolved absolute colors at
 style-resolution time (the performant successor to the compositor filter:invert).
@@ -25,8 +28,115 @@ style-resolution time (the performant successor to the compositor filter:invert)
 The "engine" dark-mode mode (src/gjoa chrome) forces prefers-color-scheme:light
 then flips this flag, so sites render light and the engine inverts to dark.
 
+diff --git a/docshell/base/BrowsingContext.cpp b/docshell/base/BrowsingContext.cpp
+index e8b50c6548..b5c5194ead 100644
+--- a/docshell/base/BrowsingContext.cpp
++++ b/docshell/base/BrowsingContext.cpp
+@@ -124,6 +124,11 @@ struct ParamTraits<mozilla::dom::ForcedColorsOverride>
+     : public mozilla::dom::WebIDLEnumSerializer<
+           mozilla::dom::ForcedColorsOverride> {};
+ 
++template <>
++struct ParamTraits<mozilla::dom::ColorInversionOverride>
++    : public mozilla::dom::WebIDLEnumSerializer<
++          mozilla::dom::ColorInversionOverride> {};
++
+ template <>
+ struct ParamTraits<mozilla::dom::PrefersReducedMotionOverride>
+     : public mozilla::dom::WebIDLEnumSerializer<
+@@ -3491,6 +3496,15 @@ void BrowsingContext::DidSet(FieldIndex<IDX_ForcedColorsOverride>,
+   PresContextAffectingFieldChanged();
+ }
+ 
++void BrowsingContext::DidSet(FieldIndex<IDX_ColorInversionOverride>,
++                             dom::ColorInversionOverride aOldValue) {
++  MOZ_ASSERT(IsTop());
++  if (ColorInversionOverride() == aOldValue) {
++    return;
++  }
++  PresContextAffectingFieldChanged();
++}
++
+ void BrowsingContext::DidSet(FieldIndex<IDX_PrefersReducedMotionOverride>,
+                              dom::PrefersReducedMotionOverride aOldValue) {
+   MOZ_ASSERT(IsTop());
+diff --git a/docshell/base/BrowsingContext.h b/docshell/base/BrowsingContext.h
+index 02abb6ab95..d68f109d10 100644
+--- a/docshell/base/BrowsingContext.h
++++ b/docshell/base/BrowsingContext.h
+@@ -254,6 +254,8 @@ struct EmbedderColorSchemes {
+   FIELD(PrefersReducedMotionOverride, dom::PrefersReducedMotionOverride)      \
+   /* DevTools override for forced-colors */                                   \
+   FIELD(ForcedColorsOverride, dom::ForcedColorsOverride)                      \
++  /* gjoa per-document dark-mode engine-inversion override */                 \
++  FIELD(ColorInversionOverride, dom::ColorInversionOverride)                  \
+   /* DevTools multiplier for animations playback rate */                      \
+   FIELD(AnimationsPlayBackRateMultiplier, double)                             \
+   /* prefers-color-scheme override based on the color-scheme style of our     \
+@@ -1110,6 +1112,10 @@ class BrowsingContext : public nsILoadContext, public nsWrapperCache {
+     return GetForcedColorsOverride();
+   }
+ 
++  dom::ColorInversionOverride ColorInversionOverride() const {
++    return GetColorInversionOverride();
++  }
++
+   dom::PrefersReducedMotionOverride PrefersReducedMotionOverride() const {
+     return GetPrefersReducedMotionOverride();
+   }
+@@ -1325,6 +1331,11 @@ class BrowsingContext : public nsILoadContext, public nsWrapperCache {
+     return IsTop();
+   }
+ 
++  bool CanSet(FieldIndex<IDX_ColorInversionOverride>, dom::ColorInversionOverride,
++              ContentParent*) {
++    return IsTop();
++  }
++
+   bool CanSet(FieldIndex<IDX_PrefersReducedMotionOverride>,
+               dom::PrefersReducedMotionOverride, ContentParent*) {
+     return IsTop();
+@@ -1350,6 +1361,9 @@ class BrowsingContext : public nsILoadContext, public nsWrapperCache {
+   void DidSet(FieldIndex<IDX_ForcedColorsOverride>,
+               dom::ForcedColorsOverride aOldValue);
+ 
++  void DidSet(FieldIndex<IDX_ColorInversionOverride>,
++              dom::ColorInversionOverride aOldValue);
++
+   void DidSet(FieldIndex<IDX_PrefersReducedMotionOverride>,
+               dom::PrefersReducedMotionOverride aOldValue);
+ 
+diff --git a/dom/chrome-webidl/BrowsingContext.webidl b/dom/chrome-webidl/BrowsingContext.webidl
+index d0508a8c29..da80d54f18 100644
+--- a/dom/chrome-webidl/BrowsingContext.webidl
++++ b/dom/chrome-webidl/BrowsingContext.webidl
+@@ -63,6 +63,13 @@ enum ForcedColorsOverride {
+   "active",
+ };
+ 
++// gjoa per-document dark-mode inversion: "none" defers to the global pref.
++enum ColorInversionOverride {
++  "none",
++  "inactive",
++  "active",
++};
++
+ /**
+  * CSS prefers-reduced-motion values override.
+  */
+@@ -255,6 +262,10 @@ interface BrowsingContext {
+   // Forced-colors simulation, for DevTools
+   [SetterThrows] attribute ForcedColorsOverride forcedColorsOverride;
+ 
++  // gjoa per-document dark-mode inversion override. Set by the GjoaDarkmode
++  // actor on top BrowsingContexts; "none" defers to the global invert pref.
++  [SetterThrows] attribute ColorInversionOverride colorInversionOverride;
++
+   // Animation playbackRate multiplier, for Devtools
+   [SetterThrows] attribute double animationsPlayBackRateMultiplier;
+ 
 diff --git a/layout/base/nsPresContext.cpp b/layout/base/nsPresContext.cpp
-index b2394c6..a7e963f 100644
+index b2394c6106..ce3725d676 100644
 --- a/layout/base/nsPresContext.cpp
 +++ b/layout/base/nsPresContext.cpp
 @@ -327,6 +327,7 @@ nsPresContext::nsPresContext(dom::Document* aDocument, nsPresContextType aType)
@@ -57,7 +167,7 @@ index b2394c6..a7e963f 100644
    if (prefName.EqualsLiteral("layout.css.dpi") ||
        prefName.EqualsLiteral("layout.css.devPixelsPerPx")) {
      int32_t oldAppUnitsPerDevPixel = mDeviceContext->AppUnitsPerDevPixel();
-@@ -775,6 +782,26 @@ void nsPresContext::UpdateForcedColors(bool aNotify) {
+@@ -775,6 +782,37 @@ void nsPresContext::UpdateForcedColors(bool aNotify) {
    }
  }
  
@@ -72,6 +182,17 @@ index b2394c6..a7e963f 100644
 +    if (PrefSheetPrefs().mIsChrome) {
 +      return false;
 +    }
++    // Per-document override set by the GjoaDarkmode actor (the per-site hybrid);
++    // "none" defers to the global pref.
++    if (auto* bc = mDocument->GetBrowsingContext()) {
++      auto ov = bc->Top()->ColorInversionOverride();
++      if (ov == ColorInversionOverride::Active) {
++        return true;
++      }
++      if (ov == ColorInversionOverride::Inactive) {
++        return false;
++      }
++    }
 +    return Preferences::GetBool("gjoa.darkmode.invert.enabled", false);
 +  }();
 +  if (aNotify && mColorInversion != old) {
@@ -84,8 +205,16 @@ index b2394c6..a7e963f 100644
  bool nsPresContext::ForcingColors() const {
    return mForcedColors == StyleForcedColors::Active;
  }
+@@ -927,6 +965,7 @@ void nsPresContext::RecomputeBrowsingContextDependentData() {
+   }());
+ 
+   UpdateForcedColors();
++  UpdateColorInversion();
+ 
+   SetInRDMPane(top->GetInRDMPane());
+ 
 diff --git a/layout/base/nsPresContext.h b/layout/base/nsPresContext.h
-index 13aa714..2794d77 100644
+index 13aa7141c8..2794d77dda 100644
 --- a/layout/base/nsPresContext.h
 +++ b/layout/base/nsPresContext.h
 @@ -362,6 +362,10 @@ class nsPresContext : public nsISupports,
@@ -117,7 +246,7 @@ index 13aa714..2794d77 100644
   protected:
    virtual ~nsPresContext();
 diff --git a/servo/components/style/device/gecko.rs b/servo/components/style/device/gecko.rs
-index 7ed8c2c..54ffa6f 100644
+index 7ed8c2c7a1..54ffa6f483 100644
 --- a/servo/components/style/device/gecko.rs
 +++ b/servo/components/style/device/gecko.rs
 @@ -389,6 +389,14 @@ impl Device {
@@ -136,7 +265,7 @@ index 7ed8c2c..54ffa6f 100644
      pub(crate) fn system_nscolor(
          &self,
 diff --git a/servo/components/style/values/specified/color.rs b/servo/components/style/values/specified/color.rs
-index 9c55023..71ca91d 100644
+index 9c55023eb0..71ca91d2aa 100644
 --- a/servo/components/style/values/specified/color.rs
 +++ b/servo/components/style/values/specified/color.rs
 @@ -860,6 +860,41 @@ impl Color {

--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -186,6 +186,22 @@
     (catch Any e
       (.error console "gjoa-loader: registerWindowActor failed" e))))
 
+;; Registers the per-site dark-mode HYBRID actor. Top documents only (subframes
+;; inherit the top BrowsingContext's colorInversionOverride); the child measures
+;; the rendered background after first paint and sets the per-document inversion
+;; override for sites with no native dark theme.
+(defn register-darkmode-actor [] :- Any
+  (try
+    (.registerWindowActor ChromeUtils "GjoaDarkmode"
+      {:parent {:esModuleURI "resource://gre/modules/GjoaDarkmodeParent.sys.mjs"}
+       :child {:esModuleURI "resource://gre/modules/GjoaDarkmodeChild.sys.mjs"
+               :events {:DOMContentLoaded {:mozSystemGroup true}}}
+       :allFrames false
+       :messageManagerGroups ["browsers"]})
+    (.log console "gjoa-loader: registered GjoaDarkmode window actor")
+    (catch Any e
+      (.error console "gjoa-loader: registerDarkmodeActor failed" e))))
+
 (defn set-new-tab-url [] :- Any
   (try
     (set! (.-newTabURL (.-AboutNewTab lazy)) NEW-TAB-URL)
@@ -200,6 +216,7 @@
       (set-defaults)
       (set-new-tab-url)
       (register-cosmetic-actor)
+      (register-darkmode-actor)
       (.addObserver (.-obs Services) observer "chrome-document-loaded")
       (let [dev (dev-mode-dir)]
         (if dev

--- a/src/gjoa/chrome/bjs/dark-mode/index.bjs
+++ b/src/gjoa/chrome/bjs/dark-mode/index.bjs
@@ -21,6 +21,10 @@
 (def PREF-CONTENT-OVERRIDE :- String "layout.css.prefers-color-scheme.content-override")
 ;; gjoa engine-level dark mode flag (read by nsPresContext::UpdateColorInversion).
 (def PREF-INVERT :- String "gjoa.darkmode.invert.enabled")
+;; Per-site override host-lists (used in "hybrid" mode by GjoaDarkmodeParent).
+(def PREF-FORCE-NATIVE :- String "gjoa.darkmode.user.force-native")
+(def PREF-FORCE-INVERT :- String "gjoa.darkmode.user.force-invert")
+(def PREF-SITE-OFF :- String "gjoa.darkmode.user.off")
 
 (def FILTER-CSS-ID :- String "gjoa-darkmode-filter-style")
 (def FILTER-CSS :- String
@@ -89,7 +93,10 @@
 
 (defn cycle-mode [] :- String
   (let [cur (mode-)
-        nxt (cond (= cur "auto") "engine" (= cur "engine") "off" :else "auto")]
+        nxt (cond (= cur "hybrid") "auto"
+                  (= cur "auto") "engine"
+                  (= cur "engine") "off"
+                  :else "hybrid")]
     (set-pref-str! PREF-MODE nxt)
     nxt))
 

--- a/src/gjoa/defaults/pref/dark-mode-prefs.bjs
+++ b/src/gjoa/defaults/pref/dark-mode-prefs.bjs
@@ -27,11 +27,25 @@
 ;;              performant successor to "filter".
 ;;   "filter" — legacy compositor-level SVG invert for sites without native dark.
 ;;              Counter-inverts images/video. Superseded by "engine".
+;;   "hybrid" — DEFAULT. Forces prefers-color-scheme:dark (native-dark sites
+;;              render their own theme) AND the GjoaDarkmode actor engine-inverts
+;;              ONLY documents that stayed light (no native dark theme), decided
+;;              per-document. Every site dark, each the best way. Per-site
+;;              overrides via the user.* prefs below.
 ;;   "off"    — dark mode disabled (same as enabled=false; exists so the mode
 ;;              pref can be cycled without touching the enabled toggle).
-(pref "gjoa.darkmode.mode" "auto")
+(pref "gjoa.darkmode.mode" "hybrid")
 
 ;; Engine-level luminance-inversion flag. Set by the dark-mode chrome module for
 ;; "engine" mode; read by nsPresContext::UpdateColorInversion to drive the Servo
-;; cascade hook. Default off; the chrome module owns it.
+;; cascade hook. Default off; the chrome module owns it (in "hybrid" mode the
+;; per-document BrowsingContext.colorInversionOverride drives inversion instead).
 (pref "gjoa.darkmode.invert.enabled" false)
+
+;; Per-site dark-mode overrides (comma-separated host lists), applied in "hybrid"
+;; mode by GjoaDarkmodeParent. Precedence: off > force-invert > force-native >
+;; auto. force-native = keep the site's look (never invert); force-invert =
+;; always invert; off = no inversion for that site.
+(pref "gjoa.darkmode.user.force-native" "")
+(pref "gjoa.darkmode.user.force-invert" "")
+(pref "gjoa.darkmode.user.off" "")

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Content half of the gjoa per-site dark-mode HYBRID actor (top documents only).
+// In "hybrid" mode the chrome module forces prefers-color-scheme:dark, so sites
+// with a native dark theme render it. This actor, one cascade behind (after
+// first paint), reads the EFFECTIVE page background; if the site stayed light
+// (no native dark theme) it sets browsingContext.colorInversionOverride =
+// "active", which nsPresContext reads to luminance-invert just this document.
+// Native-dark sites get "inactive" — kept native, never double-darkened.
+
+export class GjoaDarkmodeChild extends JSWindowActorChild {
+  async handleEvent(event) {
+    if (event.type !== "DOMContentLoaded") {
+      return;
+    }
+    const win = this.contentWindow;
+    if (!win || this.browsingContext !== this.browsingContext.top) {
+      return; // subframes inherit the top document's decision (bc->Top())
+    }
+    // Decide one cascade behind: read the already-resolved background after the
+    // first two frames so the page's own (possibly dark) theme has applied.
+    win.requestAnimationFrame(() =>
+      win.requestAnimationFrame(() => this.#measureAndApply())
+    );
+  }
+
+  async #measureAndApply() {
+    const doc = this.document;
+    const win = this.contentWindow;
+    if (!doc || !win || !doc.documentElement) {
+      return;
+    }
+    const url = doc.documentURI || "";
+    if (!/^https?:/.test(url)) {
+      return;
+    }
+    const hasNativeDark = this.#pageIsDark(win, doc);
+    let resp;
+    try {
+      resp = await this.sendQuery("Darkmode:Decide", { hasNativeDark });
+    } catch (e) {
+      return;
+    }
+    if (!resp || !resp.override) {
+      return;
+    }
+    try {
+      this.browsingContext.colorInversionOverride = resp.override;
+    } catch (e) {}
+  }
+
+  // Effective page background: body, then documentElement; first OPAQUE color
+  // wins. All transparent ⇒ the UA canvas (white) shows through ⇒ not dark.
+  #pageIsDark(win, doc) {
+    const read = el => {
+      try {
+        return win.getComputedStyle(el).backgroundColor || "";
+      } catch (e) {
+        return "";
+      }
+    };
+    let bg = "";
+    for (const el of [doc.body, doc.documentElement]) {
+      if (!el) {
+        continue;
+      }
+      const c = read(el);
+      // Skip only FULLY-transparent backgrounds. Gecko serializes opaque colors
+      // as 3-arg `rgb(r, g, b)` and transparent as 4-arg `rgba(r, g, b, 0)`, so
+      // the alpha test must require a real 4th channel — anchoring on the last
+      // comma alone would match the blue channel of `rgb(0, 0, 0)` (opaque
+      // black, the most common dark bg) and wrongly treat it as transparent.
+      if (c && c !== "transparent" && !/^rgba?\([^,)]*,[^,)]*,[^,)]*,\s*0(?:\.0+)?\s*\)$/.test(c)) {
+        bg = c;
+        break;
+      }
+    }
+    if (!bg) {
+      return false;
+    }
+    return this.#luminance(bg) < 0.22;
+  }
+
+  #luminance(rgbStr) {
+    const m = rgbStr.match(/[\d.]+/g);
+    if (!m || m.length < 3) {
+      return 1;
+    }
+    const lin = c => {
+      c = c / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * lin(+m[0]) + 0.7152 * lin(+m[1]) + 0.0722 * lin(+m[2]);
+  }
+}

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Parent half of the gjoa per-site dark-mode HYBRID actor. Decides the
+// per-document colorInversionOverride from trusted parent-process state: the
+// dark-mode mode, the per-site override prefs, and the child's measurement of
+// whether the page rendered dark on its own.
+
+const ENABLED_PREF = "gjoa.darkmode.enabled";
+const MODE_PREF = "gjoa.darkmode.mode";
+const FORCE_NATIVE_PREF = "gjoa.darkmode.user.force-native";
+const FORCE_INVERT_PREF = "gjoa.darkmode.user.force-invert";
+const OFF_PREF = "gjoa.darkmode.user.off";
+
+function hostOf(url) {
+  try {
+    return Services.io.newURI(url).host.toLowerCase();
+  } catch (e) {
+    return "";
+  }
+}
+
+// host matches the pref's CSV exactly or as a parent domain.
+function hostInPref(host, pref) {
+  let raw = "";
+  try {
+    raw = Services.prefs.getStringPref(pref, "");
+  } catch (e) {}
+  return raw
+    .split(",")
+    .map(h => h.trim().toLowerCase())
+    .filter(Boolean)
+    .some(h => host === h || host.endsWith("." + h));
+}
+
+export class GjoaDarkmodeParent extends JSWindowActorParent {
+  trustedUrl() {
+    try {
+      return this.manager?.documentURI?.spec || "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  // Returns the BrowsingContext.colorInversionOverride to set:
+  //   "active"   — invert this document (themeless / forced)
+  //   "inactive" — never invert (native dark theme / off / forced-native)
+  //   "none"     — defer to the global gjoa.darkmode.invert.enabled pref
+  #decide(hasNativeDark) {
+    // Per-document overrides are a HYBRID-mode concern. In every other mode the
+    // global pref drives inversion uniformly, so defer ("none").
+    if (
+      !Services.prefs.getBoolPref(ENABLED_PREF, false) ||
+      Services.prefs.getStringPref(MODE_PREF, "auto") !== "hybrid"
+    ) {
+      return "none";
+    }
+    const host = hostOf(this.trustedUrl());
+    if (host) {
+      if (hostInPref(host, OFF_PREF)) {
+        return "inactive";
+      }
+      if (hostInPref(host, FORCE_INVERT_PREF)) {
+        return "active";
+      }
+      if (hostInPref(host, FORCE_NATIVE_PREF)) {
+        return "inactive";
+      }
+    }
+    // Auto: invert only sites that did NOT render dark on their own.
+    return hasNativeDark ? "inactive" : "active";
+  }
+
+  async receiveMessage(msg) {
+    if (msg.name === "Darkmode:Decide") {
+      return { override: this.#decide(!!msg.data?.hasNativeDark) };
+    }
+    return null;
+  }
+}

--- a/tests/integration/darkmode-hybrid.bjs
+++ b/tests/integration/darkmode-hybrid.bjs
@@ -1,0 +1,86 @@
+#lang beagle/js
+;; Per-site dark-mode HYBRID (task #43). The headline mechanism is per-document
+;; inversion: BrowsingContext.colorInversionOverride ("active"/"inactive"/"none")
+;; drives nsPresContext::mColorInversion for THAT document only, so the engine
+;; can invert one tab (themeless site) while another keeps its native theme.
+;; These tests drive the override from chrome and verify only that document
+;; inverts — independent of the actor's detection logic (which is JS).
+(ns gjoa.tests.integration.darkmode-hybrid
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON] Any)
+
+(def TOP :- String "http://127.0.0.1:8975/")
+
+(def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  setTimeout(() => finish(false), 15000);\n"))
+
+(defn set-override-js [v :- String] :- String
+  (str "\n"
+       "  const b = Services.wm.getMostRecentWindow('navigator:browser').gBrowser.selectedBrowser;\n"
+       "  b.browsingContext.colorInversionOverride = '" v "';\n"
+       "  return b.browsingContext.colorInversionOverride;\n"))
+
+(def PROBE :- String
+  (str "\n"
+       "  const d = document.createElement('div');\n"
+       "  d.style.backgroundColor = 'rgb(255, 255, 255)';\n"
+       "  d.style.color = 'rgb(0, 0, 0)';\n"
+       "  document.body.appendChild(d);\n"
+       "  const cs = getComputedStyle(d);\n"
+       "  return JSON.stringify({ bg: cs.backgroundColor, fg: cs.color });\n"))
+
+(js/export (def tests :- Any
+  [(deftest "darkmode hybrid: per-document override 'active' inverts just this doc" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     ;; Global invert OFF, so ONLY the per-document field can cause inversion.
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false); return 'off';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk "fixture page loaded")
+       (expect-eq (chrome-eval (set-override-js "active")) "active" "override set to active")
+       (js/await (wait-for mn "return true;" 400))
+       (js/await (.setContext mn "content"))
+       (let [parsed (JSON/parse (chrome-eval PROBE))]
+         (expect-eq (.-bg parsed) "rgb(0, 0, 0)"
+                    "white bg must invert to black under colorInversionOverride=active")
+         (expect-eq (.-fg parsed) "rgb(255, 255, 255)"
+                    "black text must invert to white"))))
+
+   (deftest "darkmode hybrid: per-document override 'inactive' leaves doc untouched (global off)" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false); return 'off';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk "fixture page loaded")
+       (expect-eq (chrome-eval (set-override-js "inactive")) "inactive" "override set to inactive")
+       (js/await (wait-for mn "return true;" 400))
+       (js/await (.setContext mn "content"))
+       (let [parsed (JSON/parse (chrome-eval PROBE))]
+         (expect-eq (.-bg parsed) "rgb(255, 255, 255)"
+                    "white bg must STAY white under colorInversionOverride=inactive (global off)"))))
+
+   (deftest "darkmode hybrid: global pref still drives inversion when override is 'none'" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', true); return 'on';")
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+       (expect navOk "fixture page loaded")
+       (expect-eq (chrome-eval (set-override-js "none")) "none" "override set to none (defer to pref)")
+       (js/await (wait-for mn "return true;" 400))
+       (js/await (.setContext mn "content"))
+       (let [parsed (JSON/parse (chrome-eval PROBE))]
+         (expect-eq (.-bg parsed) "rgb(0, 0, 0)"
+                    "with override=none, the global invert pref must still invert"))
+       ;; cleanup
+       (js/await (.setContext mn "chrome"))
+       (chrome-eval "Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false); return 'cleanup';")))]))
+
+(js/export-default tests)


### PR DESCRIPTION
## Summary
Two changes from the overnight autonomous session:

### 1. `fix(build)`: Cargo.lock `serde_json` for `--frozen` builds
The scriptlet-engine patch (0008) added `serde_json` to `content_classifier_engine/Cargo.toml` but never updated `Cargo.lock`. Local mach (no `--frozen`) patched the lock in place and masked it; **CI and `nix build` (both `--frozen`) failed** — this is why the v0.3.0 CI builds (Linux + macOS) failed. Folded the lock edge into patches/0008 (forward-applies on a pristine tree).

### 2. `feat(darkmode)`: per-site HYBRID (#43)
Every site dark, each the best way. New default `hybrid` mode: native-dark sites keep their theme; themeless sites get a per-document `BrowsingContext.colorInversionOverride` so the engine luminance-inverts just that document. Per-site overrides via `gjoa.darkmode.user.*`.

- **Engine (patches/0009)** mirrors `ForcedColorsOverride` end-to-end: WebIDL enum+attr, BC FIELD/getter/CanSet(IsTop)/DidSet, ParamTraits, `nsPresContext::UpdateColorInversion`.
- **Chrome**: `GjoaDarkmode{Child,Parent}.sys.mjs` (trusted decision in parent), actor registration, hybrid mode.
- **Fixes 'dark sites render white'**: native-dark detection regex matched the blue channel of opaque `rgb(0,0,0)` → treated as transparent → inverted to white. Now requires a real alpha channel.

## Validation
- Full mach build **exit 0**; incremental rebuild regenerated the WebIDL binding (the stale-binding postmortem is in BUILD-LEDGER).
- beagle/tsc **0 errors**; 28-agent adversarial review (follow-ups in `docs/review-followups-2026-06-18.md`).
- Integration test `darkmode-hybrid.bjs` (per-document override) — running against the dev binary.

🤖 Generated autonomously overnight.