### PR TITLE
fix(tabs): resolve #40 audit bugs 3/5/6/7

### DIFF
--- a/src/gjoa/chrome/bjs/spaces/manager.bjs
+++ b/src/gjoa/chrome/bjs/spaces/manager.bjs
@@ -1,6 +1,7 @@
 #lang beagle/js
 (ns gjoa.spaces.manager
-  (:require [gjoa.spaces.visibility :refer [is-in-active-space]]))
+  (:require [gjoa.spaces.visibility :refer [is-in-active-space]]
+            [gjoa.tabs.constants :refer [SPACE-ATTR]]))
 (define-mode strict)
 
 (declare-extern [crypto Date Array] Any)
@@ -33,10 +34,20 @@
 
        :active #(.get spaces (.-active-id state))
 
-       :spaceOf #(let [id (.get tab-space %)]
-           (if (and id (.has spaces id))
-             id
-             (default-id)))
+       :spaceOf (fn [tab]
+           (let [cached (.get tab-space tab)]
+             (if (and cached (.has spaces cached))
+               cached
+               ;; WeakMap miss — e.g. a session-restored tab the hydrate-time
+               ;; tabById lookup couldn't resolve yet. Fall back to the space-id
+               ;; persisted on the tab itself (survives Firefox session restore),
+               ;; warming the WeakMap so the tab re-anchors to its real space
+               ;; instead of silently stranding in Main.
+               (let [persisted (try (.getAttribute tab SPACE-ATTR)
+                                 (catch Any _e nil))]
+                 (if (and persisted (.has spaces persisted))
+                   (do (.set tab-space tab persisted) persisted)
+                   (default-id))))))
 
        :create (fn [name icon]
          (let [s {:id (uuid) :name (or name "Untitled") :createdAt (.now Date)}]
@@ -85,6 +96,10 @@
            (let [prev (.get tab-space tab)]
              (when (not= prev id)
                (.set tab-space tab id)
+               ;; Persist on the tab node so SessionStore carries the assignment
+               ;; across restore (read back by the spaceOf fallback above).
+               (try (.setAttribute tab SPACE-ATTR id)
+                 (catch Any _e nil))
                (on-change)))))
 
        :isVisible #(is-in-active-space % tab-space spaces (default-id) (.-active-id state))

--- a/src/gjoa/chrome/bjs/tabs/constants.bjs
+++ b/src/gjoa/chrome/bjs/tabs/constants.bjs
@@ -6,3 +6,8 @@
 (js/export (def CHORD-TIMEOUT :- Int 500))
 (js/export (def CLOSED-MEMORY :- Int 32))
 (js/export (def PIN-ATTR :- String "gjoa-id"))
+;; Per-tab space assignment, persisted via SessionStore so a tab re-anchors to
+;; its real space across session restore (instead of stranding in Main when the
+;; hydrate-time tabById lookup misses). Read as a self-healing fallback in
+;; spaces/manager spaceOf.
+(js/export (def SPACE-ATTR :- String "gjoa-space-id"))

--- a/src/gjoa/chrome/bjs/tabs/events.bjs
+++ b/src/gjoa/chrome/bjs/tabs/events.bjs
@@ -3,7 +3,7 @@
   (:require [gjoa.macros :refer [q on! bool rmattr! undef-or toggle! tabs!]]))
 (define-mode strict)
 
-(declare-extern [Services gBrowser console Math Object create-logger! CLOSED-MEMORY all-rows group-by-id is-horizontal level-of parent-of-tab pin-tab-id read-pinned-id subtree-rows tab-by-id tab-url tree-data! pop-saved-by-url pop-saved-for-tab closed-tabs moving-tabs row-of saved-tab-queue state tree-of] Any)
+(declare-extern [Services gBrowser console Math Object create-logger! CLOSED-MEMORY SPACE-ATTR all-rows group-by-id is-horizontal level-of parent-of-tab pin-tab-id read-pinned-id subtree-rows tab-by-id tab-url tree-data! pop-saved-by-url pop-saved-for-tab closed-tabs moving-tabs row-of saved-tab-queue state tree-of] Any)
 
 ;; Find previous tab in array matching predicate, searching backwards (multi-site)
 (defn find-prev-matching [tabs-arr :- Any idx :- Int pred :- Any] :- Any
@@ -233,9 +233,22 @@
         (fn [e]
           (let [tab (.-target e)
                 td (tree-data! tab)]
-            ;; Assign to active space
+            ;; Assign to the persisted space if this tab carries one (a tab
+            ;; restored from a prior session keeps its gjoa-space-id), else to
+            ;; the active space. This re-anchors restored tabs to their real
+            ;; space even when the saved-tab-queue / hydrate lookups miss (#40
+            ;; bug3). If the persisted space isn't hydrated yet, leave the tab
+            ;; UNASSIGNED so spaceOf's attr fallback resolves it later — never
+            ;; clobber a restored tab onto the active space.
             (when spaces
-              (.assignTab spaces tab (.activeId spaces)))
+              (let [persisted (.getAttribute tab SPACE-ATTR)]
+                (cond
+                  (and persisted (.get spaces persisted))
+                    (.assignTab spaces tab persisted)
+                  (and persisted (> (.-length persisted) 0))
+                    nil
+                  :else
+                    (.assignTab spaces tab (.activeId spaces)))))
 
             ;; Session-restore path
             (let [prior (pop-saved-for-tab saved-tab-queue

--- a/src/gjoa/chrome/bjs/tabs/helpers.bjs
+++ b/src/gjoa/chrome/bjs/tabs/helpers.bjs
@@ -3,7 +3,7 @@
   (:require [gjoa.macros :refer [qa attr! has? tabs! bool]]))
 (define-mode strict)
 
-(declare-extern [create-logger! PIN-ATTR tree-of state gBrowser console ChromeUtils String Number Set Array JSON Math SessionStore] Any)
+(declare-extern [create-logger! PIN-ATTR SPACE-ATTR tree-of state gBrowser console ChromeUtils String Number Set Array JSON Math SessionStore] Any)
 
 (def log :- Any (create-logger! "tabs"))
 
@@ -30,6 +30,9 @@
   (when (and (not (.-done pin-reg)) SS (.-persistTabAttribute SS))
     (try
       (.persistTabAttribute SS PIN-ATTR)
+      ;; Persist the per-tab space assignment too, so a restored tab carries its
+      ;; space across session restore (see spaces/manager spaceOf fallback).
+      (.persistTabAttribute SS SPACE-ATTR)
       (set! (.-done pin-reg) true)
       (catch Any e
         (.error console "gjoa-tabs: persistTabAttribute failed" e))))))

--- a/src/gjoa/chrome/bjs/tabs/index.bjs
+++ b/src/gjoa/chrome/bjs/tabs/index.bjs
@@ -408,8 +408,11 @@
                 ;; Position panel
                 (.positionPanel layout)
 
-                ;; MutationObserver for sidebar attribute changes
-                (let [obs (MutationObserver. #(.positionPanel layout))
+                ;; MutationObserver for sidebar attribute changes. Use the
+                ;; rAF-coalesced wrapper: compact mode bursts these attributes in
+                ;; one turn, so the un-coalesced positionPanel would re-enter
+                ;; several times per frame and could read a half-applied set.
+                (let [obs (MutationObserver. #(.requestPositionPanel layout))
                       opts {:childList true
                             :attributes true
                             :attributeFilter ["sidebar-launcher-expanded" "data-gjoa-compact" "gjoa-has-hover"]}]
@@ -417,7 +420,7 @@
 
                 ;; Pref observer for vertical tabs
                 (.addObserver (.-prefs Services) "sidebar.verticalTabs"
-                  {:observe #(.positionPanel layout)})
+                  {:observe #(.requestPositionPanel layout)})
 
                 ;; Build from saved or fresh
                 (when (not (build-from-saved!))

--- a/src/gjoa/chrome/bjs/tabs/layout.bjs
+++ b/src/gjoa/chrome/bjs/tabs/layout.bjs
@@ -3,7 +3,7 @@
   (:require [gjoa.macros :refer [by-id xul-new attr! pref-bool has? rmattr! toggle! on!]]))
 (define-mode strict)
 
-(declare-extern [gBrowser ResizeObserver create-logger! all-rows data-of! level-of-row row-of state] Any)
+(declare-extern [gBrowser ResizeObserver requestAnimationFrame create-logger! all-rows data-of! level-of-row row-of state] Any)
 
 (js/export (defn make-layout! [deps :- Any] :- Any
   (let [sidebar-main (.-sidebarMain deps)
@@ -13,7 +13,8 @@
         ;; Module-private mutable state
         priv :- Any {:toolboxResizeObs nil
                      :alignSpacer nil
-                     :lastVertical nil}
+                     :lastVertical nil
+                     :posPanelRaf 0}
 
         is-vertical (fn [] :- Bool
           (pref-bool "sidebar.verticalTabs" true))
@@ -191,8 +192,22 @@
                 ;; mode toggle never leaves the selected tab hidden.
                 (when (.-reconcileSelection deps)
                   (.reconcileSelection deps))
-                (set! (.-lastVertical priv) vertical)))))]
+                (set! (.-lastVertical priv) vertical)))))
+
+        ;; rAF-coalesce positionPanel: compact mode bursts several sidebar
+        ;; attributes in one turn (data-gjoa-compact / gjoa-has-hover /
+        ;; sidebar-launcher-expanded), each firing the MutationObserver. Collapse
+        ;; them into ONE positionPanel per frame so we never thrash the layout or
+        ;; read a half-applied attribute set mid-burst.
+        request-position-panel (fn []
+          (when (= (.-posPanelRaf priv) 0)
+            (set! (.-posPanelRaf priv)
+              (requestAnimationFrame
+                (fn []
+                  (set! (.-posPanelRaf priv) 0)
+                  (position-panel))))))]
 
     {:positionPanel position-panel
+     :requestPositionPanel request-position-panel
      :isVertical is-vertical
      :setUrlbarTopLayer set-urlbar-top-layer})))

--- a/src/gjoa/chrome/bjs/tabs/rows.bjs
+++ b/src/gjoa/chrome/bjs/tabs/rows.bjs
@@ -3,7 +3,7 @@
   (:require [gjoa.macros :refer [q qa by-id attr! on! xul htm has? toggle! rmattr! bool tabs!]]))
 (define-mode strict)
 
-(declare-extern [gBrowser Promise String Array requestAnimationFrame INDENT has-children is-horizontal level-of level-of-row tree-data! data-of! all-rows create-logger! hz-display moving-tabs row-of state] Any)
+(declare-extern [gBrowser Promise String Array requestAnimationFrame cancelAnimationFrame INDENT has-children is-horizontal level-of level-of-row tree-data! data-of! all-rows create-logger! hz-display moving-tabs row-of state] Any)
 
 ;; From sibling modules — no import, declare-extern only.
 ;; --- reset-style!: clear all 7 grid/position style properties ---
@@ -23,7 +23,7 @@
         log (create-logger! "tabs/rows")
 
         ;; Module-private mutable state
-        counters :- Any {:group 0 :resync-pending false}
+        counters :- Any {:group 0 :resync-pending false :grid-raf 0}
 
         ;; ----- tab rows -----
 
@@ -111,9 +111,12 @@
                        :level    lv
                        :state    nil
                        :collapsed false
+                       ;; nil (not "") when there's no active space — "" is a
+                       ;; phantom id that downstream truthy-checks treat as Main
+                       ;; anyway; nil states "no space assigned" honestly.
                        :spaceId  (if (.-getActiveSpaceId deps)
-                                   (or (.getActiveSpaceId deps) "")
-                                   "")}
+                                   (or (.getActiveSpaceId deps) nil)
+                                   nil)}
                 row     (xul "hbox" "gjoa-group-row")
                 marker  (htm "span" "gjoa-group-marker")
                 label   (htm "span" "gjoa-tab-label")
@@ -252,9 +255,14 @@
                               (.join tracks " ")))
                       (set! (.-gridTemplateColumns (.-style c)) "")))))
 
-              ;; Pin container heights and handle popouts in rAF
-              (requestAnimationFrame
-                (fn [] (when (is-horizontal)
+              ;; Pin container heights and handle popouts in rAF. Capture the
+              ;; handle so a re-entrant pass (rapid mode toggle) cancels the
+              ;; stale one instead of double-positioning popouts.
+              (when (> (.-grid-raf counters) 0)
+                (cancelAnimationFrame (.-grid-raf counters)))
+              (set! (.-grid-raf counters)
+                (requestAnimationFrame
+                  (fn [] (set! (.-grid-raf counters) 0) (when (is-horizontal)
                    ;; Pin each container to first-row height
                    (.forEach raw-containers
                      #(let [first-row (q %
@@ -305,11 +313,14 @@
                                        (str (.-top r) "px"))
                                  (set! (.-width (.-style p))
                                        (str (.-width r) "px"))
-                                 (set! (.-zIndex (.-style p)) "9999"))))))))))))))))
+                                 (set! (.-zIndex (.-style p)) "9999")))))))))))))))))
 
         ;; ----- clear horizontal grid -----
 
         clear-horizontal-grid (fn []
+          (when (> (.-grid-raf counters) 0)
+            (cancelAnimationFrame (.-grid-raf counters))
+            (set! (.-grid-raf counters) 0))
           (let [both []]
             (when (.-pinnedContainer state)
               (.push both (.-pinnedContainer state)))

--- a/tests/integration/spaces-session-restore.bjs
+++ b/tests/integration/spaces-session-restore.bjs
@@ -1,0 +1,82 @@
+#lang beagle/js
+;; #40 bug3 — a session-restored tab must re-anchor to its real space, not Main.
+;; gjoa now persists each tab's space on a `gjoa-space-id` attribute (registered
+;; with SessionStore, so it survives restore). `spaceOf` reads it as a
+;; self-healing fallback when the in-memory WeakMap misses (which is exactly what
+;; happens at hydrate time for a tab the tabById lookup can't yet resolve).
+(ns gjoa.tests.integration.spaces-session-restore
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval expect expect-eq]]))
+(define-mode strict)
+(declare-extern [JSON] Any)
+
+(def RESET-JS :- String
+  (str "\n"
+       "  const S = window.Spaces;\n"
+       "  const main = S.list().find(s => s.name === 'Main') || S.list()[0];\n"
+       "  S.setActive(main.id);\n"
+       "  for (const s of [...S.list()]) { if (s.id !== main.id) S.delete(s.id); }\n"
+       "  const work = S.create('Work');\n"
+       "  window.__workId = work.id;\n"
+       "  window.__mainId = main.id;\n"
+       "  return JSON.stringify({ work: work.id, main: main.id });\n"))
+
+;; A restored tab the in-memory WeakMap doesn't know about: a tab-like object
+;; whose only space signal is the persisted gjoa-space-id attribute. spaceOf must
+;; read it and resolve to Work (warming the WeakMap), not strand in Main. (A real
+;; gBrowser tab can't be used here: onTabOpen assigns it on creation, populating
+;; the WeakMap, so the fallback would never be exercised — which is the whole
+;; point of the fix.)
+(def RESTORE-PROBE-JS :- String
+  (str "\n"
+       "  const S = window.Spaces;\n"
+       "  const fakeTab = { getAttribute: (a) => a === 'gjoa-space-id' ? window.__workId : null };\n"
+       "  const got = S.spaceOf(fakeTab);\n"
+       "  return JSON.stringify({ isWork: got === window.__workId, isMain: got === window.__mainId });\n"))
+
+;; assignTab must persist the attribute so the tab survives a future restore.
+(def ASSIGN-PERSIST-JS :- String
+  (str "\n"
+       "  const S = window.Spaces;\n"
+       "  const t = gBrowser.addTab('https://example.com/assign', {\n"
+       "    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  S.assignTab(t, window.__workId);\n"
+       "  const attr = t.getAttribute('gjoa-space-id');\n"
+       "  gBrowser.removeTab(t);\n"
+       "  return attr;\n"))
+
+;; A tab with NO attr and not in the WeakMap still falls back to Main (unchanged
+;; behaviour — the fix must not regress the genuine no-space case).
+(def NO-ATTR-JS :- String
+  (str "\n"
+       "  const S = window.Spaces;\n"
+       "  const t = gBrowser.addTab('https://example.com/plain', {\n"
+       "    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  const got = S.spaceOf(t);\n"
+       "  const isMain = got === window.__mainId;\n"
+       "  gBrowser.removeTab(t);\n"
+       "  return JSON.stringify({ isMain });\n"))
+
+(js/export (def tests :- Any
+  [(deftest "spaces #40bug3: restored tab re-anchors via persisted gjoa-space-id (not Main)" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval RESET-JS)
+     (let [parsed (JSON/parse (chrome-eval RESTORE-PROBE-JS))]
+       (expect (.-isWork parsed)
+               "restored tab with persisted gjoa-space-id resolves to Work")
+       (expect (not (.-isMain parsed))
+               "restored tab must NOT strand in Main")))
+
+   (deftest "spaces #40bug3: assignTab persists gjoa-space-id on the tab" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval RESET-JS)
+     (expect-eq (chrome-eval ASSIGN-PERSIST-JS) (chrome-eval "return window.__workId;")
+                "assignTab writes the space id to the gjoa-space-id attribute"))
+
+   (deftest "spaces #40bug3: tab with no space attr still falls back to Main" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval RESET-JS)
+     (let [parsed (JSON/parse (chrome-eval NO-ATTR-JS))]
+       (expect (.-isMain parsed)
+               "a tab with no persisted space and no WeakMap entry defaults to Main")))]))
+
+(js/export-default tests)


### PR DESCRIPTION
Closes the deferred tab/space audit bugs from #40. All Lane 1 (chrome JS, no rebuild).

| bug | issue | fix |
|---|---|---|
| **3** | session-restored tabs strand in **Main** when hydrate's `tabById` can't resolve them | persist each tab's space on a `gjoa-space-id` attr (SessionStore-registered → survives restore); `onTabOpen` anchors restored tabs to their persisted space; `spaceOf` self-heals from the attr on a WeakMap miss |
| **5** | compact MutationObserver re-enters `positionPanel` on a burst of sidebar attribute changes | rAF-coalesce via `requestPositionPanel`; observers route through it (initial sync stays direct) |
| **6** | group rows mint an empty-string `spaceId` ("") — a phantom id | use nil instead |
| **7** | rapid mode-toggle double-positions popout rows (uncancellable grid rAF) | capture + cancel the prior rAF handle |

## Validation
- New `tests/integration/spaces-session-restore.bjs` (3 cases: re-anchor via attr, assignTab persists, no-attr→Main)
- **28/28** spaces + tab integration tests pass on the dev binary (incl. `tab-mode-toggle` — no regression to the validated mode-toggle fix)
- beagle/tsc **0 errors**

🤖 Generated autonomously.