### PR TITLE
feat(darkmode): Tier b — no-flash hybrid (pre-paint polarity flip)

### DIFF
--- a/BUILD-LEDGER.md
+++ b/BUILD-LEDGER.md
@@ -446,3 +446,36 @@ Folded the 1-line `serde_json` dependency edge into `patches/0008` (forward-appl
 on a pristine tree). New gate idea (K): preflight should `cargo metadata
 --frozen` (or grep that every Cargo.toml dep edge exists in Cargo.lock) so a
 crate added without a lock update fails preflight, not a 30-min CI build.
+
+## 2026-06-18 — Lane 3 mach build: dark-mode-v2 Tier b (no-FOUC hybrid)
+
+**Type:** incremental `./mach build` in `nix develop .#mach`, 1820 s (~30 min), 8
+warnings (all pre-existing / third-party). **Trigger:** Tier b — engine
+color-inversion polarity flip (`nsPresContext` + `PresShell::Initialize`) + the
+reworked `GjoaDarkmode` actors. **Outcome:** GREEN, first try. The dev binary
+loads the actors via `dist/bin/modules/*.sys.mjs` symlinks into the source tree
+(so edits are live without repacking omni.ja).
+
+**Validation:** darkmode suite **7/7 in isolation** — P0/P1/P2 global invert;
+legacy hybrid actor-invert; tier-b engine default-invert darkens a themeless
+`/light` page; tier-b native-dark `/dark` page keeps its theme. Full-suite 59/68
+with 9 fails, **all pre-existing, none Tier b**: 7 darkmode are a cascade from the
+real-network youtube player-prune test discarding the BC (pass 7/7 alone), 1
+youtube network flake, 1 adblock `content.protection` (fails identically on the
+pre-Tier-b `result/` binary — task #50).
+
+**Design pivot (pre-build):** the planned "default-invert-then-retract" was
+scrapped — the luminance inversion `Y -> 1-Y` is NOT losslessly reversible once
+channels clamp (saturated darks), so recovering authored luminance from an
+inverted read misclassifies them. Shipped the **polarity flip**: hybrid docs start
+un-inverted (first cascade = authored colors), `PresShell::Initialize` reads the
+authored root bg *directly* and flips themeless pages to inverted pre-paint;
+native-dark pages are left alone. A 4-dimension pre-build review caught **5
+blockers** (missing `PresShell.cpp` hunk in patch 0009, stale chrome bundle, the
+lossy math, a same-tab override clobber, an explicit-vs-refiner async race) — all
+fixed before the build, which then passed first try.
+
+**Fixture lesson:** a no-CSS page under hybrid's forced `prefers-color-scheme:dark`
+renders with the UA *dark* canvas — correctly NOT inverted. A real themeless-light
+site hardcodes a light bg; added a `/light` fixture for the invert assertion (the
+plain `/` no-bg page is not a valid themeless-light case under hybrid).

--- a/docs/darkmode-v2-tier-b-design.md
+++ b/docs/darkmode-v2-tier-b-design.md
@@ -1,110 +1,99 @@
-# Dark-mode-v2 Tier b — no-FOUC + smarter engine (implementation-ready)
+# Dark-mode-v2 Tier b — no-flash hybrid (AS BUILT)
 
-Tier 1 (curated registry + YouTube native-dark) is shipped. Tier b removes the
-flash-of-white and raises the engine floor. **Lane 3 (engine rebuild).** It is
-**all-or-nothing**: change (A) alone breaks the actor (see "Why all-or-nothing").
+Tier 1 (curated registry + YouTube native-dark) shipped first. Tier b removes the
+flash-of-light in the per-site **hybrid** mode by moving the dark/native decision
+*before the first paint*, at the engine. **Lane 3 (engine rebuild).**
 
-## The flash today (after Tier 1)
-In hybrid mode a themeless page renders LIGHT, then ~2 frames later the actor
-sets `colorInversionOverride="active"` and it goes dark. Tier 1's actor reset (to
-`"none"` at document-start) made this re-measure happen on every navigation, so
-themeless pages flash light→dark consistently. Native-dark pages are fine (they
-render dark from frame 1).
+> This document was rewritten after implementation. The original plan was
+> "default every page to inverted at construction, then *retract* native-dark
+> pages by reading their (already-inverted) background and un-inverting it." A
+> pre-build review killed that: the luminance inversion `Y -> 1-Y` is **not**
+> losslessly reversible once channels clamp (saturated darks like navy/maroon),
+> so recovering the authored luminance from an inverted read misclassifies them.
+> The shipped design **flips the polarity** to avoid any recovery — see below.
 
-## The core insight (dissolves the chicken-and-egg)
-The servo color hook runs UPSTREAM of inversion: the pre-inversion AUTHORED color
-flows through `Color::to_computed_color` before `invert_color_luminance`. So the
-engine can sample the root/canvas background's *un-inverted* luminance at the
-exact place it decides whether to invert — no circularity (it reads the input to
-the hook, not its output). The JS actor cannot do this (getComputedStyle is
-post-inversion); the engine can.
+## The flash, and why pre-paint is the only cure
+A dark mode that may flash is easy (paint light, measure after paint, invert).
+That is exactly Tier 1, and you see the white frames. "No flash" forces the
+decision *before* the first paint — but whether a page is "already dark" is only
+knowable *after* it has styled itself. We resolve that paradox inside Firefox's
+existing **paint-suppression window** (the page is laid out but not yet revealed):
+classify there, commit, then reveal. One render, no clone, no wait-for-settle.
 
-## The five coordinated changes
+## The core move (polarity flip — dissolves the chicken-and-egg)
+In hybrid mode a top content document **starts un-inverted**. Its first cascade
+therefore computes the page's **AUTHORED** colors (accurate — nothing went through
+the inversion hook yet). At `PresShell::Initialize`, after the root frame exists
+but before paint is unsuppressed, we read the authored root background:
+- **themeless** (light or transparent ⇒ the UA white canvas shows) → flip the
+  whole document to inverted, pre-paint, so it renders dark from frame 1.
+- **native-dark** (authored luminance < 0.22) → leave it; it keeps its own theme.
 
-### (A) Hybrid defaults to inverted at the engine — `nsPresContext::UpdateColorInversion` (`nsPresContext.cpp:789`)
-After the `Inactive` check, before the global-pref fallback: if the override is
-`None` and `Preferences::GetBool("gjoa.darkmode.hybrid.default-invert", false)`,
-return `true`. So a themeless top http(s) doc has `mColorInversion=true` at
-construction — before first paint. "Start dark, maybe back off."
+No inverted-value recovery anywhere on the engine path: we read the authored color
+directly because the first cascade was never inverted.
 
-### (B) Pre-paint native-dark classification — `PresShell::Initialize` (`PresShell.cpp:1643`, after `ContentInserted` at `:1696`, before the paint-suppression block at `:1737`)
-Call a new `nsPresContext::ClassifyAuthoredRootDarkness()`:
-- Reads `FrameConstructor()->GetRootElementStyleFrame()` (exists here; same frame
-  `DefaultBackgroundColorScheme` reads at `nsPresContext.cpp:1670`).
-- Computes the **specified/authored** `background-color` (NOT the computed/
-  inverted one — the specified value never went through `to_computed_color`).
-- WCAG luminance test (`LookAndFeel::IsDarkColor`-style; threshold 0.22 to match
-  the JS `#luminance`). Returns tri-state dark / light / unknown.
-- If **dark** → set `mColorInversion=false` (retract; native-dark keeps its
-  theme). If **unknown** → leave the default-invert (themeless-safe).
+## The engine changes (patch `0009-dark-mode-engine-color-inversion.patch`)
 
-This runs BEFORE the paint-suppression timer arms, so the retraction lands before
-the first cascade is painted — native-dark sites never have an inverted frame.
+### `nsPresContext` — the flip + a durable bit
+- `mHybridDefaultInvert` (member): the pre-paint classification result. Durable so
+  it survives later `UpdateColorInversion` re-derives (BC field changes, etc.).
+- `UpdateColorInversion` precedence (unchanged head, new tail): override `Active`
+  → invert; override `Inactive` → don't; else `if (mHybridDefaultInvert) invert`;
+  else the global `gjoa.darkmode.invert.enabled` pref. The hybrid pref does **not**
+  force inversion at construction — that is what keeps the first cascade authored.
+- `ApplyHybridDefaultInvertIfThemeless()` (new): returns early if already inverting
+  / pref off / an explicit override already decided; reads
+  `nsCSSRendering::FindEffectiveBackgroundColor(rootStyleFrame, /*stopAtThemed*/true,
+  /*preferBodyToCanvas*/true)`; if transparent or `RelativeLuminanceUtils::Compute
+  (bg) >= 0.22` (themeless) sets `mHybridDefaultInvert=true` and calls
+  `UpdateColorInversion(true)` → flips `mColorInversion` + restyles pre-paint.
+- `DefaultBackgroundColor()`: when inverting a light-scheme document, returns the
+  luminance-inverted canvas background (`RelativeLuminanceUtils::Adjust(bg,
+  1-Compute(bg))`) so the canvas backstop / inter-page blank is dark, not white.
 
-### (C) Canvas backstop honors inversion — `nsPresContext::DefaultBackgroundColor()` (`nsPresContext.cpp:1676`)
-Currently returns `PrefSheetPrefs().ColorsFor(DefaultBackgroundColorScheme()).mDefaultBackground`.
-Gate: when `ColorInversion()` is true AND `DefaultBackgroundColorScheme()==ColorScheme::Light`,
-return the luminance-inverted light background (reuse the `RelativeLuminanceUtils::Adjust`
-math from the servo `invert_color_luminance`, `color.rs:279`) — opaque (the
-`LoadColors` opaque-force + `nsCanvasFrame` opacity assert require it). This one
-function feeds `GetDefaultBackgroundColorToDraw` / `ComputeCanvasBackground` /
-`ComputeBackstopColor`, covering both the suppressed-paint backstop and the
-inter-page blank. `mColorInversion` is already correct here (UpdateColorInversion
-runs in `nsPresContext::Init` before `Initialize`).
+### `PresShell::Initialize`
+One call: `mPresContext->ApplyHybridDefaultInvertIfThemeless()`, placed after the
+root `ContentInserted` block, before `MaybeScheduleRendering` and the paint-
+suppression setup. The restyle it posts flushes before the first paint (Gecko
+flushes style before paint within a refresh tick; paint is also suppressed here).
 
-### (D) Share the invert math — `color.rs:279`
-Factor `invert_color_luminance` so the C++ backstop (C) calls byte-identical math
-(shared `RelativeLuminanceUtils::Adjust` / a small FFI). No behavior change to the
-END-hook.
+## The chrome arm (`src/gjoa/chrome/bjs/dark-mode/index.bjs`)
+The `hybrid` mode arm sets `gjoa.darkmode.hybrid.default-invert` true (plus
+`prefers-color-scheme: dark` via content-override 0, so native-dark sites that key
+on the media query activate). Every other mode (`off`/`engine`/`filter`/`auto`)
+sets it false, so the engine flip never leaks outside hybrid.
 
-### (E) Chrome arm — `src/gjoa/chrome/bjs/dark-mode/index.bjs:70-86`
-Add a real `hybrid` arm to `apply!`: `set-chrome-scheme! true`, `set-content-override! 0`,
-`set-invert! false`, AND `set-pref-bool! "gjoa.darkmode.hybrid.default-invert" true`.
-EVERY other arm (`off`/`engine`/`filter`/`:else auto`) must set it `false` so the
-engine default never leaks into non-hybrid modes. Add the pref const near
-`PREF-INVERT` (`:23`).
+## The actor (refiner, not decider) — `GjoaDarkmode{Parent,Child}.sys.mjs`
+The engine is the primary classifier now. The actor does two things on top:
+- **document-start (DOMWindowCreated):** ask the parent for an EXPLICIT curated
+  decision (fix registry / user per-site pref) and apply its `override` + `css` +
+  `inject` immediately, so curated sites (YouTube `html[dark]` + a `#0f0f0f` USER
+  sheet) are correct from frame 1. The reset-to-`none` here clears any inherited
+  override so a fresh same-tab navigation re-classifies cleanly. The explicit work
+  is stored as a promise the DOMContentLoaded path awaits, so the refiner can never
+  race the curated decision.
+- **post-paint (DOMContentLoaded), refiner:** only for non-explicit sites. Samples
+  the body/root background, probing the live inversion state (white→black AND
+  black→white swatches) to read it the right way round, and retracts the engine's
+  invert (`override:"inactive"`) for a site that turned out dark via **late**
+  JS/CSS theming the pre-paint check ran too early to see. Best-effort, threshold-
+  based — the engine is the precise classifier.
 
-## Why all-or-nothing (do NOT ship A without B)
-With (A) default-invert + Tier 1's actor reset: a native-dark page resets to
-`none` → (A) makes `none`→invert → it renders inverted (light) → the actor
-measures the inverted (light) result → decides `active` → stays inverted. So (A)
-WITHOUT (B) inverts native-dark sites. (B) retracts pre-paint by reading the
-AUTHORED bg, which the actor cannot. Ship A+B+C+D+E together.
+## Known limitations / follow-ups
+- **Curated attribute-gated sites (e.g. YouTube)**: a ~1-IPC window where the
+  engine flip runs before the child's async `override:"inactive"` lands → a brief,
+  self-correcting double-dark. Fix: seed the curated override pre-layout from a
+  parent-process host check (task #49).
+- **Late-theme non-curated sites**: handled by the post-paint refiner with a brief
+  flash (same as Tier 1, no regression); the refiner's luminance flip is a coarse
+  threshold, not exact.
+- **Policy layer (task #48)**: discrete modes should become escape hatches; the
+  default should follow the system theme (system dark → hybrid engages). This sits
+  on top of the Tier-b mechanism.
 
-## The actor's new role (refiner, not decider) — the LOAD-BEARING subtlety
-The post-paint actor STAYS but is demoted to a refiner for cases the engine's
-root-only classifier misses (dark bg on an inner wrapper, late JS theming,
-per-site user overrides). CRITICAL: when the engine default is invert-on, the
-actor must read the AUTHORED root luminance, NOT the inverted computed style, or
-its detection breaks. Expose the engine's pre-inversion root luminance to the
-actor via a readonly `BrowsingContext` field set during (B)'s classification, so
-the actor never has to un-invert a computed read. Without this, flipping the
-default to invert breaks the actor (research pitfall 2).
-
-## Smarter algorithm (separable, also Lane 3)
-Skip inverting images/video/canvas in the servo invert path (the blunt invert
-currently mangles photos — the legacy filter path already counter-inverts media).
-Lower-risk than the FOUC; can ship independently to raise Tier 0's floor.
-
-## Build + validate
-1. `bun run import` (engine compiles from `engine/`, not `src/gjoa`).
-2. `bun run preflight` (gates A–I; the `gjoa preflight` wrapper currently points
-   at a stale `.ts` path — use `bun run preflight`).
-3. Full `./mach build` inside `nix develop .#mach`. Append outcome to BUILD-LEDGER.
-4. Tests — extend `tests/integration/darkmode-hybrid.bjs` (the `/dark` fixture
-   route already exists; the "actor keeps native-dark" assertion lands here, now
-   deterministic because (B) decides pre-paint, no cross-nav circularity):
-   - themeless paints inverted on FIRST paint (probe immediately, no rAF) — proves
-     (A)+(C) at construction/Initialize, not the actor.
-   - native-dark stays dark on first paint — proves (B) retracted pre-paint.
-   - canvas/Canvas system-color backstop is dark for a themeless doc — proves (C).
-   - actor refiner retracts an inner-wrapper-dark site the root classifier missed.
-5. `nix build .#gjoa --impure` for the native binary.
-
-## Runner-up (if `ClassifyAuthoredRootDarkness` proves unreliable at Initialize)
-Keep (A)+(C), drop (B), extend the paint-suppression window by one style flush
-(`nglayout.initialpaint.delay`) to do a synchronous pre-inversion root-bg check
-before unsuppressing. Adds first-paint latency on the hot path; the recommended
-approach decides within the existing pre-paint window with no added latency.
-
-Full research: session workflow `wf_dabd653c` (FOUC) + `wf_ea21f849` (quality).
+## Validation
+`tests/integration/darkmode-hybrid.bjs`: (1) engine default-invert darkens a
+themeless page; (2) a native-dark (`/dark`, authored `#111`) page keeps its theme
+(root stays dark + an injected white box stays white ⇒ inversion was not applied).
+Plus the P0/P1/P2 global-invert tests in `darkmode-invert.bjs` (unaffected:
+`default-invert` defaults off).

--- a/patches/0009-dark-mode-engine-color-inversion.patch
+++ b/patches/0009-dark-mode-engine-color-inversion.patch
@@ -5,6 +5,7 @@
 #     - servo/components/style/device/gecko.rs
 #     - layout/base/nsPresContext.h
 #     - layout/base/nsPresContext.cpp
+#     - layout/base/PresShell.cpp
 #     - dom/chrome-webidl/BrowsingContext.webidl
 #     - docshell/base/BrowsingContext.h
 #     - docshell/base/BrowsingContext.cpp
@@ -28,6 +29,19 @@ style-resolution time (the performant successor to the compositor filter:invert)
 The "engine" dark-mode mode (src/gjoa chrome) forces prefers-color-scheme:light
 then flips this flag, so sites render light and the engine inverts to dark.
 
+Dark-mode-v2 Tier b (no flash-of-light in the per-site "hybrid" mode):
+- nsPresContext: mHybridDefaultInvert + ApplyHybridDefaultInvertIfThemeless().
+  In hybrid mode a top document starts UN-inverted, so its first cascade exposes
+  the page's AUTHORED background. PresShell::Initialize then reads that root
+  background (un-inverted = accurate) and, for a themeless page (light or
+  transparent), flips the whole document to inverted BEFORE first paint — so it
+  renders dark with no flash. A page that authored its own dark theme is left
+  native. Gated on pref gjoa.darkmode.hybrid.default-invert.
+- DefaultBackgroundColor(): when inverting a light-scheme document, the canvas /
+  inter-page backstop is luminance-inverted too, so no white frame flashes
+  between navigations or behind suppressed paints.
+- PresShell.cpp: the one call site (ApplyHybridDefaultInvertIfThemeless), placed
+  after the root frame is built and before painting is unsuppressed.
 diff --git a/docshell/base/BrowsingContext.cpp b/docshell/base/BrowsingContext.cpp
 index e8b50c6548..b5c5194ead 100644
 --- a/docshell/base/BrowsingContext.cpp
@@ -135,11 +149,44 @@ index d0508a8c29..da80d54f18 100644
    // Animation playbackRate multiplier, for Devtools
    [SetterThrows] attribute double animationsPlayBackRateMultiplier;
  
+diff --git a/layout/base/PresShell.cpp b/layout/base/PresShell.cpp
+index 9d651a17a9..fd2dfbc81a 100644
+--- a/layout/base/PresShell.cpp
++++ b/layout/base/PresShell.cpp
+@@ -1703,6 +1703,12 @@ nsresult PresShell::Initialize() {
+     NS_ENSURE_STATE(!mHaveShutDown);
+   }
+ 
++  // gjoa hybrid dark mode: the first (un-inverted) cascade has built the root
++  // frame, so its authored background is now readable. Flip a themeless document
++  // to inverted (dark) before painting is unsuppressed, so it renders dark from
++  // the first paint with no flash; native-dark pages are left untouched.
++  mPresContext->ApplyHybridDefaultInvertIfThemeless();
++
+   mDocument->MaybeScheduleRendering();
+ 
+   NS_ASSERTION(rootFrame, "How did that happen?");
 diff --git a/layout/base/nsPresContext.cpp b/layout/base/nsPresContext.cpp
-index b2394c6106..ce3725d676 100644
+index b2394c6106..d4cdbe4398 100644
 --- a/layout/base/nsPresContext.cpp
 +++ b/layout/base/nsPresContext.cpp
-@@ -327,6 +327,7 @@ nsPresContext::nsPresContext(dom::Document* aDocument, nsPresContextType aType)
+@@ -33,6 +33,7 @@
+ #include "mozilla/Preferences.h"
+ #include "mozilla/PresShell.h"
+ #include "mozilla/PresShellInlines.h"
++#include "mozilla/RelativeLuminanceUtils.h"
+ #include "mozilla/RestyleManager.h"
+ #include "mozilla/SMILAnimationController.h"
+ #include "mozilla/ServoBindings.h"
+@@ -70,6 +71,7 @@
+ #include "nsCOMPtr.h"
+ #include "nsCRT.h"
+ #include "nsCSSFrameConstructor.h"
++#include "nsCSSRendering.h"
+ #include "nsContentUtils.h"
+ #include "nsDeviceContext.h"
+ #include "nsDocShell.h"
+@@ -327,6 +329,7 @@ nsPresContext::nsPresContext(dom::Document* aDocument, nsPresContextType aType)
  
    UpdateFontVisibility();
    UpdateForcedColors(/* aNotify = */ false);
@@ -147,7 +194,7 @@ index b2394c6106..ce3725d676 100644
  }
  
  static const char* gExactCallbackPrefs[] = {
-@@ -340,6 +341,7 @@ static const char* gExactCallbackPrefs[] = {
+@@ -340,6 +343,7 @@ static const char* gExactCallbackPrefs[] = {
      "layout.css.text-autospace.enabled",
      "layout.css.text-transform.uppercase-eszett.enabled",
      "privacy.trackingprotection.enabled",
@@ -155,7 +202,7 @@ index b2394c6106..ce3725d676 100644
      nullptr,
  };
  
-@@ -532,6 +534,11 @@ void nsPresContext::PreferenceChanged(const char* aPrefName) {
+@@ -532,6 +536,11 @@ void nsPresContext::PreferenceChanged(const char* aPrefName) {
    }
  
    nsDependentCString prefName(aPrefName);
@@ -167,7 +214,7 @@ index b2394c6106..ce3725d676 100644
    if (prefName.EqualsLiteral("layout.css.dpi") ||
        prefName.EqualsLiteral("layout.css.devPixelsPerPx")) {
      int32_t oldAppUnitsPerDevPixel = mDeviceContext->AppUnitsPerDevPixel();
-@@ -775,6 +782,37 @@ void nsPresContext::UpdateForcedColors(bool aNotify) {
+@@ -775,6 +784,82 @@ void nsPresContext::UpdateForcedColors(bool aNotify) {
    }
  }
  
@@ -193,6 +240,14 @@ index b2394c6106..ce3725d676 100644
 +        return false;
 +      }
 +    }
++    // gjoa hybrid: a themeless top document is classified pre-paint by
++    // ApplyHybridDefaultInvertIfThemeless() (PresShell::Initialize), AFTER the
++    // first un-inverted cascade exposes the page's AUTHORED colors. That sets
++    // mHybridDefaultInvert and re-derives this flag; the bit is durable so later
++    // re-derives keep inverting the page.
++    if (mHybridDefaultInvert) {
++      return true;
++    }
 +    return Preferences::GetBool("gjoa.darkmode.invert.enabled", false);
 +  }();
 +  if (aNotify && mColorInversion != old) {
@@ -202,10 +257,47 @@ index b2394c6106..ce3725d676 100644
 +  }
 +}
 +
++// gjoa hybrid: called from PresShell::Initialize after the FIRST (un-inverted)
++// cascade has built the root frame, so the background we read here is the page's
++// AUTHORED color, not an inverted one (in hybrid mode this document starts
++// un-inverted; only ApplyHybridDefaultInvertIfThemeless flips it). If the page
++// did NOT author a dark theme -- background is light or transparent (the UA white
++// canvas shows through) -- flip the whole document to inverted pre-paint so it
++// renders dark from the first paint with no flash. A native-dark page (authored
++// luminance < 0.22, matching the JS actor's #luminance threshold) is left alone
++// and keeps its own theme. The decision is recorded in mHybridDefaultInvert so it
++// survives later UpdateColorInversion re-derives (durable).
++void nsPresContext::ApplyHybridDefaultInvertIfThemeless() {
++  if (mColorInversion || mHybridDefaultInvert) {
++    return;  // already inverting: explicit override, global pref, or prior call
++  }
++  if (!Preferences::GetBool("gjoa.darkmode.hybrid.default-invert", false)) {
++    return;
++  }
++  // An explicit actor/fix override (Active/Inactive) has already decided.
++  if (auto* bc = mDocument->GetBrowsingContext()) {
++    if (bc->Top()->ColorInversionOverride() != ColorInversionOverride::None) {
++      return;
++    }
++  }
++  nsIFrame* frame = FrameConstructor()->GetRootElementStyleFrame();
++  if (!frame) {
++    return;
++  }
++  auto bg = nsCSSRendering::FindEffectiveBackgroundColor(
++      frame, /* aStopAtThemed = */ true, /* aPreferBodyToCanvas = */ true);
++  const bool themeless = NS_GET_A(bg.mColor) == 0 ||
++                         RelativeLuminanceUtils::Compute(bg.mColor) >= 0.22f;
++  if (themeless) {
++    mHybridDefaultInvert = true;
++    UpdateColorInversion(/* aNotify = */ true);  // mColorInversion=true + restyle
++  }
++}
++
  bool nsPresContext::ForcingColors() const {
    return mForcedColors == StyleForcedColors::Active;
  }
-@@ -927,6 +965,7 @@ void nsPresContext::RecomputeBrowsingContextDependentData() {
+@@ -927,6 +1012,7 @@ void nsPresContext::RecomputeBrowsingContextDependentData() {
    }());
  
    UpdateForcedColors();
@@ -213,8 +305,30 @@ index b2394c6106..ce3725d676 100644
  
    SetInRDMPane(top->GetInRDMPane());
  
+@@ -1638,9 +1724,18 @@ nscolor nsPresContext::DefaultBackgroundColor() const {
+   if (!GetBackgroundColorDraw()) {
+     return NS_RGB(255, 255, 255);
+   }
+-  return PrefSheetPrefs()
+-      .ColorsFor(DefaultBackgroundColorScheme())
+-      .mDefaultBackground;
++  ColorScheme scheme = DefaultBackgroundColorScheme();
++  nscolor bg = PrefSheetPrefs().ColorsFor(scheme).mDefaultBackground;
++  // gjoa engine dark mode: when this document is being inverted but its default
++  // scheme is light, the canvas backstop / inter-page blank must be dark too, or
++  // a white frame flashes between navigations and behind suppressed paints.
++  // Mirror the servo luminance inversion (Y -> 1 - Y); alpha is preserved (the
++  // pref default background is opaque).
++  if (mColorInversion && scheme == ColorScheme::Light) {
++    bg = RelativeLuminanceUtils::Adjust(bg,
++                                        1.0f - RelativeLuminanceUtils::Compute(bg));
++  }
++  return bg;
+ }
+ 
+ nsDocShell* nsPresContext::GetDocShell() const {
 diff --git a/layout/base/nsPresContext.h b/layout/base/nsPresContext.h
-index 13aa7141c8..2794d77dda 100644
+index 13aa7141c8..b6ffd4b24d 100644
 --- a/layout/base/nsPresContext.h
 +++ b/layout/base/nsPresContext.h
 @@ -362,6 +362,10 @@ class nsPresContext : public nsISupports,
@@ -228,20 +342,31 @@ index 13aa7141c8..2794d77dda 100644
    bool ForcingColors() const;
  
    mozilla::ColorScheme DefaultBackgroundColorScheme() const;
-@@ -565,6 +569,7 @@ class nsPresContext : public nsISupports,
+@@ -565,8 +569,14 @@ class nsPresContext : public nsISupports,
    void SetInRDMPane(bool aInRDMPane);
    void UpdateInnerSizeSpoofedForRFP();
    void UpdateForcedColors(bool aNotify = true);
 +  void UpdateColorInversion(bool aNotify = true);
  
   public:
++  // gjoa hybrid dark mode: pre-paint, flip a themeless document to inverted
++  // (dark) after its first un-inverted cascade exposes the authored background.
++  // Native-dark pages are left untouched. Called from PresShell::Initialize.
++  void ApplyHybridDefaultInvertIfThemeless();
++
    float GetFullZoom() { return mFullZoom; }
-@@ -1440,6 +1445,8 @@ class nsPresContext : public nsISupports,
+   /**
+    * Device full zoom differs from full zoom because it gets the zoom from
+@@ -1440,6 +1450,12 @@ class nsPresContext : public nsISupports,
    FontVisibility mFontVisibility = FontVisibility::Unknown;
    mozilla::dom::PrefersColorSchemeOverride mOverriddenOrEmbedderColorScheme;
    mozilla::StyleForcedColors mForcedColors;
 +  // gjoa engine-level dark mode flag (content-only). See UpdateColorInversion.
 +  bool mColorInversion = false;
++  // gjoa hybrid: a themeless document classified pre-paint by
++  // ApplyHybridDefaultInvertIfThemeless. Durable per-document input to
++  // UpdateColorInversion so the flip survives later re-derives.
++  bool mHybridDefaultInvert = false;
  
   protected:
    virtual ~nsPresContext();

--- a/src/gjoa/chrome/bjs/dark-mode/index.bjs
+++ b/src/gjoa/chrome/bjs/dark-mode/index.bjs
@@ -25,6 +25,10 @@
 (def PREF-FORCE-NATIVE :- String "gjoa.darkmode.user.force-native")
 (def PREF-FORCE-INVERT :- String "gjoa.darkmode.user.force-invert")
 (def PREF-SITE-OFF :- String "gjoa.darkmode.user.off")
+;; Engine pre-paint default-invert (hybrid mode only); read by nsPresContext so a
+;; themeless page renders dark from frame 1 (no flash), retracted pre-paint for
+;; sites that authored their own dark theme.
+(def PREF-DEFAULT-INVERT :- String "gjoa.darkmode.hybrid.default-invert")
 
 (def FILTER-CSS-ID :- String "gjoa-darkmode-filter-style")
 (def FILTER-CSS :- String
@@ -42,6 +46,10 @@
 ;; Toggle the engine-level luminance-inversion flag (read by nsPresContext).
 (defn set-invert! [on :- Boolean] :- Any
   (set-pref-bool! PREF-INVERT on))
+
+;; Toggle the engine pre-paint default-invert flag (hybrid mode only).
+(defn set-default-invert! [on :- Boolean] :- Any
+  (set-pref-bool! PREF-DEFAULT-INVERT on))
 
 (defn apply-filter! [] :- Any
   (when (not (.-filter-el state))
@@ -72,18 +80,23 @@
         m (mode-)]
     (cond
       (or (not en) (= m "off"))
-        (do (set-chrome-scheme! false) (set-content-override! 2) (set-invert! false) (remove-filter!))
+        (do (set-chrome-scheme! false) (set-content-override! 2) (set-invert! false) (set-default-invert! false) (remove-filter!))
       ;; "engine": force LIGHT so sites render their light theme, then the engine
       ;; inverts every absolute color to dark at style-resolution time — cached,
       ;; raster-safe, no per-frame compositor filter.
       (= m "engine")
-        (do (set-chrome-scheme! true) (set-content-override! 1) (set-invert! true) (remove-filter!))
+        (do (set-chrome-scheme! true) (set-content-override! 1) (set-invert! true) (set-default-invert! false) (remove-filter!))
       ;; "filter": legacy compositor invert (Lane-1 fallback, superseded by engine).
       (= m "filter")
-        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (apply-filter!))
-      ;; "auto": native dark via prefers-color-scheme: dark.
+        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (set-default-invert! false) (apply-filter!))
+      ;; "hybrid": force prefers-color-scheme: dark so native-dark sites activate;
+      ;; the engine pre-paint default-inverts themeless pages (no flash) and the
+      ;; GjoaDarkmode actor refines per-site (curated fixes + auto retraction).
+      (= m "hybrid")
+        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (set-default-invert! true) (remove-filter!))
+      ;; "auto": native dark via prefers-color-scheme: dark only.
       :else
-        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (remove-filter!)))))
+        (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (set-default-invert! false) (remove-filter!)))))
 
 ;; Public toggle API (for a future toolbar button), exposed on window.
 (defn toggle [] :- Boolean

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -3,59 +3,72 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // Content half of the gjoa per-site dark-mode HYBRID actor (top documents only).
-// In "hybrid" mode the chrome module forces prefers-color-scheme:dark, so sites
-// with a native dark theme render it. This actor, one cascade behind (after
-// first paint), reads the EFFECTIVE page background; if the site stayed light
-// (no native dark theme) it sets browsingContext.colorInversionOverride =
-// "active", which nsPresContext reads to luminance-invert just this document.
-// Native-dark sites get "inactive" — kept native, never double-darkened.
+//
+// In hybrid mode the engine (gjoa.darkmode.hybrid.default-invert) classifies the
+// document pre-paint: a themeless page is flipped to inverted (dark) before first
+// paint, a page that authored its own dark theme is left native — so there is no
+// flash-of-light. This actor does two things on top of that:
+//
+//   document-start (DOMWindowCreated): ask the parent for an EXPLICIT curated
+//     decision (fix registry / user per-site pref) and apply its override + css
+//     + inject immediately, so curated sites (e.g. YouTube html[dark]) are
+//     correct from frame 1.
+//   post-paint (DOMContentLoaded): for sites with no explicit decision, a
+//     best-effort refiner — it samples the body/root background (probing the live
+//     inversion state to read it the right way round) and retracts the engine's
+//     invert for a site that turned out dark via LATE JS/CSS theming, which the
+//     engine's pre-paint root check ran too early to see.
 
 export class GjoaDarkmodeChild extends JSWindowActorChild {
   constructor() {
     super();
     this._sheetUri = null;
-    this._injected = false;
+    this._explicitApplied = false;
+    this._explicitPromise = null;
   }
 
   async handleEvent(event) {
+    if (this.browsingContext !== this.browsingContext.top) {
+      return; // subframes inherit the top document's decision (bc->Top())
+    }
     if (event.type === "DOMWindowCreated") {
-      // document-start: before the page reads its theme config, ask the parent
-      // for a per-site inject scriptlet (e.g. YouTube's html[dark]) and run it
-      // in the page main world so the FIRST cascade is native-dark.
-      if (this.browsingContext !== this.browsingContext.top) {
-        return;
-      }
-      // Reset any override INHERITED from the previous same-tab page, so this
-      // fresh document is measured from its AUTHORED colors — not the prior
-      // page's inverted result. Without this, a native-dark site entered from a
-      // themeless (inverted) one keeps "active", renders inverted, and the
-      // post-paint measurement reads the inverted (light) bg and stays inverted
-      // (circular). Tier b decides pre-paint at the engine level and removes the
-      // brief themeless re-measure flash this introduces.
+      // Reset any override INHERITED from the previous same-tab page so this
+      // fresh document starts from the engine's pre-paint default, then apply
+      // the curated/user decision (if any) at document-start. Store the promise
+      // SYNCHRONOUSLY so a DOMContentLoaded that fires before the IPC round-trip
+      // resolves can await it (else the refiner races the curated decision).
       try {
         this.browsingContext.colorInversionOverride = "none";
       } catch (e) {}
-      await this.#maybeInject();
+      this._explicitPromise = this.#applyExplicit();
+      await this._explicitPromise;
       return;
     }
     if (event.type !== "DOMContentLoaded") {
       return;
     }
-    const win = this.contentWindow;
-    if (!win || this.browsingContext !== this.browsingContext.top) {
-      return; // subframes inherit the top document's decision (bc->Top())
+    // Serialize against the document-start curated decision before deciding the
+    // refiner runs at all — otherwise both could write colorInversionOverride.
+    if (this._explicitPromise) {
+      try {
+        await this._explicitPromise;
+      } catch (e) {}
     }
-    // Decide one cascade behind: read the already-resolved background after the
-    // first two frames so the page's own (possibly dark) theme has applied.
+    if (this._explicitApplied) {
+      return; // a curated fix / user pref already decided at document-start
+    }
+    const win = this.contentWindow;
+    if (!win) {
+      return;
+    }
+    // Refine one cascade behind: read the resolved background after two frames
+    // so any late page theming has applied, then ask the parent to decide.
     win.requestAnimationFrame(() =>
-      win.requestAnimationFrame(() => this.#measureAndApply())
+      win.requestAnimationFrame(() => this.#measureAndRefine())
     );
   }
 
-  async #maybeInject() {
-    if (this._injected) {
-      return;
-    }
+  async #applyExplicit() {
     const win = this.contentWindow;
     const doc = this.document;
     if (!win || !doc) {
@@ -71,26 +84,43 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     } catch (e) {
       return;
     }
-    if (!resp || !resp.inject) {
-      return;
+    if (!resp || !resp.explicit) {
+      return; // no curated fix / user pref — engine default-invert + auto decide
     }
-    this._injected = true;
-    // Run in the page's MAIN world at document-start (before the app boots) via a
-    // privileged Cu.Sandbox over the content window — NOT a <script> element,
-    // which the page CSP blocks (YouTube blocks inline scripts). Same channel
-    // discipline as GjoaCosmeticChild.injectScriptlets: sandboxPrototype=win +
-    // wantXrays=false so the scriptlet's writes (html[dark]) land on the page.
+    this._explicitApplied = true;
+    // Apply the curated decision at document-start, before first paint: the
+    // inject scriptlet (page main world), the curated USER_SHEET css, and the
+    // inversion override — together, so the site is correct from frame 1.
+    if (resp.inject) {
+      this.#runInject(win, resp.inject);
+    }
+    if (resp.css) {
+      this.#injectSheet(win, resp.css);
+    }
+    if (resp.override && resp.override !== "none") {
+      try {
+        this.browsingContext.colorInversionOverride = resp.override;
+      } catch (e) {}
+    }
+  }
+
+  // Run a per-site scriptlet in the page's MAIN world at document-start via a
+  // privileged Cu.Sandbox over the content window — NOT a <script> element,
+  // which the page CSP blocks (YouTube blocks inline scripts). sandboxPrototype
+  // = win + wantXrays = false so the scriptlet's writes (html[dark]) land on the
+  // page (same channel discipline as GjoaCosmeticChild.injectScriptlets).
+  #runInject(win, code) {
     try {
       const sandbox = Cu.Sandbox(win, {
         sandboxName: "gjoa-darkmode-inject",
         sandboxPrototype: win,
         wantXrays: false,
       });
-      Cu.evalInSandbox(resp.inject, sandbox);
+      Cu.evalInSandbox(code, sandbox);
     } catch (e) {}
   }
 
-  async #measureAndApply() {
+  async #measureAndRefine() {
     const doc = this.document;
     const win = this.contentWindow;
     if (!doc || !win || !doc.documentElement) {
@@ -100,9 +130,6 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     if (!/^https?:/.test(url)) {
       return;
     }
-    // Measure up front (cheap sync getComputedStyle). The parent IGNORES it when
-    // a fix or pref matches (those branches return before reading hasNativeDark),
-    // so "skip measurement when a fix exists" holds with a SINGLE round-trip.
     const hasNativeDark = this.#pageIsDark(win, doc);
     let resp;
     try {
@@ -113,8 +140,6 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     if (!resp) {
       return;
     }
-    // Fix CSS (Tier 1/2): inject as a page-CSS-proof USER_SHEET, same mechanism
-    // as GjoaCosmeticChild.rebuildSheet.
     if (resp.css) {
       this.#injectSheet(win, resp.css);
     }
@@ -152,8 +177,16 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     }
   }
 
-  // Effective page background: body, then documentElement; first OPAQUE color
-  // wins. All transparent ⇒ the UA canvas (white) shows through ⇒ not dark.
+  // Coarse "is this page's AUTHORED background dark?" check for the refiner. The
+  // effective bg is body, then documentElement; first OPAQUE color wins (all
+  // transparent ⇒ the UA canvas shows ⇒ not dark). When the engine is currently
+  // inverting this document, the measured bg is the inverted authored color, so we
+  // flip the luminance (the inversion is a luminance map ~Y -> 1 - Y) to read it
+  // the right way round — without this, an inverted themeless page would read dark
+  // and be misclassified native-dark. This is a THRESHOLD test, not an exact
+  // recovery (channel clamping makes the flip approximate near the boundary); the
+  // engine's pre-paint check is the precise classifier, this only catches the
+  // late-theme tail.
   #pageIsDark(win, doc) {
     const read = el => {
       try {
@@ -171,9 +204,13 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
       // Skip only FULLY-transparent backgrounds. Gecko serializes opaque colors
       // as 3-arg `rgb(r, g, b)` and transparent as 4-arg `rgba(r, g, b, 0)`, so
       // the alpha test must require a real 4th channel — anchoring on the last
-      // comma alone would match the blue channel of `rgb(0, 0, 0)` (opaque
-      // black, the most common dark bg) and wrongly treat it as transparent.
-      if (c && c !== "transparent" && !/^rgba?\([^,)]*,[^,)]*,[^,)]*,\s*0(?:\.0+)?\s*\)$/.test(c)) {
+      // comma alone would match the blue channel of `rgb(0, 0, 0)` (opaque black,
+      // the most common dark bg) and wrongly treat it as transparent.
+      if (
+        c &&
+        c !== "transparent" &&
+        !/^rgba?\([^,)]*,[^,)]*,[^,)]*,\s*0(?:\.0+)?\s*\)$/.test(c)
+      ) {
         bg = c;
         break;
       }
@@ -181,7 +218,36 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     if (!bg) {
       return false;
     }
-    return this.#luminance(bg) < 0.22;
+    let lum = this.#luminance(bg);
+    if (this.#inversionActive(win, doc)) {
+      lum = 1 - lum;
+    }
+    return lum < 0.22;
+  }
+
+  // Detect whether the engine is luminance-inverting this document by probing
+  // known swatches: under inversion white computes to black AND black to white.
+  // Requiring BOTH flips avoids a false positive from a stray user-!important /
+  // leftover USER_SHEET background spoofing a single swatch.
+  #inversionActive(win, doc) {
+    const read = bg => {
+      try {
+        const probe = doc.createElement("div");
+        probe.style.cssText =
+          "position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;" +
+          "background-color:" + bg;
+        (doc.body || doc.documentElement).appendChild(probe);
+        const c = win.getComputedStyle(probe).backgroundColor;
+        probe.remove();
+        return c;
+      } catch (e) {
+        return "";
+      }
+    };
+    return (
+      read("rgb(255,255,255)") === "rgb(0, 0, 0)" &&
+      read("rgb(0,0,0)") === "rgb(255, 255, 255)"
+    );
   }
 
   #luminance(rgbStr) {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -4,14 +4,27 @@
 
 // Parent half of the gjoa per-site dark-mode HYBRID actor. Decides the
 // per-document colorInversionOverride from trusted parent-process state: the
-// dark-mode mode, the per-site override prefs, and the child's measurement of
-// whether the page rendered dark on its own.
+// dark-mode mode, the per-site override prefs, and (for the auto refiner) the
+// child's measurement of whether the page authored itself dark.
+//
+// Two decision surfaces:
+//   #explicit() — the curated fix registry + user per-site prefs. Returned at
+//     document-start (Darkmode:GetInject) so curated sites apply their override
+//     + css + inject BEFORE first paint (no flash).
+//   #auto()     — the post-paint refiner (Darkmode:Decide). Only runs for sites
+//     with no explicit decision. With the engine's pre-paint default-invert
+//     (gjoa.darkmode.hybrid.default-invert) on, it defers to the engine for
+//     themeless pages and only retracts ("inactive") sites whose AUTHORED
+//     background is dark but the engine's root-only pre-paint check missed.
 
 const ENABLED_PREF = "gjoa.darkmode.enabled";
 const MODE_PREF = "gjoa.darkmode.mode";
 const FORCE_NATIVE_PREF = "gjoa.darkmode.user.force-native";
 const FORCE_INVERT_PREF = "gjoa.darkmode.user.force-invert";
 const OFF_PREF = "gjoa.darkmode.user.off";
+// Engine default-invert (read by nsPresContext::UpdateColorInversion); when on,
+// the engine darkens themeless pages pre-paint and the actor only refines.
+const DEFAULT_INVERT_PREF = "gjoa.darkmode.hybrid.default-invert";
 
 // Curated per-site dark-mode fix registry (Dark-Reader-derived, MIT). Packaged
 // to resource://gre/modules/darkmode-fixes.json (FINAL_TARGET_FILES.modules).
@@ -90,73 +103,91 @@ export class GjoaDarkmodeParent extends JSWindowActorParent {
     }
   }
 
-  // Returns { override, css, inject } for this document.
-  //   override: BrowsingContext.colorInversionOverride to set
-  //     ("active" invert / "inactive" never / "none" defer to the global pref).
-  //   css: optional USER_SHEET body the fix owns (Tier-1 curated colors).
-  //   inject: optional document-start scriptlet (e.g. YouTube html[dark]).
-  // Precedence: fix registry > user.* prefs > auto measurement.
-  async #decide(hasNativeDark) {
-    // Per-document overrides are a HYBRID-mode concern. In every other mode the
-    // global pref drives inversion uniformly, so defer ("none").
-    if (
-      !Services.prefs.getBoolPref(ENABLED_PREF, false) ||
-      Services.prefs.getStringPref(MODE_PREF, "auto") !== "hybrid"
-    ) {
-      return { override: "none", css: "", inject: "" };
+  #hybridActive() {
+    return (
+      Services.prefs.getBoolPref(ENABLED_PREF, false) &&
+      Services.prefs.getStringPref(MODE_PREF, "auto") === "hybrid"
+    );
+  }
+
+  // The explicit (non-measured) decision: curated fix registry, then user
+  // per-site prefs. Returns { override, css, inject } or null when nothing
+  // explicit applies (the engine default-invert + auto refiner then decide).
+  async #explicit() {
+    if (!this.#hybridActive()) {
+      return null;
     }
     const host = hostOf(this.trustedUrl());
-    if (host) {
-      // (1) Fix registry — highest precedence; owns override + css + inject.
-      const fix = fixForHost(await loadFixes(), host);
-      if (fix) {
-        let css = fix.css || "";
-        if (fix.invertSelectors && fix.invertSelectors.length) {
-          css +=
-            "\n" +
-            fix.invertSelectors.join(",") +
-            "{filter:invert(1) hue-rotate(180deg)!important}\n";
-        }
-        return {
-          override: fix.override || "inactive",
-          css,
-          inject: fix.inject || "",
-        };
-      }
-      // (2) User per-site prefs (unchanged order/behavior).
-      if (hostInPref(host, OFF_PREF)) {
-        return { override: "inactive", css: "", inject: "" };
-      }
-      if (hostInPref(host, FORCE_INVERT_PREF)) {
-        return { override: "active", css: "", inject: "" };
-      }
-      if (hostInPref(host, FORCE_NATIVE_PREF)) {
-        return { override: "inactive", css: "", inject: "" };
-      }
+    if (!host) {
+      return null;
     }
-    // (3) Auto: invert only sites that did NOT render dark on their own.
-    return { override: hasNativeDark ? "inactive" : "active", css: "", inject: "" };
+    // (1) Fix registry — highest precedence; owns override + css + inject.
+    const fix = fixForHost(await loadFixes(), host);
+    if (fix) {
+      let css = fix.css || "";
+      if (fix.invertSelectors && fix.invertSelectors.length) {
+        css +=
+          "\n" +
+          fix.invertSelectors.join(",") +
+          "{filter:invert(1) hue-rotate(180deg)!important}\n";
+      }
+      return {
+        override: fix.override || "inactive",
+        css,
+        inject: fix.inject || "",
+      };
+    }
+    // (2) User per-site prefs.
+    if (hostInPref(host, OFF_PREF)) {
+      return { override: "inactive", css: "", inject: "" };
+    }
+    if (hostInPref(host, FORCE_INVERT_PREF)) {
+      return { override: "active", css: "", inject: "" };
+    }
+    if (hostInPref(host, FORCE_NATIVE_PREF)) {
+      return { override: "inactive", css: "", inject: "" };
+    }
+    return null;
+  }
+
+  // The auto refiner, post-paint. hasNativeDark is the child's AUTHORED-darkness
+  // measurement (already un-inverted by the child when inversion is active).
+  #auto(hasNativeDark) {
+    if (!this.#hybridActive()) {
+      return { override: "none", css: "", inject: "" };
+    }
+    // With the engine's pre-paint default-invert active, a themeless page is
+    // already dark; defer to the engine ("none") instead of re-asserting. Only a
+    // site whose AUTHORED background is dark (one the engine's pre-paint check
+    // ran too early to see — late CSS/JS theming) needs retracting.
+    if (Services.prefs.getBoolPref(DEFAULT_INVERT_PREF, false)) {
+      return {
+        override: hasNativeDark ? "inactive" : "none",
+        css: "",
+        inject: "",
+      };
+    }
+    // default-invert off: the actor is the sole decider (legacy hybrid path).
+    return {
+      override: hasNativeDark ? "inactive" : "active",
+      css: "",
+      inject: "",
+    };
   }
 
   async receiveMessage(msg) {
     if (msg.name === "Darkmode:GetInject") {
-      // document-start fast-path: the child asks ONLY for the inject scriptlet,
-      // before the page reads its theme config, so the first cascade is correct.
-      const host = hostOf(this.trustedUrl());
-      if (
-        host &&
-        Services.prefs.getBoolPref(ENABLED_PREF, false) &&
-        Services.prefs.getStringPref(MODE_PREF, "auto") === "hybrid"
-      ) {
-        const fix = fixForHost(await loadFixes(), host);
-        if (fix && fix.inject) {
-          return { inject: fix.inject };
-        }
+      // document-start: return the explicit curated/user decision so the child
+      // applies override + css + inject BEFORE first paint. `explicit:false`
+      // tells the child to fall through to the post-paint auto refiner.
+      const explicit = await this.#explicit();
+      if (explicit) {
+        return { explicit: true, ...explicit };
       }
-      return { inject: "" };
+      return { explicit: false, override: "none", css: "", inject: "" };
     }
     if (msg.name === "Darkmode:Decide") {
-      return await this.#decide(!!msg.data?.hasNativeDark);
+      return this.#auto(!!msg.data?.hasNativeDark);
     }
     return null;
   }

--- a/src/gjoa/toolkit/components/content-classifier/darkmode-fixes.json
+++ b/src/gjoa/toolkit/components/content-classifier/darkmode-fixes.json
@@ -2,6 +2,7 @@
   "youtube.com": {
     "mode": "native",
     "override": "inactive",
+    "css": "html,body{background-color:#0f0f0f!important}",
     "inject": "(function(){\"use strict\";var d=document,D=d.documentElement;function m(){try{if(D&&!D.hasAttribute(\"dark\"))D.setAttribute(\"dark\",\"\");}catch(e){}}m();try{new MutationObserver(m).observe(D,{attributes:true,attributeFilter:[\"dark\"]});}catch(e){}})();"
   },
   "news.ycombinator.com": {

--- a/tests/integration/darkmode-hybrid.bjs
+++ b/tests/integration/darkmode-hybrid.bjs
@@ -18,7 +18,8 @@
 (define-mode strict)
 (declare-extern [JSON] Any)
 
-(def TOP :- String "http://127.0.0.1:8975/") ;; themeless light fixture
+(def TOP :- String "http://127.0.0.1:8975/") ;; no-bg page (UA-dark under hybrid)
+(def LIGHT-TOP :- String "http://127.0.0.1:8975/light") ;; hardcoded-light themeless site
 
 (def NAV-JS :- String
   (str "\n"
@@ -47,11 +48,34 @@
        " d.style.backgroundColor='rgb(255,255,255)'; d.style.color='rgb(0,0,0)';"
        " document.body.appendChild(d); return 'injected';"))
 
+;; Tier b: hybrid + the engine pre-paint default-invert. A themeless top doc is
+;; inverted by the ENGINE at construction (no actor round-trip); a native-dark
+;; page is retracted pre-paint (PresShell::Initialize) and keeps its theme.
+(def HYBRID-B-JS :- String
+  (str "Services.prefs.setBoolPref('gjoa.darkmode.enabled', true);"
+       " Services.prefs.setStringPref('gjoa.darkmode.mode', 'hybrid');"
+       " Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false);"
+       " Services.prefs.setBoolPref('gjoa.darkmode.hybrid.default-invert', true);"
+       " return 'hybrid-b';"))
+
+(def DARK-TOP :- String "http://127.0.0.1:8975/dark") ;; authored-dark (#111) fixture
+
+;; Inject a plain white box (no explicit text color) to probe inversion state.
+(def INJECT-WHITE :- String
+  (str "const d=document.createElement('div'); d.id='dm-w';"
+       " d.style.backgroundColor='rgb(255,255,255)';"
+       " document.body.appendChild(d); return 'injected';"))
+
+;; Chrome-side settle so the post-paint actor refiner has a chance to (wrongly)
+;; re-invert before we assert it did not. Marionette has no content setTimeout.
+(def SETTLE-JS :- String
+  "const r=arguments[arguments.length-1]; setTimeout(()=>r(1), 700);")
+
 (js/export (def tests :- Any
   [(deftest "darkmode hybrid: actor inverts a themeless (light) page per-document" [mn ctx]
      (js/await (.setContext mn "chrome"))
      (chrome-eval HYBRID-JS)
-     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [TOP]))]
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [LIGHT-TOP]))]
        (expect navOk "light fixture loaded")
        ;; The actor measures light -> decides 'active'; poll until the engine has
        ;; inverted an explicit white box in that document (covers the full chain:
@@ -61,6 +85,42 @@
        (js/await (await-true
                    (str "const d=document.getElementById('dm-hy'); const cs=d&&getComputedStyle(d);"
                         " return !!(cs && cs.backgroundColor==='rgb(0, 0, 0)' && cs.color==='rgb(255, 255, 255)');")
-                   6000))))]))
+                   6000))))
+   ;; Tier b: the ENGINE default-invert darkens a themeless page at cascade time,
+   ;; without any actor round-trip. Inject a white box and assert it computes
+   ;; black — proving (A) sets mColorInversion at construction.
+   (deftest "darkmode tier-b: engine default-invert darkens a themeless page" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval HYBRID-B-JS)
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [LIGHT-TOP]))]
+       (expect navOk "light fixture loaded")
+       (js/await (.setContext mn "content"))
+       (chrome-eval INJECT-WHITE)
+       (js/await (await-true
+                   (str "const d=document.getElementById('dm-w'); const cs=d&&getComputedStyle(d);"
+                        " return !!(cs && cs.backgroundColor==='rgb(0, 0, 0)');")
+                   4000))))
+   ;; Tier b: a native-dark page (authored #111) is RETRACTED pre-paint by
+   ;; PresShell::Initialize -> MaybeRetractColorInversionForNativeDark, so it keeps
+   ;; its theme. After a settle (refiner could otherwise re-invert), the root stays
+   ;; dark AND an injected white box stays white (inversion is off for this doc).
+   (deftest "darkmode tier-b: native-dark page keeps its theme (no invert)" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval HYBRID-B-JS)
+     (let [navOk (js/await (.executeAsyncScript mn NAV-JS [DARK-TOP]))]
+       (expect navOk "dark fixture loaded")
+       (js/await (.executeAsyncScript mn SETTLE-JS []))
+       (js/await (.setContext mn "content"))
+       ;; root background did NOT invert: #111 (sum 51) stays dark, not ~light.
+       (js/await (await-true
+                   (str "const m=getComputedStyle(document.documentElement).backgroundColor.match(/[0-9]+/g);"
+                        " return !!(m && (+m[0] + +m[1] + +m[2]) < 180);")
+                   4000))
+       (chrome-eval INJECT-WHITE)
+       ;; a freshly-injected white box stays white -> mColorInversion was retracted.
+       (js/await (await-true
+                   (str "const d=document.getElementById('dm-w'); const cs=d&&getComputedStyle(d);"
+                        " return !!(cs && cs.backgroundColor==='rgb(255, 255, 255)');")
+                   4000))))]))
 
 (js/export-default tests)

--- a/tools/test-driver/cosmetic-fixture-server.mjs
+++ b/tools/test-driver/cosmetic-fixture-server.mjs
@@ -12,21 +12,30 @@ const HTML = `<!doctype html>
   <div class="gjoa-keep" id="keep">KEEP ME</div>
 </body></html>`;
 
-// A themeless LIGHT page (default white) is served at "/"; a NATIVE-DARK page
-// (authored dark root/body) at "/dark", so the dark-mode hybrid actor's two
-// decisions can be exercised deterministically: light -> invert, dark -> keep.
+// Dark-mode hybrid fixtures. "/light" is a real THEMELESS-LIGHT site: it hardcodes
+// a white background and ignores prefers-color-scheme, so hybrid mode must invert
+// it. "/dark" is a NATIVE-DARK site (authored dark root/body) that hybrid must
+// keep. (The plain "/" page authors no background at all, so under hybrid's forced
+// prefers-color-scheme:dark it renders with the UA dark canvas — already dark, not
+// a themeless-light case — so it is NOT used for the invert assertion.)
+const HTML_LIGHT = `<!doctype html>
+<html style="background:#fff"><head><meta charset="utf-8"><title>gjoa light fixture</title>
+<style>html,body{background:#fff;color:#111}</style></head>
+<body><div id="content">THEMELESS LIGHT</div></body></html>`;
 const HTML_DARK = `<!doctype html>
 <html style="background:#111"><head><meta charset="utf-8"><title>gjoa dark fixture</title>
 <style>html,body{background:#111;color:#eee}</style></head>
 <body><div id="content">NATIVE DARK</div></body></html>`;
 
 const server = createServer((req, res) => {
-  const dark = req.url && req.url.startsWith("/dark");
+  const url = req.url || "";
   res.writeHead(200, {
     "Content-Type": "text/html; charset=utf-8",
     "Cache-Control": "no-store",
   });
-  res.end(dark ? HTML_DARK : HTML);
+  res.end(
+    url.startsWith("/dark") ? HTML_DARK : url.startsWith("/light") ? HTML_LIGHT : HTML
+  );
 });
 
 server.listen(PORT, "127.0.0.1", () => {


### PR DESCRIPTION
## Dark-mode-v2 Tier b — eliminate the flash-of-light in hybrid mode (#45)

Decides dark-vs-native **before the first paint**, at the engine, so a themeless page loads straight into dark and a native-dark page keeps its own theme — no white flash either way.

### The core move (polarity flip)
The original plan (default everything to inverted, then *retract* native-dark pages by un-inverting their measured background) was scrapped pre-build: the luminance inversion `Y→1−Y` is **not** losslessly reversible once color channels clamp (saturated darks like navy/maroon), so recovering authored luminance from an inverted read misclassifies them.

Shipped instead: a hybrid document **starts un-inverted**, so its first cascade computes the page's **authored** colors. `PresShell::Initialize` reads the authored root background *directly* (accurate) and flips themeless pages to inverted pre-paint; native-dark pages are left alone.

### Changes
- **Engine** (`patches/0009`): `nsPresContext::ApplyHybridDefaultInvertIfThemeless()` + durable `mHybridDefaultInvert`; `DefaultBackgroundColor()` inverts the canvas backstop (no white inter-page flash). One `PresShell::Initialize` call site.
- **Actors**: engine is the primary classifier; the `GjoaDarkmode` actor applies curated/user overrides at document-start (no flash on YouTube/HN) and post-paint best-effort refines late-theming sites.
- **Chrome**: `index.bjs` hybrid arm sets `gjoa.darkmode.hybrid.default-invert`.
- **Tests/docs**: `darkmode-hybrid.bjs` (engine default-invert + native-dark retraction); a `/light` fixture (real themeless-light site); as-built design doc.

### Verification
- 4-dimension adversarial pre-build review caught **5 blockers** (missing `PresShell.cpp` hunk in patch 0009, stale chrome bundle, the lossy math, a same-tab override clobber, an explicit-vs-refiner race) — all fixed; second review **BUILD-READY**; preflight 9/9.
- Mach build green first try (~30 min); **darkmode suite 7/7 in isolation**; no regressions (the full-suite fails are pre-existing youtube/adblock + a discarded-BC cascade).

### Follow-ups (tracked)
- #48 system-theme default + escape-hatch modes · #47 new-tab as home page · #49 seed curated override pre-layout (YouTube transient) · #50 pre-existing adblock test.

Native nix rebuild deferred (per request) to batch with #49 tonight.