### PR TITLE
feat(darkmode): system-theme default + escape-hatch modes

### DIFF
--- a/src/gjoa/chrome/bjs/dark-mode/index.bjs
+++ b/src/gjoa/chrome/bjs/dark-mode/index.bjs
@@ -72,8 +72,14 @@
       (do (.removeProperty (.-style root) "color-scheme")
           (rmattr! root "gjoa-darkmode")))))
 
-(defn enabled? [] :- Boolean (pref-bool PREF-ENABLED false))
-(defn mode- [] :- String (pref-str PREF-MODE "auto"))
+(defn enabled? [] :- Boolean (pref-bool PREF-ENABLED true))
+(defn mode- [] :- String (pref-str PREF-MODE "system"))
+
+;; The chrome window's prefers-color-scheme reflects the OS / browser theme
+;; (independent of the content-override pref, which is content-only), so this is
+;; a reliable read of "is the system in dark mode right now".
+(defn system-dark? [] :- Boolean
+  (.-matches (.matchMedia window "(prefers-color-scheme: dark)")))
 
 (defn apply! [] :- Any
   (let [en (enabled?)
@@ -81,6 +87,13 @@
     (cond
       (or (not en) (= m "off"))
         (do (set-chrome-scheme! false) (set-content-override! 2) (set-invert! false) (set-default-invert! false) (remove-filter!))
+      ;; "system" (default): follow the OS theme. Dark OS -> the no-flash hybrid
+      ;; engine; light OS -> leave sites in their own (light) themes. The discrete
+      ;; modes below are manual escape hatches. Re-applied live on OS theme change.
+      (= m "system")
+        (if (system-dark?)
+          (do (set-chrome-scheme! true) (set-content-override! 0) (set-invert! false) (set-default-invert! true) (remove-filter!))
+          (do (set-chrome-scheme! false) (set-content-override! 2) (set-invert! false) (set-default-invert! false) (remove-filter!)))
       ;; "engine": force LIGHT so sites render their light theme, then the engine
       ;; inverts every absolute color to dark at style-resolution time — cached,
       ;; raster-safe, no per-frame compositor filter.
@@ -104,14 +117,28 @@
     (set-pref-bool! PREF-ENABLED new-state)
     new-state))
 
+;; Cycle the three user-facing states: follow the system theme (default), force
+;; dark everywhere (hybrid), force off (sites as-is). The legacy engine/filter
+;; modes stay reachable via about:config but are not in the quick cycle.
 (defn cycle-mode [] :- String
   (let [cur (mode-)
-        nxt (cond (= cur "hybrid") "auto"
-                  (= cur "auto") "engine"
-                  (= cur "engine") "off"
-                  :else "hybrid")]
+        nxt (cond (= cur "system") "hybrid"
+                  (= cur "hybrid") "off"
+                  (= cur "off") "system"
+                  :else "system")]
     (set-pref-str! PREF-MODE nxt)
     nxt))
+
+;; Make on-by-default + system-driven the real defaults (default branch), so the
+;; GjoaDarkmode actor and the engine — which read these prefs directly — agree
+;; with the chrome. A user pref still overrides.
+(defn set-darkmode-defaults! [] :- Any
+  (try
+    (let [d (.getDefaultBranch (.-prefs Services) "")]
+      (.setBoolPref d PREF-ENABLED true)
+      (.setCharPref d PREF-MODE "system"))
+    (catch Any e
+      (.error console "gjoa-darkmode: set-darkmode-defaults! failed" e))))
 
 (defn destroy! [] :- Any
   (let [u (.-unsub state)]
@@ -121,14 +148,20 @@
   (remove-filter!))
 
 (defn init-! [] :- Any
+  (set-darkmode-defaults!)
   (apply!)
-  (let [observer {:observe (fn [_s _t _d] (apply!))}]
+  (let [observer {:observe (fn [_s _t _d] (apply!))}
+        mql (.matchMedia window "(prefers-color-scheme: dark)")
+        on-sys (fn [_e] (apply!))]
     (.addObserver (.-prefs Services) PREF-ENABLED observer)
     (.addObserver (.-prefs Services) PREF-MODE observer)
+    ;; live-follow the OS theme while in "system" mode
+    (.addEventListener mql "change" on-sys)
     (set! (.-unsub state)
       (fn []
         (.removeObserver (.-prefs Services) PREF-ENABLED observer)
-        (.removeObserver (.-prefs Services) PREF-MODE observer))))
+        (.removeObserver (.-prefs Services) PREF-MODE observer)
+        (.removeEventListener mql "change" on-sys))))
   (set! (.-gjoaDarkMode window)
     {:toggle toggle :cycleMode cycle-mode :isEnabled enabled? :getMode mode-})
   (on1! window "unload" destroy!)

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -104,9 +104,16 @@ export class GjoaDarkmodeParent extends JSWindowActorParent {
   }
 
   #hybridActive() {
+    // Active for the explicit "hybrid" mode AND whenever the engine's pre-paint
+    // default-invert is on (e.g. "system" mode while the OS is dark) — that pref
+    // is the single signal that hybrid behavior is live, so the actor's curated
+    // fixes + refiner track it without knowing the mode string.
+    if (!Services.prefs.getBoolPref(ENABLED_PREF, false)) {
+      return false;
+    }
     return (
-      Services.prefs.getBoolPref(ENABLED_PREF, false) &&
-      Services.prefs.getStringPref(MODE_PREF, "auto") === "hybrid"
+      Services.prefs.getStringPref(MODE_PREF, "auto") === "hybrid" ||
+      Services.prefs.getBoolPref(DEFAULT_INVERT_PREF, false)
     );
   }
 

--- a/tests/integration/darkmode-hybrid.bjs
+++ b/tests/integration/darkmode-hybrid.bjs
@@ -100,10 +100,11 @@
                    (str "const d=document.getElementById('dm-w'); const cs=d&&getComputedStyle(d);"
                         " return !!(cs && cs.backgroundColor==='rgb(0, 0, 0)');")
                    4000))))
-   ;; Tier b: a native-dark page (authored #111) is RETRACTED pre-paint by
-   ;; PresShell::Initialize -> MaybeRetractColorInversionForNativeDark, so it keeps
-   ;; its theme. After a settle (refiner could otherwise re-invert), the root stays
-   ;; dark AND an injected white box stays white (inversion is off for this doc).
+   ;; Tier b: a native-dark page (authored #111) is left un-inverted pre-paint by
+   ;; PresShell::Initialize -> ApplyHybridDefaultInvertIfThemeless (it only flips
+   ;; themeless pages), so it keeps its theme. After a settle (refiner could
+   ;; otherwise re-invert), the root stays dark AND an injected white box stays
+   ;; white (inversion is off for this doc).
    (deftest "darkmode tier-b: native-dark page keeps its theme (no invert)" [mn ctx]
      (js/await (.setContext mn "chrome"))
      (chrome-eval HYBRID-B-JS)
@@ -121,6 +122,24 @@
        (js/await (await-true
                    (str "const d=document.getElementById('dm-w'); const cs=d&&getComputedStyle(d);"
                         " return !!(cs && cs.backgroundColor==='rgb(255, 255, 255)');")
-                   4000))))]))
+                   4000))))
+   ;; #48: in "system" mode the engine's pre-paint default-invert tracks the OS
+   ;; theme live. Spoof the OS via ui.systemUsesDarkTheme; the chrome matchMedia
+   ;; change drives apply!, which sets/clears gjoa.darkmode.hybrid.default-invert.
+   (deftest "darkmode system-mode: default-invert follows the OS theme" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval (str "Services.prefs.setBoolPref('gjoa.darkmode.enabled', true);"
+                       " Services.prefs.setStringPref('gjoa.darkmode.mode', 'system');"
+                       " return 'system';"))
+     ;; OS dark -> the no-flash hybrid engine engages
+     (chrome-eval "Services.prefs.setIntPref('ui.systemUsesDarkTheme', 1); return 'os-dark';")
+     (js/await (await-true
+                 "return Services.prefs.getBoolPref('gjoa.darkmode.hybrid.default-invert', false) === true;"
+                 4000))
+     ;; OS light -> sites left in their own themes
+     (chrome-eval "Services.prefs.setIntPref('ui.systemUsesDarkTheme', 0); return 'os-light';")
+     (js/await (await-true
+                 "return Services.prefs.getBoolPref('gjoa.darkmode.hybrid.default-invert', false) === false;"
+                 4000)))]))
 
 (js/export-default tests)


### PR DESCRIPTION
## Dark mode follows the OS theme by default (#48)

Demotes the discrete modes to manual escape hatches and makes the default behavior **follow the system theme** — the model you'd expect from a browser dark mode.

- **`system` mode (new default):** OS dark → the no-flash hybrid engine (Tier b); OS light → sites keep their own (light) themes. Live-follows the OS via a `prefers-color-scheme` matchMedia listener, so flipping the OS theme retypes pages without a restart.
- **On-by-default:** `enabled=true` + `mode=system` are set on the **default branch**, so the engine and the `GjoaDarkmode` actor (which read these prefs directly) agree with the chrome. A user pref still overrides.
- **Actor activation:** the actor is now active whenever the engine's `default-invert` pref is on (covers system+dark), not only the literal `hybrid` mode string — so curated fixes (YouTube/HN) + the refiner track the engine.
- **Escape hatches:** `cycle-mode` is `system → hybrid (force dark) → off (force light) → system`; the legacy `engine`/`filter` modes remain reachable via about:config.

### Verification
darkmode suite **8/8** (incl. new `system-mode: default-invert follows the OS theme`, which spoofs the OS via `ui.systemUsesDarkTheme` and asserts the engine pref tracks it live). Chrome-only (Lane 1) + an actor tweak (live via the dev symlink) — no engine rebuild.

Sits on top of #45 (Tier b). Native nix rebuild deferred to tonight's batch.