### PR TITLE
feat(newtab): gjoa new-tab page is the home/startup page

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -164,7 +164,13 @@
       (.setCharPref d "browser.toolbars.bookmarks.visibility" "never")
       (.setBoolPref d "sidebar.verticalTabs" true)
       (.setBoolPref d "gjoa.sidebar.menuBar" false)
-      (.setBoolPref d "gjoa.toolbar.newTabButton" false))
+      (.setBoolPref d "gjoa.toolbar.newTabButton" false)
+      ;; Use the gjoa new-tab page as the home/startup page too: "about:newtab"
+      ;; resolves to BROWSER_NEW_TAB_URL (set to chrome://gjoa-newtab via
+      ;; AboutNewTab.newTabURL above), so the home button, new windows, and a
+      ;; home-based startup all land on the same custom page as new tabs — instead
+      ;; of Firefox's default about:home on first load.
+      (.setCharPref d "browser.startup.homepage" "about:newtab"))
     (catch Any e
       (.error console "gjoa-loader: setDefaults failed" e))))
 
@@ -205,7 +211,7 @@
     (catch Any e
       (.error console "gjoa-loader: registerDarkmodeActor failed" e))))
 
-(defn set-new-tab-url [] :- Any
+(defn set-new-tab-url! [] :- Any
   (try
     (set! (.-newTabURL (.-AboutNewTab lazy)) NEW-TAB-URL)
     (.log console (str "gjoa-loader: new tab URL set to " NEW-TAB-URL))
@@ -217,7 +223,7 @@
     (when (not (.-observer-registered st))
       (set! (.-observer-registered st) true)
       (set-defaults)
-      (set-new-tab-url)
+      (set-new-tab-url!)
       (register-cosmetic-actor)
       (register-darkmode-actor)
       (.addObserver (.-obs Services) observer "chrome-document-loaded")

--- a/tests/integration/newtab-home.bjs
+++ b/tests/integration/newtab-home.bjs
@@ -1,0 +1,29 @@
+#lang beagle/js
+;; #47: the gjoa custom new-tab page is also the home / startup page, so the
+;; first tab on launch and the home button land on the same page as new tabs
+;; (not Firefox's default about:home). GjoaLoader sets the home page default to
+;; "about:newtab", which resolves to BROWSER_NEW_TAB_URL — itself pointed at
+;; chrome://gjoa-newtab via AboutNewTab.newTabURL. We assert both ends of that
+;; chain from chrome (deterministic; no navigation/render timing).
+(ns gjoa.tests.integration.newtab-home
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval expect-eq]]))
+(define-mode strict)
+
+(def NEWTAB-URL :- String "chrome://gjoa-newtab/content/newtab.html")
+
+(js/export (def tests :- Any
+  [(deftest "newtab: the gjoa new-tab page is the home page too" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     ;; GjoaLoader.set-defaults pointed the home page at about:newtab ...
+     (let [home (chrome-eval
+                  "return Services.prefs.getDefaultBranch('').getCharPref('browser.startup.homepage', '');")]
+       (expect-eq home "about:newtab"
+                  "browser.startup.homepage default should be about:newtab"))
+     ;; ... and about:newtab resolves to the gjoa custom new-tab page.
+     (let [ntu (chrome-eval
+                 (str "const {AboutNewTab}=ChromeUtils.importESModule('resource:///modules/AboutNewTab.sys.mjs');"
+                      " return AboutNewTab.newTabURL;"))]
+       (expect-eq ntu NEWTAB-URL
+                  "AboutNewTab.newTabURL should be the gjoa new-tab page")))]))
+
+(js/export-default tests)


### PR DESCRIPTION
Fixes #47: the home button + first-tab-on-launch now land on the custom gjoa new-tab page (chrome://gjoa-newtab) instead of Firefox's default about:home. `GjoaLoader` sets `browser.startup.homepage` default to `about:newtab`, which resolves to `BROWSER_NEW_TAB_URL`. Also fixes a pre-existing E019 purity-lint leak (`set-new-tab-url` → `set-new-tab-url!`). Test asserts both ends of the resolution chain; passes on the dev binary.