### PR TITLE
feat(darkmode): apply explicit per-site override pre-paint (#49)

### DIFF
--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -40,6 +40,11 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
       try {
         this.browsingContext.colorInversionOverride = "none";
       } catch (e) {}
+      // Sync, pre-layout: apply the explicit override (curated registry mirror +
+      // user per-site prefs) BEFORE PresShell::Initialize reads it, so an
+      // attribute-gated curated site (YouTube) never transiently flips. The
+      // css/inject still come via the async #applyExplicit.
+      this.#syncExplicitOverride();
       this._explicitPromise = this.#applyExplicit();
       await this._explicitPromise;
       return;
@@ -102,6 +107,79 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
         this.browsingContext.colorInversionOverride = resp.override;
       } catch (e) {}
     }
+  }
+
+  // Synchronous, pre-layout explicit-override decision (no IPC). Mirrors the
+  // parent's #explicit precedence (curated registry > user per-site prefs) but
+  // reads everything from prefs the parent keeps in sync, so the override lands
+  // BEFORE PresShell::Initialize. Gated on the engine's default-invert being on
+  // (otherwise no pre-paint flip exists to pre-empt).
+  #syncExplicitOverride() {
+    try {
+      if (
+        !Services.prefs.getBoolPref("gjoa.darkmode.hybrid.default-invert", false)
+      ) {
+        return;
+      }
+      const url = this.document?.documentURI || "";
+      if (!/^https?:/.test(url)) {
+        return;
+      }
+      let host = "";
+      try {
+        host = Services.io.newURI(url).host.toLowerCase();
+      } catch (e) {}
+      if (!host) {
+        return;
+      }
+      const override = this.#explicitOverrideForHost(host);
+      if (override && override !== "none") {
+        this.browsingContext.colorInversionOverride = override;
+      }
+    } catch (e) {}
+  }
+
+  #explicitOverrideForHost(host) {
+    // (1) curated fix registry mirror (host -> override JSON).
+    try {
+      const raw = Services.prefs.getStringPref("gjoa.darkmode.fix-overrides", "");
+      if (raw) {
+        const map = JSON.parse(raw);
+        let h = host;
+        let v = map[h];
+        let i;
+        while (v === undefined && (i = h.indexOf(".")) !== -1) {
+          h = h.slice(i + 1);
+          v = map[h];
+        }
+        if (v) {
+          return v;
+        }
+      }
+    } catch (e) {}
+    // (2) user per-site prefs (same precedence/behavior as the parent).
+    if (this.#hostInPref(host, "gjoa.darkmode.user.off")) {
+      return "inactive";
+    }
+    if (this.#hostInPref(host, "gjoa.darkmode.user.force-invert")) {
+      return "active";
+    }
+    if (this.#hostInPref(host, "gjoa.darkmode.user.force-native")) {
+      return "inactive";
+    }
+    return null;
+  }
+
+  #hostInPref(host, pref) {
+    let raw = "";
+    try {
+      raw = Services.prefs.getStringPref(pref, "");
+    } catch (e) {}
+    return raw
+      .split(",")
+      .map(h => h.trim().toLowerCase())
+      .filter(Boolean)
+      .some(h => host === h || host.endsWith("." + h));
   }
 
   // Run a per-site scriptlet in the page's MAIN world at document-start via a

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -49,9 +49,27 @@ async function loadFixes() {
     } catch (e) {
       gFixes = {}; // never retry-loop; missing data = no fixes
     }
+    mirrorOverridesPref(gFixes);
     return gFixes;
   })();
   return gFixesLoading;
+}
+
+// Mirror the registry's host -> override into a pref the CONTENT-process actor
+// reads SYNCHRONOUSLY at document-start (before PresShell::Initialize), so a
+// curated site's override lands pre-paint with no IPC round-trip — eliminating
+// the brief double-dark on attribute-gated sites (e.g. YouTube's html[dark]).
+function mirrorOverridesPref(fixes) {
+  try {
+    const overrides = {};
+    for (const host of Object.keys(fixes || {})) {
+      overrides[host] = fixes[host].override || "inactive";
+    }
+    Services.prefs.setStringPref(
+      "gjoa.darkmode.fix-overrides",
+      JSON.stringify(overrides)
+    );
+  } catch (e) {}
 }
 
 // Most-specific host match: exact host, then walk parent domains.

--- a/tests/integration/darkmode-hybrid.bjs
+++ b/tests/integration/darkmode-hybrid.bjs
@@ -14,7 +14,7 @@
 ;; the authored bg pre-paint and dissolves that circularity; the "inactive"
 ;; assertion lands there.
 (ns gjoa.tests.integration.darkmode-hybrid
-  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect]]))
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq]]))
 (define-mode strict)
 (declare-extern [JSON] Any)
 
@@ -140,6 +140,47 @@
      (chrome-eval "Services.prefs.setIntPref('ui.systemUsesDarkTheme', 0); return 'os-light';")
      (js/await (await-true
                  "return Services.prefs.getBoolPref('gjoa.darkmode.hybrid.default-invert', false) === false;"
-                 4000)))]))
+                 4000)))
+   ;; #49: an explicit per-site override (here a user.off entry for the fixture
+   ;; host; the curated registry mirror works identically) is applied SYNCHRONOUSLY
+   ;; at document-start — before PresShell::Initialize — so the engine's pre-paint
+   ;; flip is pre-empted with no IPC round-trip. Validated via RESTART so the prefs
+   ;; are in the content process's startup snapshot (set-then-navigate races the
+   ;; parent->content pref propagation; production sets these at startup so it does
+   ;; not). The themeless /light page must then NOT invert: a white box stays white.
+   (deftest "darkmode #49: explicit override pre-empts the engine flip (sync, pre-paint)" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (chrome-eval (str "Services.prefs.setBoolPref('gjoa.darkmode.enabled', true);"
+                       " Services.prefs.setStringPref('gjoa.darkmode.mode', 'hybrid');"
+                       " Services.prefs.setBoolPref('gjoa.darkmode.invert.enabled', false);"
+                       " Services.prefs.setBoolPref('gjoa.darkmode.hybrid.default-invert', true);"
+                       " Services.prefs.setStringPref('gjoa.darkmode.user.off', '127.0.0.1');"
+                       " Services.prefs.savePrefFile(null);"
+                       " return 'seeded';"))
+     (let [client (js/await (.restartGjoa ctx))]
+       (js/await (.setContext client "chrome"))
+       (js/await (.executeAsyncScript client "const [r]=arguments; setTimeout(()=>r(1), 1500);" []))
+       (let [navOk (js/await (.executeAsyncScript client NAV-JS [LIGHT-TOP]))]
+         (expect navOk "light fixture loaded after restart")
+         (js/await (.executeAsyncScript client SETTLE-JS []))
+         (js/await (.setContext client "content"))
+         (let [box (js/await (.executeAsyncScript client
+                     (str "const [resolve]=arguments;"
+                          " const d=document.createElement('div'); d.id='dm-w';"
+                          " d.style.backgroundColor='rgb(255,255,255)';"
+                          " document.body.appendChild(d);"
+                          " setTimeout(()=>resolve(getComputedStyle(d).backgroundColor), 300);")
+                     []))]
+           (expect-eq box "rgb(255, 255, 255)"
+                      (str "explicit override (inactive) did not pre-empt the engine flip; box=" box))))
+       (js/await (.setContext client "chrome"))
+       (js/await (.executeScript client
+         (str "Services.prefs.clearUserPref('gjoa.darkmode.user.off');"
+              " Services.prefs.clearUserPref('gjoa.darkmode.hybrid.default-invert');"
+              " Services.prefs.clearUserPref('gjoa.darkmode.mode');"
+              " Services.prefs.clearUserPref('gjoa.darkmode.enabled');"
+              " Services.prefs.clearUserPref('gjoa.darkmode.invert.enabled');"
+              " Services.prefs.savePrefFile(null);")
+         []))))]))
 
 (js/export-default tests)


### PR DESCRIPTION
Eliminates the brief double-dark on **attribute-gated** curated sites (YouTube's `html[dark]`): the explicit per-site override is now applied **synchronously, before `PresShell::Initialize`**, with no IPC round-trip.

- **Parent** mirrors the curated registry's `host→override` into `gjoa.darkmode.fix-overrides` on load.
- **Child** computes the override synchronously at `DOMWindowCreated` (which precedes `PresShell::Initialize`) from synced prefs — curated mirror, then user per-site prefs (off/force-invert/force-native), same precedence as the parent. CSS/inject still arrive via the async path. Gated on the engine's `default-invert`.

**Validated via restart** so the prefs are in the content process's startup snapshot (matching production, where they're set at startup) rather than racing parent→content propagation as a set-then-navigate test would. Themeless `/light` stays un-inverted because the override landed pre-paint. **darkmode 9/9.**

Closes the last open dark-mode polish item. Native build for the daily driver is compiling.