### PR TITLE
feat(help): list the : ex-commands in the help overlay (#52)

### DIFF
--- a/src/gjoa/chrome/bjs/tabs/vim.bjs
+++ b/src/gjoa/chrome/bjs/tabs/vim.bjs
@@ -468,6 +468,20 @@
                     (.appendChild row k)
                     (.appendChild row d)
                     (.appendChild el row)))))
+              ;; The ": commands" section — make the ex-command set as
+              ;; self-documenting as the leader keymap (same ? / :help overlay).
+              (let [exHeader (htm "div" "gjoa-wk-header gjoa-wk-section")]
+                (set! (.-textContent exHeader) ": commands")
+                (.appendChild el exHeader))
+              (.forEach EX-COMMANDS (fn [c]
+                (let [row (htm "div" "gjoa-wk-row")
+                      k (htm "span" "gjoa-wk-cmd")
+                      d (htm "span" "gjoa-wk-desc")]
+                  (set! (.-textContent k) (str ":" (.-name c) (if (.-takesArgs c) " …" "")))
+                  (set! (.-textContent d) (.-description c))
+                  (.appendChild row k)
+                  (.appendChild row d)
+                  (.appendChild el row))))
               (.appendChild (.-documentElement document) el)
               (set! (.-which-key-el vs) el)
               el)))

--- a/src/gjoa/chrome/css/gjoa-which-key.uc.css
+++ b/src/gjoa/chrome/css/gjoa-which-key.uc.css
@@ -62,6 +62,24 @@
   font-weight: 600 !important;
 }
 
+/* Second-section header (": commands") gets breathing room above it. */
+#gjoa-which-key .gjoa-wk-section {
+  margin-top: 10px !important;
+}
+
+/* Ex-command pill: like a key, but left-aligned with a fixed column so the
+ * descriptions line up across the varying `:command` widths. */
+#gjoa-which-key .gjoa-wk-cmd {
+  display: inline-block !important;
+  min-width: 7em !important;
+  padding: 0 6px !important;
+  background-color: color-mix(in srgb, var(--gjoa-fg) 8%, transparent) !important;
+  border-radius: 3px !important;
+  color: var(--gjoa-accent) !important;
+  font-weight: 600 !important;
+  white-space: nowrap !important;
+}
+
 #gjoa-which-key .gjoa-wk-desc {
   color: var(--gjoa-fg) !important;
 }

--- a/tests/integration/help-menu.bjs
+++ b/tests/integration/help-menu.bjs
@@ -1,0 +1,28 @@
+#lang beagle/js
+;; #52: the help overlay (leader `?` / `:help`) must list the `:` EX-COMMANDS,
+;; not just the leader keymap — so the command set is self-documenting. We run
+;; the `help` ex-command (which builds + toggles #gjoa-which-key) and assert the
+;; overlay text contains the ": commands" section and representative commands.
+(ns gjoa.tests.integration.help-menu
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval expect]]))
+(define-mode strict)
+
+(def TRIGGER :- String
+  (str "const win=Services.wm.getMostRecentWindow('navigator:browser');"
+       " if (!win.gjoaTest || !win.gjoaTest.vim) return 'NO-API';"
+       " win.gjoaTest.vim.runExCommand('help');"
+       " const wk=win.document.getElementById('gjoa-which-key');"
+       " return wk ? wk.textContent : 'NO-WK';"))
+
+(js/export (def tests :- Any
+  [(deftest "help overlay lists the : ex-commands" [mn ctx]
+     (js/await (.setContext mn "chrome"))
+     (let [txt (chrome-eval TRIGGER)]
+       (expect (not= txt "NO-API") "gjoaTest.vim must be exposed (gjoa.test.exposeAPI)")
+       (expect (not= txt "NO-WK") "the #gjoa-which-key help overlay should exist after :help")
+       (expect (.includes txt ": commands") "help overlay should have a ': commands' section")
+       (expect (.includes txt ":tabpos") "help overlay should list :tabpos")
+       (expect (.includes txt ":space") "help overlay should list :space")
+       (expect (.includes txt ":checkpoint") "help overlay should list :checkpoint")))]))
+
+(js/export-default tests)

--- a/tests/integration/tags.json
+++ b/tests/integration/tags.json
@@ -4,7 +4,7 @@
     "darkmode":  ["darkmode-hybrid", "darkmode-invert"],
     "adblock":   ["adblock-cosmetic", "adblock-cosmetic-actor", "adblock-production", "adblock-ui", "adblock-validate"],
     "scriptlet": ["scriptlet-engine", "youtube-scriptlet"],
-    "tabs":      ["tab-mode-toggle", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys"],
+    "tabs":      ["tab-mode-toggle", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys", "help-menu"],
     "spaces":    ["spaces", "spaces-header", "spaces-scope-groups", "spaces-vim", "spaces-session-restore", "session-restore"],
     "newtab":    ["newtab-home", "new-tab-honors-active-space", "new-tab-no-indent-chain", "new-tab-visibility"],
     "misc":      ["sqlite"]


### PR DESCRIPTION
The which-key help overlay (`?` / `:help`) only showed the leader keymap, leaving the `:` ex-command set undiscoverable. Now it renders a "\: commands" section from the `EX-COMMANDS` registry (`:name …` + description) right beside the keymap. Test drives `:help` and asserts the commands appear. Lane 1, darkmode/tabs suites unaffected.