### PR TITLE
feat(darkmode): Dark Reader → gjoa registry transform tool (roadmap #1)

### DIFF
--- a/tools/prep/darkmode-registry.bjs
+++ b/tools/prep/darkmode-registry.bjs
@@ -1,0 +1,539 @@
+#lang beagle/js
+;; tools/prep/darkmode-registry.bjs — Dark Reader → gjoa curated dark-mode entry generator.
+;;
+;; WHAT THIS IS
+;;   Transforms Dark Reader's per-site "dynamic-theme-fixes" config into gjoa
+;;   curated-registry entries for
+;;   src/gjoa/toolkit/components/content-classifier/darkmode-fixes.json.
+;;   It scales the curated registry beyond the hand-written youtube + HN entries
+;;   without a human resolving Dark Reader's ${...} color tokens by hand.
+;;
+;; WORKFLOW (snapshot → print → eyeball → --write)
+;;   1. SNAPSHOT — the tool reads a LOCAL snapshot (tools/prep/darkreader-fixes.snapshot)
+;;      so runs are reproducible, not network-dependent. Refresh it with:
+;;        curl -sL https://raw.githubusercontent.com/darkreader/darkreader/main/src/config/dynamic-theme-fixes.config \
+;;          -o tools/prep/darkreader-fixes.snapshot
+;;   2. PRINT — `bun .beagle-tools/gjoa/tools/prep/darkmode-registry.js <host> [host...]`
+;;      parses the snapshot, finds each host's block (matching the host against the
+;;      block's URL-pattern lines), extracts + resolves its CSS section, and prints
+;;      the resulting JSON entry. Default mode is print-only.
+;;   3. EYEBALL — a human visually validates each generated entry (DR's ${} tokens are
+;;      resolved here, but DR also leans on runtime-only var(--darkreader-*) theme vars
+;;      which this tool maps to fixed dark values — those especially want a human look).
+;;   4. --write — MERGES the generated entries into darkmode-fixes.json, preserving all
+;;      existing keys (youtube.com, news.ycombinator.com, and anything already curated).
+;;
+;; THE TRANSFORM
+;;   Dark Reader's per-site CSS is a set of CORRECTIONS layered on top of DR's own
+;;   page inversion — NOT a standalone dark theme. The faithful gjoa equivalent is
+;;   therefore { "mode":"css", "override":"active", "css": <DR CSS, tokens resolved> }:
+;;     - override:"active"  → gjoa's engine inverts the page's resolved colors
+;;                            (WCAG luminance flip Y → 1-Y). This mirrors DR's
+;;                            "invert the page first" step.
+;;     - the resolved CSS   → DR's corrections fix the rough spots the blanket
+;;                            inversion gets wrong (logos to leave alone, specific
+;;                            backgrounds, etc.). This mirrors DR's "then correct" step.
+;;   Contrast with the hand-written entries, which use override:"inactive": those sites
+;;   ship a *complete* hand-authored dark theme (HN) or a native dark mode we toggle
+;;   (YouTube), so the engine must NOT also invert — inactive disables engine inversion
+;;   and the css alone carries the theme. Generated DR entries are the opposite model:
+;;   active inversion + corrections. (If a generated site turns out to have a full theme
+;;   in its DR CSS, a human flips it to inactive during eyeball — hence print-first.)
+;;
+;;   Each ${...} token is resolved by gjoa's EXACT engine flip — a port of
+;;   engine/servo/.../color.rs invert_color_luminance (patches/0009): per channel,
+;;   linearize sRGB → WCAG relative luminance Y → target 1-Y → factor → re-encode.
+;;   Hue/saturation are preserved by scaling all three channels by one shared factor;
+;;   alpha passes through. So ${#ffffff} → a dark color, ${#000000} → a light one.
+;;   Hex (#rgb/#rrggbb/#rrggbbaa), rgb()/rgba(), hsl()/hsla(), and CSS named colors
+;;   are all normalized to channels first, then flipped.
+;;
+;; SELF-CHECK
+;;   `--selftest` asserts the flip on known values (white→dark, black→light, mid-grey
+;;   round-trips) and exits nonzero on failure. Run it after editing the flip math.
+(ns gjoa.tools.prep.darkmode-registry
+  (:require [fs :refer [existsSync readFileSync writeFileSync]]
+            [path :refer [join]]
+            [gjoa.tools.prep.paths :refer [REPO-ROOT]]
+            [gjoa.tools.prep.log :refer [log]]))
+(define-mode strict)
+(declare-extern [process console Math JSON RegExp Error Number isNaN parseInt parseFloat] Any)
+
+;; ---------------------------------------------------------------------------
+;; Paths
+;; ---------------------------------------------------------------------------
+
+(def SNAPSHOT-PATH :- String (join REPO-ROOT "tools" "prep" "darkreader-fixes.snapshot"))
+(def REGISTRY-PATH :- String
+  (join REPO-ROOT "src" "gjoa" "toolkit" "components" "content-classifier" "darkmode-fixes.json"))
+
+;; ---------------------------------------------------------------------------
+;; Color model: an [r g b a] tuple with r/g/b in 0..255 and a in 0..1.
+;; ---------------------------------------------------------------------------
+
+;; The subset of CSS named colors Dark Reader actually emits as ${name} tokens
+;; (surveyed from the snapshot). Each maps to its [r g b] sRGB value. `transparent`
+;; is special-cased by the caller (it is not luminance-flipped).
+(def NAMED-COLORS :- Any
+  {"black"     [0 0 0]
+   "white"     [255 255 255]
+   "red"       [255 0 0]
+   "blue"      [0 0 255]
+   "cyan"      [0 255 255]
+   "yellow"    [255 255 0]
+   "orange"    [255 165 0]
+   "purple"    [128 0 128]
+   "gold"      [255 215 0]
+   "goldenrod" [218 165 32]
+   "khaki"     [240 230 140]
+   "gray"      [128 128 128]
+   "grey"      [128 128 128]
+   "lightgray" [211 211 211]
+   "lightgrey" [211 211 211]
+   "darkgray"  [169 169 169]
+   "darkgrey"  [169 169 169]
+   "slategray" [112 128 144]
+   "lightblue" [173 216 230]
+   "darkblue"  [0 0 139]
+   "darkred"   [139 0 0]
+   "aliceblue" [240 248 255]})
+
+;; Clamp x into [lo hi].
+(defn clamp [x :- Any lo :- Any hi :- Any] :- Any
+  (Math.max lo (Math.min hi x)))
+
+;; Expand a hex string (already stripped of '#') to [r g b a]. Accepts 3, 4, 6, 8
+;; digit forms. Returns nil if it isn't valid hex.
+(defn parse-hex [h :- String] :- Any
+  (let [n (.-length h)
+        valid (.test (RegExp. "^[0-9a-fA-F]+$") h)]
+    (cond
+      (not valid) nil
+      (= n 3) [(parseInt (str (aget h 0) (aget h 0)) 16)
+               (parseInt (str (aget h 1) (aget h 1)) 16)
+               (parseInt (str (aget h 2) (aget h 2)) 16)
+               1]
+      (= n 4) [(parseInt (str (aget h 0) (aget h 0)) 16)
+               (parseInt (str (aget h 1) (aget h 1)) 16)
+               (parseInt (str (aget h 2) (aget h 2)) 16)
+               (/ (parseInt (str (aget h 3) (aget h 3)) 16) 255)]
+      (= n 6) [(parseInt (.slice h 0 2) 16)
+               (parseInt (.slice h 2 4) 16)
+               (parseInt (.slice h 4 6) 16)
+               1]
+      (= n 8) [(parseInt (.slice h 0 2) 16)
+               (parseInt (.slice h 2 4) 16)
+               (parseInt (.slice h 4 6) 16)
+               (/ (parseInt (.slice h 6 8) 16) 255)]
+      :else nil)))
+
+;; Split the inside of an rgb()/rgba()/hsl()/hsla() on commas OR whitespace
+;; (CSS color level 4 allows both), trimming and dropping empties + a leading '/'
+;; alpha separator.
+(defn split-args [body :- String] :- Any
+  (let [raw (.split (.trim body) (RegExp. "[\\s,/]+"))]
+    (.filter raw (fn [s] (> (.-length s) 0)))))
+
+;; Parse one numeric component, honoring a trailing '%'. `whole` is the value a
+;; bare 100% maps to (255 for rgb channels, 1 for alpha).
+(defn parse-component [s :- String whole :- Any] :- Any
+  (if (.endsWith s "%")
+    (* (/ (parseFloat (.slice s 0 -1)) 100) whole)
+    (parseFloat s)))
+
+;; Convert hsl(h s% l%) to [r g b]. h in degrees, s/l in 0..1.
+(defn hsl->rgb [h :- Any s :- Any l :- Any] :- Any
+  (let [hh (/ (mod (mod h 360) 360) 360)
+        q (if (< l 0.5) (* l (+ 1 s)) (- (+ l s) (* l s)))
+        p (- (* 2 l) q)
+        hue->rgb (fn [t0 :- Any]
+                   (let [t (cond (< t0 0) (+ t0 1) (> t0 1) (- t0 1) :else t0)]
+                     (cond
+                       (< t (/ 1 6)) (+ p (* (- q p) 6 t))
+                       (< t (/ 1 2)) q
+                       (< t (/ 2 3)) (+ p (* (- q p) (- (/ 2 3) t) 6))
+                       :else p)))]
+    (if (= s 0)
+      [(Math.round (* l 255)) (Math.round (* l 255)) (Math.round (* l 255))]
+      [(Math.round (* (hue->rgb (+ hh (/ 1 3))) 255))
+       (Math.round (* (hue->rgb hh) 255))
+       (Math.round (* (hue->rgb (- hh (/ 1 3))) 255))])))
+
+;; Parse any single CSS color string (hex/rgb/rgba/hsl/hsla/named) to [r g b a].
+;; Returns nil if unrecognized (caller leaves the token untouched).
+(defn parse-color [raw :- String] :- Any
+  (let [s (.trim raw)
+        lower (.toLowerCase s)]
+    (cond
+      (.startsWith s "#")
+      (parse-hex (.slice s 1))
+
+      (or (.startsWith lower "rgb(") (.startsWith lower "rgba("))
+      (let [body (.slice s (+ (.indexOf s "(") 1) (.lastIndexOf s ")"))
+            parts (split-args body)]
+        (if (>= (.-length parts) 3)
+          [(clamp (Math.round (parse-component (aget parts 0) 255)) 0 255)
+           (clamp (Math.round (parse-component (aget parts 1) 255)) 0 255)
+           (clamp (Math.round (parse-component (aget parts 2) 255)) 0 255)
+           (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)]
+          nil))
+
+      (or (.startsWith lower "hsl(") (.startsWith lower "hsla("))
+      (let [body (.slice s (+ (.indexOf s "(") 1) (.lastIndexOf s ")"))
+            parts (split-args body)]
+        (if (>= (.-length parts) 3)
+          (let [h (parseFloat (aget parts 0))
+                sat (/ (parse-component (aget parts 1) 100) 100)
+                lit (/ (parse-component (aget parts 2) 100) 100)
+                rgb (hsl->rgb h (clamp sat 0 1) (clamp lit 0 1))]
+            [(aget rgb 0) (aget rgb 1) (aget rgb 2)
+             (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)])
+          nil))
+
+      ;; bare hex without '#', e.g. ${fff}
+      (.test (RegExp. "^[0-9a-fA-F]{3,8}$") s)
+      (parse-hex s)
+
+      (get NAMED-COLORS lower)
+      (let [rgb (get NAMED-COLORS lower)]
+        [(aget rgb 0) (aget rgb 1) (aget rgb 2) 1])
+
+      :else nil)))
+
+;; ---------------------------------------------------------------------------
+;; The luminance flip — exact port of engine/servo/.../color.rs
+;; invert_color_luminance (patches/0009-dark-mode-engine-color-inversion.patch).
+;; ---------------------------------------------------------------------------
+
+;; sRGB channel (0..255) → linear-light (WCAG `compute`).
+(defn compute [u :- Any] :- Any
+  (let [f (/ u 255)]
+    (if (<= f 0.03928)
+      (/ f 12.92)
+      (Math.pow (/ (+ f 0.055) 1.055) 2.4))))
+
+;; linear-light → sRGB byte, rounded + clamped (WCAG `decompute`).
+(defn decompute [x :- Any] :- Any
+  (let [s (if (<= x (/ 0.03928 12.92))
+            (* x 12.92)
+            (- (* 1.055 (Math.pow x (/ 1 2.4))) 0.055))]
+    (clamp (Math.round (* s 255)) 0 255)))
+
+;; Flip one [r g b a]: invert WCAG relative luminance Y → 1-Y, preserving hue/sat
+;; (single shared factor across channels) and alpha. Byte-identical to the engine.
+(defn flip-rgba [rgba :- Any] :- Any
+  (let [r (aget rgba 0) g (aget rgba 1) b (aget rgba 2) a (aget rgba 3)
+        lr (compute r) lg (compute g) lb (compute b)
+        lum (+ (* 0.2126 lr) (* 0.7152 lg) (* 0.0722 lb))
+        target (- 1 lum)
+        factor (/ (+ target 0.05) (+ lum 0.05))
+        adj (fn [l :- Any] (decompute (Math.max 0 (- (* (+ l 0.05) factor) 0.05))))]
+    [(adj lr) (adj lg) (adj lb) a]))
+
+;; The relative luminance Y of an [r g b a] (used by the selftest assertions).
+(defn luminance [rgba :- Any] :- Any
+  (+ (* 0.2126 (compute (aget rgba 0)))
+     (* 0.7152 (compute (aget rgba 1)))
+     (* 0.0722 (compute (aget rgba 2)))))
+
+;; Two-digit hex for a 0..255 byte.
+(defn byte->hex [n :- Any] :- String
+  (.padStart (.toString (clamp (Math.round n) 0 255) 16) 2 "0"))
+
+;; Format an [r g b a] back to CSS. Solid → #rrggbb; alpha < 1 → rgba(...).
+(defn rgba->css [rgba :- Any] :- String
+  (let [r (aget rgba 0) g (aget rgba 1) b (aget rgba 2) a (aget rgba 3)]
+    (if (>= a 1)
+      (str "#" (byte->hex r) (byte->hex g) (byte->hex b))
+      (str "rgba(" (clamp (Math.round r) 0 255) ", " (clamp (Math.round g) 0 255) ", "
+           (clamp (Math.round b) 0 255) ", " (Number (.toFixed a 3)) ")"))))
+
+;; Resolve one token's inner color text to flipped CSS. Returns nil if the inner
+;; text is not a parseable color (e.g. `transparent`, or a var() — handled earlier).
+(defn resolve-token [inner :- String] :- Any
+  (let [parsed (parse-color inner)]
+    (if parsed
+      (rgba->css (flip-rgba parsed))
+      nil)))
+
+;; ---------------------------------------------------------------------------
+;; Dark Reader runtime theme variables.
+;;
+;; DR injects var(--darkreader-neutral-background) / -neutral-text etc. at runtime
+;; from its computed dark theme. gjoa has no such vars, so a faithful entry must
+;; substitute concrete dark values. These mirror DR's default dark theme
+;; (background #181a1b, text #e8e6e3) and the engine's own dark-grey neutrals.
+;; ---------------------------------------------------------------------------
+
+(def DARKREADER-VARS :- Any
+  {"--darkreader-neutral-background"  "#181a1b"
+   "--darkreader-neutral-text"        "#e8e6e3"
+   "--darkreader-neutral-color"       "#e8e6e3"
+   "--darkreader-selection-background" "#0060df"
+   "--darkreader-selection-text"      "#ffffff"})
+
+;; ---------------------------------------------------------------------------
+;; Snapshot parsing.
+;; A block is: 1+ URL-pattern lines, then named UPPERCASE sections (INVERT, CSS,
+;; IGNORE INLINE STYLE, IGNORE IMAGE ANALYSIS, …). Blocks are separated by a line
+;; that is a run of '=' characters. The first block (url `*`) is the global
+;; default and is skipped.
+;; ---------------------------------------------------------------------------
+
+;; The `m` (multiline) flag makes ^/$ match at each line boundary, so a separator
+;; line (a run of '=') splits the file into blocks.
+(def SEPARATOR :- Any (RegExp. "^=+\\s*$" "m"))
+;; A section header is an all-caps line (letters + spaces) standing alone.
+(def SECTION-HEADER :- Any (RegExp. "^[A-Z][A-Z ]+$"))
+
+;; The section headers Dark Reader uses. A SECTION-HEADER-shaped line is only
+;; treated as a new section if it is one of these — so a stray uppercase CSS
+;; selector inside a CSS body is not misread as a header.
+(def KNOWN-SECTIONS :- Any
+  ["INVERT" "CSS" "IGNORE INLINE STYLE" "IGNORE IMAGE ANALYSIS"
+   "INVERT SIZE" "PLUS"])
+
+;; Parse the whole snapshot into a vector of {:patterns [...] :sections {NAME text}}.
+(defn parse-snapshot! [text :- String] :- Any
+  (let [blocks (.split text SEPARATOR)
+        out []]
+    (doseq [block blocks]
+      (let [lines (.split (.trimEnd block) "\n")
+            patterns []
+            sections {}
+            cur-name (atom nil)
+            cur-lines (atom [])
+            flush! (fn []
+                     (when @cur-name
+                       (set! (get sections @cur-name) (.trim (.join @cur-lines "\n"))))
+                     (reset! cur-lines []))]
+        (doseq [line lines]
+          (let [trimmed (.trim line)]
+            (cond
+              ;; blank line outside any section → ignore; inside → keep (CSS layout)
+              (and (= trimmed "") (not @cur-name)) nil
+
+              (and (.test SECTION-HEADER trimmed) (.includes KNOWN-SECTIONS trimmed))
+              (do (flush!) (reset! cur-name trimmed))
+
+              ;; A URL-pattern line: we are before any section header.
+              (and (not @cur-name) (not= trimmed ""))
+              (.push patterns trimmed)
+
+              :else
+              (.push @cur-lines line))))
+        (flush!)
+        (when (> (.-length patterns) 0)
+          (.push out {:patterns patterns :sections sections}))))
+    out))
+
+;; ---------------------------------------------------------------------------
+;; Host matching.
+;; A DR pattern is a host glob like `*.wikipedia.org`, `old.reddit.com`, or a bare
+;; host. We match a query host if the pattern's host part equals it or is a
+;; suffix-with-dot match. Leading `*.` matches any subdomain AND the bare apex.
+;; ---------------------------------------------------------------------------
+
+;; Strip a DR pattern down to its host (drop scheme, path, query selectors).
+(defn pattern-host [pat :- String] :- String
+  (let [no-scheme (.replace pat (RegExp. "^[a-z]+://") "")
+        host (aget (.split no-scheme "/") 0)]
+    (.toLowerCase (.trim host))))
+
+(defn host-matches? [pat :- String host :- String] :- Any
+  (let [p (pattern-host pat)
+        h (.toLowerCase host)]
+    (cond
+      (= p "*") false ;; the global block; never a per-site match
+      (= p h) true
+      (.startsWith p "*.")
+      (let [base (.slice p 2)]
+        (or (= h base) (.endsWith h (str "." base))))
+      ;; bare host pattern also matches subdomains of the query (DR semantics:
+      ;; `reddit.com` covers `www.reddit.com`) — but require a dot boundary.
+      (.endsWith h (str "." p)) true
+      :else false)))
+
+;; Find the first block whose patterns match `host`.
+(defn find-block [blocks :- Any host :- String] :- Any
+  (.find blocks
+         (fn [b]
+           (.some (.-patterns b) (fn [pat] (host-matches? pat host))))))
+
+;; ---------------------------------------------------------------------------
+;; CSS resolution: replace every ${...} token and var(--darkreader-*) reference.
+;; ---------------------------------------------------------------------------
+
+;; Resolve all ${...} tokens in a CSS string. Unrecognized inners (transparent,
+;; nested var) are left as their literal inner text so the rule still parses.
+(defn resolve-tokens [css :- String unresolved :- Any] :- String
+  (.replace css (RegExp. "\\$\\{([^}]*)\\}" "g")
+            (fn [_match inner]
+              (let [trimmed (.trim inner)]
+                (cond
+                  (= (.toLowerCase trimmed) "transparent") "transparent"
+                  :else
+                  (let [resolved (resolve-token trimmed)]
+                    (if resolved
+                      resolved
+                      (do (.push unresolved trimmed) trimmed))))))))
+
+;; Substitute DR runtime vars with concrete dark values. Records any unmapped
+;; --darkreader-* var so the human sees it during eyeball.
+(defn resolve-dr-vars [css :- String unmapped :- Any] :- String
+  (.replace css (RegExp. "var\\(\\s*(--darkreader-[A-Za-z0-9_-]+)\\s*(?:,[^)]*)?\\)" "g")
+            (fn [_match name]
+              (let [v (get DARKREADER-VARS name)]
+                (if v
+                  v
+                  (do (.push unmapped name)
+                      ;; fall back to neutral background so the rule still resolves
+                      "#181a1b"))))))
+
+;; Build the gjoa registry entry for a block's CSS section. Returns
+;; {:css ... :unresolved [...] :unmapped-vars [...]} or nil if no CSS section.
+(defn build-entry [block :- Any] :- Any
+  (let [css (get (.-sections block) "CSS")]
+    (if (or (not css) (= (.trim css) ""))
+      nil
+      (let [unresolved []
+            unmapped []
+            resolved (resolve-dr-vars (resolve-tokens css unresolved) unmapped)
+            ;; collapse the multi-line CSS to a single compact line, matching the
+            ;; existing registry entries' style (one rule run, spaces normalized).
+            compact (.trim (.replace (.replace resolved (RegExp. "\\s*\\n\\s*" "g") " ")
+                                     (RegExp. "  +" "g") " "))]
+        {:css compact
+         :entry {:mode "css" :override "active" :css compact}
+         :unresolved unresolved
+         :unmapped-vars unmapped}))))
+
+;; ---------------------------------------------------------------------------
+;; Self-test: the flip on known values.
+;; ---------------------------------------------------------------------------
+
+(defn selftest! [] :- Any
+  (let [white (flip-rgba [255 255 255 1])
+        black (flip-rgba [0 0 0 1])
+        grey  [119 119 119 1]
+        grey-flip (flip-rgba grey)
+        grey-round (flip-rgba grey-flip)
+        white-lum (luminance white)
+        black-lum (luminance black)
+        grey-lum (luminance grey)
+        grey-round-lum (luminance grey-round)
+        info (.-info log)
+        ok (.-ok log)
+        err (.-error log)
+        failures (atom 0)
+        check! (fn [label :- String pass :- Any detail :- String]
+                 (if pass
+                   (ok (str label " — " detail))
+                   (do (err (str label " FAILED — " detail))
+                       (reset! failures (+ @failures 1)))))]
+    (info "flip self-test (exact engine luminance port)")
+    (info (str "  flip(#ffffff) = " (rgba->css white) "  luminance=" (.toFixed white-lum 4)))
+    (info (str "  flip(#000000) = " (rgba->css black) "  luminance=" (.toFixed black-lum 4)))
+    (info (str "  flip(#777777) = " (rgba->css grey-flip) "  luminance=" (.toFixed (luminance grey-flip) 4)))
+    (info (str "  flip(flip(#777777)) = " (rgba->css grey-round) "  luminance=" (.toFixed grey-round-lum 4)))
+    (check! "white→dark" (< white-lum 0.22)
+            (str "luminance " (.toFixed white-lum 4) " < 0.22"))
+    (check! "black→light" (> black-lum 0.5)
+            (str "luminance " (.toFixed black-lum 4) " > 0.5"))
+    (check! "mid-grey round-trips" (< (Math.abs (- grey-round-lum grey-lum)) 0.05)
+            (str "|" (.toFixed grey-round-lum 4) " - " (.toFixed grey-lum 4) "| = "
+                 (.toFixed (Math.abs (- grey-round-lum grey-lum)) 4) " < 0.05"))
+    (if (> @failures 0)
+      (do (err (str @failures " self-test assertion(s) failed")) 1)
+      (do (ok "all self-test assertions passed") 0))))
+
+;; ---------------------------------------------------------------------------
+;; CLI
+;; ---------------------------------------------------------------------------
+
+(def USAGE :- String
+  (.trim "
+gjoa darkmode-registry — Dark Reader → gjoa curated dark-mode entry generator
+
+Usage:
+  bun .beagle-tools/gjoa/tools/prep/darkmode-registry.js <host> [host...]   print entries
+  bun .beagle-tools/gjoa/tools/prep/darkmode-registry.js --write <host>...  merge into registry
+  bun .beagle-tools/gjoa/tools/prep/darkmode-registry.js --selftest         run the flip self-test
+
+Default prints the generated JSON entry/entries for each host so a human can
+eyeball before --write merges them into darkmode-fixes.json (existing keys kept).
+Reads the local snapshot at tools/prep/darkreader-fixes.snapshot.
+"))
+
+(defn read-snapshot! [] :- Any
+  (when (not (existsSync SNAPSHOT-PATH))
+    (let [err (.-error log)]
+      (err (str "snapshot not found at " SNAPSHOT-PATH))
+      (err "refresh it: curl -sL https://raw.githubusercontent.com/darkreader/darkreader/main/src/config/dynamic-theme-fixes.config -o tools/prep/darkreader-fixes.snapshot")
+      (.exit process 1)))
+  (readFileSync SNAPSHOT-PATH "utf8"))
+
+;; Generate {:host :entry :unresolved :unmapped-vars :matched-by} for one host,
+;; or {:host :missing true} if no block matched / no CSS section.
+(defn generate-for-host [blocks :- Any host :- String] :- Any
+  (let [block (find-block blocks host)]
+    (if (not block)
+      {:host host :missing true :reason "no matching DR block"}
+      (let [built (build-entry block)]
+        (if (not built)
+          {:host host :missing true :reason "matched block has no CSS section (INVERT/IGNORE only)"}
+          {:host host
+           :entry (.-entry built)
+           :unresolved (.-unresolved built)
+           :unmapped-vars (.-unmapped-vars built)
+           :matched-by (.join (.-patterns block) ", ")})))))
+
+(defn print-result! [r :- Any] :- Any
+  (let [info (.-info log)
+        warn (.-warn log)
+        step (.-step log)]
+    (if (.-missing r)
+      (warn (str (.-host r) ": skipped — " (.-reason r)))
+      (do
+        (step (str (.-host r) "  (matched DR patterns: " (.-matched-by r) ")"))
+        (when (> (.-length (.-unresolved r)) 0)
+          (warn (str "  unresolved tokens left literal: " (.join (.-unresolved r) ", "))))
+        (when (> (.-length (.-unmapped-vars r)) 0)
+          (warn (str "  unmapped --darkreader vars (fell back to neutral bg): "
+                     (.join (.-unmapped-vars r) ", "))))
+        (.log console (.stringify JSON {(.-host r) (.-entry r)} nil 2))))))
+
+(defn main! [] :- Any
+  (let [argv (.slice (.-argv process) 2)
+        write? (.includes argv "--write")
+        selftest? (.includes argv "--selftest")
+        hosts (.filter argv (fn [a] (not (.startsWith a "--"))))]
+    (cond
+      selftest?
+      (.exit process (selftest!))
+
+      (= (.-length hosts) 0)
+      (do (.log console USAGE) (.exit process 0))
+
+      :else
+      (let [snapshot (read-snapshot!)
+            blocks (parse-snapshot! snapshot)
+            results (.map hosts (fn [h] (generate-for-host blocks h)))
+            generated (.filter results (fn [r] (not (.-missing r))))]
+        (doseq [r results] (print-result! r))
+        (when write?
+          (if (= (.-length generated) 0)
+            (let [warn (.-warn log)] (warn "nothing to write (no hosts produced entries)"))
+            (let [existing (if (existsSync REGISTRY-PATH)
+                             (.parse JSON (readFileSync REGISTRY-PATH "utf8"))
+                             {})
+                  added []]
+              (doseq [r generated]
+                (set! (get existing (.-host r)) (.-entry r))
+                (.push added (.-host r)))
+              (writeFileSync REGISTRY-PATH (str (.stringify JSON existing nil 2) "\n"))
+              (let [ok (.-ok log)]
+                (ok (str "merged " (.-length added) " entr" (if (= (.-length added) 1) "y" "ies")
+                         " into darkmode-fixes.json: " (.join added ", ")))))))))))
+
+(main!)

--- a/tools/prep/darkreader-fixes.snapshot
+++ b/tools/prep/darkreader-fixes.snapshot
@@ -1,0 +1,39455 @@
+*
+
+INVERT
+.jfk-bubble.gtx-bubble
+.captcheck_answer_label > input + img
+span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
+span[data-href^="https://www.hcaptcha.com/"] > #icon
+img.Wirisformula
+a[data-testid="headerMediumLogo"]>svg
+.d2l-navigation-link-image-container
+.d2l-iframe-loading-container
+div.mc-ip-hide[style*="background: rgb(255, 255, 255) !important"]
+[style*="color: rgb(0, 0, 1) !important;"]
+
+CSS
+.jfk-bubble.gtx-bubble {
+    background-color: white !important;
+}
+.vimvixen-hint {
+    background-color: ${#ffd76e} !important;
+    border-color: ${#c59d00} !important;
+    color: ${#302505} !important;
+}
+#vimvixen-console-frame {
+    color-scheme: light !important;
+}
+::placeholder {
+    opacity: 0.5 !important;
+}
+#edge-translate-panel-body,
+.MuiTypography-body1,
+.nfe-quote-text {
+    color: var(--darkreader-neutral-text) !important;
+}
+gr-main-header {
+    background-color: ${lightblue} !important;
+}
+.tou-z65h9k,
+.tou-mignzq,
+.tou-1b6i2ox,
+.tou-lnqlqk {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.tou-75mvi {
+    background-color: ${rgb(207, 236, 245)} !important;
+}
+.tou-ta9e87,
+.tou-1w3fhi0,
+.tou-1b8t2us,
+.tou-py7lfi,
+.tou-1lpmd9d,
+.tou-1frrtv8,
+.tou-17ezmgn {
+    background-color: ${rgb(245, 245, 245)} !important;
+}
+.tou-uknfeu {
+    background-color: ${rgb(250, 237, 218)} !important;
+}
+.tou-6i3zyv {
+    background-color: ${rgb(133, 195, 216)} !important;
+}
+div.mermaid-viewer-control-panel .btn {
+    background-color: var(--darkreader-neutral-background);
+    fill: var(--darkreader-neutral-text);
+}
+svg g rect.er {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.entityBox {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.attributeBoxOdd {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.attributeBoxEven {
+    fill: var(--darkreader-selection-background);
+    fill-opacity: 0.8 !important;
+}
+svg rect.er.relationshipLabelBox {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg g g.nodes rect,
+svg g g.nodes polygon {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.task {
+    fill: var(--darkreader-selection-background) !important;
+}
+svg line.messageLine0,
+svg line.messageLine1 {
+    stroke: var(--darkreader-neutral-text) !important;
+}
+div.mermaid .actor {
+    fill: var(--darkreader-neutral-background) !important;
+}
+mitid-authenticators-code-app > .code-app-container {
+    background-color: white !important;
+    padding-top: 1rem;
+}
+iframe#unpaywall[src$="unpaywall.html"] {
+    color-scheme: light !important;
+}
+select {
+    --darkreader-bg--form-control-background-color: rgba(22, 22, 22, 0) !important;
+}
+body#tumblr {
+    --darkreader-bg--secondary-accent: 31, 32, 34 !important;
+    --darkreader-bg--white: 23, 23, 23 !important;
+    --darkreader-text--black: 228, 224, 218 !important;
+}
+:host {
+    --d2l-border-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+    --d2l-button-icon-background-color-hover: var(--darkreader-bg--d2l-color-gypsum) !important;
+    --d2l-color-ferrite: var(--darkreader-neutral-text) !important;
+    --d2l-color-sylvite: var(--darkreader-bg--d2l-color-sylvite) !important;
+    --d2l-dropdown-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-dropdown-border-color: var(--darkreader-border--d2l-color-mica) !important;
+    --d2l-input-backgroud-color: var(--darkreader-neutral-background) !important;
+    --d2l-menu-border-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+    --d2l-tooltip-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-tooltip-border-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+:host([_floating]) .d2l-floating-buttons-container {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-top-color: var(--darkreader-border--d2l-color-mica) !important;
+    opacity: 0.88 !important;
+}
+d2l-card {
+    background: var(--darkreader-neutral-background) !important;
+    border-color: var(--darkreader-border--d2l-color-gypsum) !important;
+}
+d2l-dropdown-content > div,
+d2l-menu-item {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-radius: 10px !important;
+}
+d2l-empty-state-simple {
+    border-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+.d2l-button-filter > ul > li > a.vui-button {
+    border-color: var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-label-text:has(.d2l-button-subtle-content):hover,
+.d2l-label-text:has(.d2l-button-subtle-content):focus,
+.d2l-label-text:has(.d2l-button-subtle-content):active {
+    background-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+.d2l-navigation-centerer {
+    color: inherit !important;
+}
+.d2l-tabs-layout {
+    border-color: var(--darkreader-border--d2l-color-gypsum) !important;
+}
+.d2l-input,
+.d2l-calendar-date,
+.d2l-htmleditor-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.d2l-collapsible-panel {
+    border: 1px solid var(--darkreader-border--d2l-color-mica) !important;
+    border-radius: 0.4rem !important;
+}
+.d2l-collapsible-panel-divider {
+    border-bottom: 1px solid var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-w2d-flex {
+    border-bottom: 2px solid var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-collapsible-panel scrolled,
+.d2l-collapsible-panel-header,
+.d2l-w2d-collection-fixed {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.d2l-loading-spinner-bg {
+    fill: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+.d2l-loading-spinner-bg-stroke {
+    stroke: var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-loading-spinner-wrapper svg path,
+.d2l-loading-spinner-wrapper svg circle {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.d2l-twopanelselector-side.d2l-twopanelselector-side-sep {
+    background: var(--darkreader-bg--d2l-color-mica) !important;
+}
+.d2l-le-TreeAccordionItem-anchor::before {
+    background: var(--darkreader-bg--d2l-color-corundum) !important;
+}
+table[class|="moz-header"] {
+    background: none;
+}
+*[style*="color: rgba(0,0,0,"]:not([style*="color: rgba(0,0,0,0)"]),
+*[style*="color: rgba(0, 0, 0,"]:not([style*="color: rgba(0, 0, 0, 0)"]),
+*[style*="color:#000"],
+*[style*="color:black"],
+*[style*="color:#282828"],
+*[style*="color:#444"],
+*[style*="color: #222222"] {
+    color: var(--darkreader-neutral-text) !important;
+}
+*[style*="background:#fff"],
+*[style*="background-color:#fff"],
+*[style*="background: #fff"] {
+    background: var(--darkreader-neutral-background) !important;
+}
+*[bgcolor="#F5F5F5"],
+*[style*="background-color: #F5F5F5"] {
+    background: ${#F5F5F5} !important;
+}
+*[style*="background: #e6e6e6"] {
+    background: ${#e6e6e6} !important;
+}
+body[style*="background: rgb(255, 255, 255) !important"] *:not(a),
+.body[style*="background-color: rgb(254, 254, 254) !important"] *:not(a) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div[style*="www.gstatic.com/android/"] {
+    background: none !important;
+}
+*[style*="background:#f9f9f9"] {
+    background: ${#F9F9F9} !important;
+}
+body.mediawiki.skin-vector #mw-page-base {
+    background-image: none !important;
+}
+.overflow-hidden .spinning-bg,
+.overflow-hidden .solid-bg {
+    background: transparent !important;
+}
+
+IGNORE CSS URL
+^https://fonts.googleapis.com/
+
+================================
+
+*.abc.net.au
+
+INVERT
+[data-component="ABCNewsLogo"] *
+
+IGNORE INLINE STYLE
+[data-component="ABCLogo"] *
+
+================================
+
+*.acesso.gov.pt
+*.portaldasfinancas.gov.pt
+
+INVERT
+img[src$="/logo-at.png"]
+img[src$="/logo-at.svg"]
+img[src$="/FatSorte_logo.png"]
+img[src$="/at_logo.svg"]
+img[src$="/logo-at_small.svg"]
+img[src$="/logo_e_balcao_small.png"]
+img[src$="/logo_direitos_contribuinte_38.png"]
+img[src$="/bullet_ebalcao.png"]
+img[src$="/bullet_apm.png"]
+.logo-efatura
+.logo-sgdt
+
+CSS
+html[data-darkreader-scheme="dark"] table#main_Table {
+    background-color: black !important;
+}
+html[data-darkreader-scheme="dark"] table#header {
+    position: relative !important;
+    z-index: 10 !important;
+}
+html[data-darkreader-scheme="dark"] table#header::before {
+    background-color: #001053 !important;
+    bottom: 0 !important;
+    content: "" !important;
+    left: 50% !important;
+    position: absolute !important;
+    top: 0 !important;
+    transform: translateX(-50%) !important;
+    width: 100vw !important;
+    z-index: -1 !important;
+}
+body {
+    background-color: transparent !important;
+}
+
+================================
+
+*.americanexpress.com
+
+INVERT
+img[alt*="FDIC-Insured"]
+
+CSS
+select[aria-labelledby="bankAccount-label"] > option {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+*.archlinux.org
+
+INVERT
+img[src*="icons/"]
+img[src="/svg/calendar.svg"]
+.cdx-search-input .cdx-text-input__icon.cdx-text-input__start-icon
+.cdx-button--icon-only .vector-icon
+
+CSS
+.vector-sticky-pinned-container::after {
+    background: inherit;
+}
+body {
+    height: fit-content;
+}
+
+================================
+
+*.autotask.net
+
+CSS
+.bg-background-primary {
+    background-color: ${rgb(255 255 255)} !important;
+}
+.bg-background-hover {
+    background-color: ${rgb(207, 217, 226)} !important;
+}
+
+================================
+
+*.babbel.com
+
+IGNORE INLINE STYLE
+#radix-\:r2\: > svg:nth-child(1) *
+#radix-\:r3\: > div > div > div > svg *
+#\32 53PcCLJv1hu747b7LM72J > div > div > div > div > div > a > div > svg *
+#\35 1RrI7tAWynOXHmNFDQeaT > div > div > div > div > div > a > div > svg *
+
+================================
+
+*.bambulab.com
+
+CSS
+.bannerTextWrap .title,
+.bannerTextWrap .subtitle {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+================================
+
+*.bancoctt.pt
+
+INVERT
+header h1.brand img
+footer ul.logos img
+img[src^="/Content/Themes/BCTT/logo.png"]
+path[d^="M83.897 7.128c6.053"][fill="#000"]
+div.header__title a.header__logo-link svg path[fill="#333333"]
+
+CSS
+div#home-locations.map-center3:not([data-darkreader-inline-bgimage]) {
+    background-image: url("/application/themes/images/map/centro3.jpg") !important;
+}
+div.card-container img {
+    background-color: white !important;
+}
+
+IGNORE INLINE STYLE
+div.card-container *
+div.header__title a.header__logo-link *
+
+================================
+
+*.bitrix24.ru
+
+INVERT
+#ws-canvas
+
+================================
+
+*.cnrtl.fr
+
+CSS
+.tlf_cdefinition {
+    background-color: ${rgb(255, 255, 0)} !important;
+}
+.tlf_cdomaine {
+    background-color: ${rgb(255, 176, 96)} !important;
+}
+.tlf_csyntagme {
+    background-color: ${rgb(192, 255, 192)} !important;
+}
+
+================================
+
+*.discogs.com
+
+INVERT
+[class*="logo"]
+
+CSS
+.swiper-pagination-bullet {
+    background: var(--swiper-pagination-bullet-inactive-color, #FFFFFF) !important;
+}
+.bg-\[linear-gradient\(to_right\,transparent_var\(--fill-stop\)\,\#f2f2f2_var\(--fill-stop\)\)\] {
+    background-image: linear-gradient(to right,transparent var(--fill-stop),${#d2d2d2} var(--fill-stop)) !important;
+}
+
+================================
+
+*.docs.kubernetes.io
+
+CSS
+.highlight pre code > span[style*="text-decoration: underline"] {
+    text-decoration: none !important;
+}
+
+================================
+
+*.dreamwidth.org
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.tropo nav,
+.tropo footer,
+#intro-box-main {
+    background-image: none !important;
+}
+html[data-darkreader-scheme="dark"] .tropo #logo {
+    filter: invert(90%) hue-rotate(180deg) !important;
+}
+html[data-darkreader-scheme="dimmed"] .tropo #logo {
+    filter: brightness(85%) !important;
+}
+.ContextualPopup {
+    background: var(--darkreader-neutral-background) !important;
+}
+*[style*="color: rgba(0,0,0,"],
+*[style*="color: rgba(0, 0, 0,"],
+*[style*="color:#000"],
+*[style*="color:black"],
+*[style*="color:#282828"],
+*[style*="color:#444"],
+*[style*="background:#fff"],
+*[style*="background-color:#fff"],
+*[bgcolor="#F5F5F5"],
+*[style*="background-color: #F5F5F5"],
+*[style*="background:#f9f9f9"] {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+.entry-content *
+.comment-content *
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+*.galaxus.de
+
+INVERT
+#logo
+
+CSS
+#sidebarMenu div {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+*.gamer.com.tw
+
+INVERT
+.sidenav__icon
+
+CSS
+body {
+    background-color: transparent !important;
+    background-image: none !important;
+}
+.main-nav__logo {
+    background-color: currentColor !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.service__icon.icon-arrow
+.MSG-mainpic
+#BH-main_menu
+#BH-master h4
+.BH-slave_btns .BH-slave_btnA
+#BH-slave h5
+
+================================
+
+*.globo.com
+
+INVERT
+.header__brand__link[href*=extra]
+.header__brand__link[href*=umsoplaneta] path[fill=black]
+.header__brand__link[href*=umsoplaneta] path[stroke=black]
+.header__brand__link[href*=marieclaire]
+.header__brand__link[href*=revistaquem]
+.header__brand__link[href*=gq]
+#logo-valor_100-anos
+.pages-footer img[src$="logo_edg.png"]
+.pages-footer img[src$="logo-Conde-Nast.png"]
+.pages-footer img[src$="logo_condenast.png"]
+.pages-footer img[src$="Rádio_wordmark.png"]
+.header__menu__icon_background_color
+
+CSS
+.bar-scrubber .bar-scrubber-icon,
+.bar-background .bar-fill-2 {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.bar-background .bar-fill-1 {
+    background-color: rgba(255, 255, 255, .3) !important;
+}
+.multicontent {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+span.bstn-hl-summary {
+    color: var(--darkreader-neutral-text) !important;
+}
+.glb-grid .tabela-body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.bstn-hl.with-photo::before {
+    background-image: var(--bstn-hl-cover) !important;
+}
+.footer__logo__wrapper {
+    background: var(--darkreader-bg--custom-footer-background) !important;
+}
+
+IGNORE INLINE STYLE
+.poster__play-wrapper *
+#Logo_Valor_Economico_Branco *
+
+IGNORE IMAGE ANALYSIS
+.barra-globocom .barra-itens li .barra-item-videos
+
+================================
+
+*.hom.com
+
+INVERT
+img.logoimg
+img.sub-footer__brands-image
+img.sub-footer__certifications-image
+img.retina_size
+div.s3-uploaded-icon img
+div.cart-drawer__empty-cart svg
+button.product-popup-modal__button svg.icon
+summary.mobile-toggle span
+div.R-RatingStars__stars.u-marginBottom--none i.stars__icon
+div.R-RatingStars__stars.u-marginRight--none i[class^="stars__icon stars__icon--"]
+div.collapsible__content-care-info img
+div.R-SliderIndicator__inner
+collapsible-row.product__accordion summary span
+
+CSS
+div.sub-footer,
+div.row.full-width-row-full,
+div.image-with-text__content,
+div.email-signup {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div.image-with-text-overlay--bg::after {
+    background-color: rgba(var(--color-overlay-rgb),var(--overlay-opacity)) !important;
+}
+div.header__bg__overlay {
+    background-image: none !important;
+}
+div.gallery--item figure::after,
+div.revealed-media--media::after {
+    background: none !important;
+}
+div.email-signup--image:after {
+    background: rgba(var(--overlay-color-rgb),var(--overlay-opacity)) !important;
+}
+div.R-ReviewsList-container .item__inner {
+    background: transparent !important;
+}
+.ruk_rating_snippet * {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+div.sub-footer__socials *
+div.footer-payment-icons *
+div.cart-drawer__empty-cart *
+
+================================
+
+*.hypothes.is
+
+INVERT
+a[href="https://hypothes.is"] > svg[aria-labelledby="logo-title"] > g > path[fill-rule="nonzero"]
+img[class="fusion-standard-logo"]
+.pdfViewer .canvasWrapper
+
+CSS
+.pdfViewer .textLayer {
+    opacity: 1 !important;
+}
+.pdfViewer .hypothesis-highlight {
+    background-color: var(--darkreader-bg--highlight-color) !important;
+}
+.pdfViewer .hypothesis-shape-highlight {
+    border-color: rgba(128,128,128,0.3) !important;
+    outline: none !important;
+}
+.toolbarButton::before,
+.secondaryToolbarButton::before,
+.dropdownToolbarButton::after,
+.treeItemToggler::before {
+    background-color: var(--toolbar-icon-bg-color) !important;
+}
+
+================================
+
+*.iherb.com
+
+INVERT
+ul.social-media-icons
+.my-account-link-icon
+.icon-box > svg > path
+.rtl-plugin-key-1301cbg > div > div > svg > path
+.add-to-cart-checkmark
+.add-to-cart-close
+
+CSS
+.rtl-plugin-key-bpb6ad svg path,
+.rtl-plugin-key-14wt5ex svg path,
+span.search-glass {
+    fill: var(--darkreader-text-666666) !important;
+}
+.payment-sprite,
+.product-image-wrapper,
+.product-image,
+#productundefined > div > a > img,
+.rtl-plugin-key-k008qs > div > img,
+.top-affiliate-network-grid > a > img,
+.brands-banner-collapsible img:first-of-type,
+#brands-of-the-week-inner > li > a > div > img,
+#brands-of-week > div.row.row-centered.subdivide-10-greater > div > div > img,
+img[class^="ProductItem__ProductImage"],
+.sub-nav-image.sub-nav-link,
+.css-c65ugd,
+.css-1gybq1s,
+div.brand-logo-circle,
+div.shop-by-logo-image-container {
+    background-color: #f7f8f7 !important;
+}
+div[class^="components__Container"],
+div[class^="ProductPanel__Container"] {
+    background-color: initial !important;
+    opacity: 0.99 !important;
+}
+.category-icon img.icon-image {
+    mix-blend-mode: unset !important;
+}
+div[class^="ShipmentPanel__ProductListWrapper"] {
+    background-color: rgb(248, 248, 248) !important;
+}
+
+IGNORE INLINE STYLE
+.custom-flex-box-item span
+
+================================
+
+*.indeed.com
+
+INVERT
+#indeed-globalnav-logo
+
+CSS
+.jobsearch-Layout--gradientBg {
+    background-image: none !important;
+}
+
+================================
+
+*.instructure.com
+
+CSS
+.css-vrgbjj-textArea {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.css-4y58qe-textArea {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+*.maricopa.edu
+
+CSS
+#background-content {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+*.msi.com
+funtoro.com
+
+INVERT
+img[src$="/logo.png"]
+img[src$="-logo.png"]
+img[src$="logo.svg"]
+img[src$="/logo-msi.png"]
+article#MSI_Support section.main-support div.card-content span.icon-style
+article#MSI_Support section.main-contact-support span.icon-style
+article#MSI_Support.Page_faq span.item-icon img
+article#MSI_Support img#faq_icon-image
+li[data-id="#lt-twitter"] svg
+img[src$="/HDMILogo_note.png"]
+div#msi-microsite-eps div.epsWhereToBuy__cardList img
+div#msi-microsite-eps div.epsPartners a img
+section.topheader a.topheader__toplogo img.logo__img
+main#Copilot-plus-PC-For-Commercial div.header-copilot-plus img
+main#Copilot-plus-PC-For-Commercial div.header-business-ready
+main#Windows-11-Pro div.header-windows11 img
+main#Windows-11-Pro div.header-what-s-your
+img[src$="/norton-icon.png"]
+article.support section.supportCard div.supportCard-icon img
+
+CSS
+html[data-darkreader-scheme="dark"] main#news_list figure.template__card__img img.card__img,
+html[data-darkreader-scheme="dark"] article#newslist div.tab-content#Exhibitions img {
+    background-color: white !important;
+}
+article#solutions section.industry :is(
+    .industry__kvTxtBox-title,
+    .industry__kvTxtBox-content,
+    .industry__kvTxtBox-list
+),
+div#msi-microsite-amr h1.baseBannerTitle,
+div.page:is(#ODMService, #Product_index) section.index-s4 div.txt-center *,
+div#msi-app section.businessSupportTitle div.baseBanner h1.baseBannerTitle,
+div#MSI-Center section#kv.block :is(h2, p),
+article#contact-us figure.kv-banner div.kv-text :is(h1, p),
+main.about header#msi-key-visual.kv div.kv__content h1 {
+    color: black !important;
+}
+
+================================
+
+*.myconnectwise.net
+
+CSS
+.cwsvg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+*.myworkday.com
+
+INVERT
+.WIF3
+.WIF3:hover
+.WIG3
+.WIG3:hover
+.WFD3 .WGL3
+.WAJS
+.WAJS:hover
+.WJG3
+.WHL3
+.WKFP
+
+================================
+
+*.palletsprojects.com
+
+CSS
+span.w {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+*.sapo.pt
+forum.pplware.com
+sapo.pt
+
+INVERT
+div.bsu-v4-sub-menu-splitter
+:is(div, h1).logo img[alt^="SAPO"]
+body:not(.home) header div.logo a[aria-label^="AutoSAPO"]
+footer div.logo a[aria-label^="AutoSAPO"]
+img[src$="/logo_vendaja_black.png"]
+img.img-logo[src^="https://avozdecastelobranco.sapo.pt"]
+body.wp-theme-zox-news div.mvp-fly-but-wrap span
+body.wp-theme-zox-news div.mvp-search-but-wrap span
+img[src$="/econtas-logo.png"]
+img[src$="/ED_LOGO-900x183.png"]
+img[src$="/ED_LOGO.png"]
+img[src$="/2016-logo-risco-cor.png"]
+img[src$="/AutoM-cor-1-no-bg.png"]
+img[src$="/E-goi-logo.png"]
+img[src$="/Beira-Alta-TV-2023-preto.png"]
+img.tie-logo-img[src^="https://diariodistrito.sapo.pt"]
+img[src$="/forever-young-logo-1.png"]
+img.logo[alt="Green eFact"]
+div.logo img[src^="https://estrelaseouricos.sapo.pt"]
+span[class$="-accordion-chevron"]
+span[class$="-accordion-icon"]
+div.toggle-header-search span
+a#mobile-menu-icon span.tie-mobile-menu-icon
+
+CSS
+svg#sapoLogo path:is([d^="M34.56"], [d^="M63.99"]),
+li.logo svg path:is([d^="M33.96"], [d^="M63.39"]) {
+    fill: #000000 !important;
+}
+html[data-darkreader-scheme="dark"] div#bsu-footer.bsu-footer-light a.bsu-footer-logo {
+    background-position: 0 -60px !important;
+}
+html[data-theme="dark"][data-darkreader-scheme="dark"] div#bsu-footer div.bsu-footer-text {
+    filter: none !important;
+}
+
+================================
+
+*.seoul.go.kr
+
+INVERT
+.h-logo
+.s-live-icon
+
+================================
+
+*.service-now.com
+
+INVERT
+.highcharts-legend-item text
+.palette-content.trees .tree_spacer
+.palette-content.trees img.tree
+.palette-content.trees img.wf-list-icon
+
+CSS
+.cm-s-snc span.cm-string {
+    color: #cf947b !important;
+}
+.cm-s-snc span.cm-def {
+    color: #60a4d8 !important;
+}
+.cm-s-snc span.cm-property {
+    color: white !important;
+}
+.cm-s-snc_readonly span.cm-string {
+    color: #cf947b !important;
+}
+#hierarchy-menu {
+    background-color: #797774 !important;
+}
+.sn-ng-bsm svg {
+    fill: #FFF !important;
+}
+.ui-refresh .btn-inline-form,
+.ui-refresh .btn-inline-form-attached {
+    background-color: #797774;
+}
+.node-outline {
+    fill: #797774 !important;
+}
+.sn-polaris-nav {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+.snf-collapsible-list-header {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+.sn-polaris-nav-list-items a.item-label .item-icon {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+.snf-collapsible-list-items,
+.snf-collapsible-list-items a {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+.sn-history-menu .menu-item > .menu-item-label > span.label {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+.sn-history-menu .menu-item > .menu-item-label > span.menu-item-description {
+    background-color: #000 !important;
+    color: #FFF !important;
+}
+div >  .sn-history-menu mark.filter-match,
+.sn-history-menu mark.filter-match-fuzzy {
+    color: #FFF !important;
+}
+div >  .sn-history-menu .is-filtered .label {
+    color: #FFF !important;
+}
+span.is-filtered .label {
+    color: #FFF !important;
+}
+.is-filtered .item-icon .label {
+    color: #FFF !important;
+}
+span > mark.filter-match,
+mark.filter-match-fuzzy {
+    color: #FFF !important;
+}
+.tox .tox-tbtn svg {
+    fill: #FFF !important;
+}
+.user-menu-label {
+    color: #FFF !important;
+}
+.sn-polaris-tab.is-active {
+    background-color: #000;
+    color: #fff !important;
+}
+.grid-container svg path {
+    fill: #000 !important;
+}
+
+================================
+
+*.speedtestcustom.com
+
+CSS
+.stroke-primary {
+    stroke: #003b5c !important;
+}
+.result-graph-svg {
+    fill: #003b5c !important;
+}
+
+================================
+
+*.tommy.com
+
+INVERT
+img[class*="Footer_SocialIcon"]
+
+================================
+
+*.visualcapitalist.com
+
+INVERT
+div.mvp-fly-but-wrap span
+div.mvp-search-but-wrap span
+img[src$="/DecarbChannel_LogoHeader_Mar8.png"]
+div#mvp-fly-menu-wrap img:is([src^="/wp-content/uploads/2021/03/Hamburger-Menu"], [src$="/DC-logo-flyout.png"])
+div.eltd-vertical-menu-area-inner div.eltd-logo-wrapper img
+
+================================
+
+*.webex.com
+
+CSS
+body {
+    background: var(--darkreader-neutral-background) !important;
+}
+.wxp-chapter-bar-item-progress {
+    background: var(--mds-color-decorative-violet-50) !important;
+}
+
+================================
+
+*.wvu.edu
+
+CSS
+.bg-dark {
+    background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--blue {
+    background-color: rgba(var(--bs-wvu-accent--blue-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--blue-dark {
+    background-color: rgba(var(--bs-wvu-accent--blue-dark-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--blue-light {
+    background-color: rgba(var(--bs-wvu-accent--blue-light-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--old-gold {
+    background-color: rgba(var(--bs-wvu-accent--old-gold-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--sunset {
+    background-color: rgba(var(--bs-wvu-accent--sunset-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-accent--yellow {
+    background-color: rgba(var(--bs-wvu-accent--yellow-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-blue {
+    background-color: rgba(var(--bs-wvu-blue-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-gold {
+    background-color: rgba(var(--bs-wvu-gold-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--cream {
+    background-color: rgba(var(--bs-wvu-neutral--cream-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--off-white {
+    background-color: rgba(var(--bs-wvu-neutral--off-white-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--warm-gray-dark {
+    background-color: rgba(var(--bs-wvu-neutral--warm-gray-dark-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--warm-gray-light {
+    background-color: rgba(var(--bs-wvu-neutral--warm-gray-light-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--warm-gray-medium {
+    background-color: rgba(var(--bs-wvu-neutral--warm-gray-medium-rgb), var(--bs-bg-opacity)) !important;
+}
+.bg-wvu-neutral--tan {
+    background-color: rgba(var(--bs-wvu-neutral--tan-rgb), var(--bs-bg-opacity)) !important;
+}
+.btn-outline-wvu-blue,
+.text-wvu-accent--blue,
+.text-wvu-accent--blue-dark,
+.text-wvu-accent--old-gold,
+.text-wvu-blue,
+.text-wvu-neutral--warm-gray-dark {
+    background-color: var(--bs-body-bg);
+}
+.text-wvu-accent--blue {
+    color: rgba(var(--bs-wvu-accent--blue-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-accent--blue-dark {
+    color: rgba(var(--bs-wvu-accent--blue-dark-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-accent--blue-light {
+    color: rgba(var(--bs-wvu-accent--blue-light-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-accent--old-gold {
+    color: rgba(var(--bs-wvu-accent--old-gold-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-accent--sunset {
+    color: rgba(var(--bs-wvu-accent--sunset-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-accent--yellow {
+    color: rgba(var(--bs-wvu-accent--yellow-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-blue {
+    color: rgba(var(--bs-wvu-blue-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-gold {
+    color: rgba(var(--bs-wvu-gold-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--cream {
+    color: rgba(var(--bs-wvu-neutral--cream-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--off-white {
+    color: rgba(var(--bs-wvu-neutral--off-white-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--warm-gray-dark {
+    color: rgba(var(--bs-wvu-neutral--warm-gray-dark-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--warm-gray-light {
+    color: rgba(var(--bs-wvu-neutral--warm-gray-light-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--warm-gray-medium {
+    color: rgba(var(--bs-wvu-neutral--warm-gray-medium-rgb), var(--bs-text-opacity)) !important;
+}
+.text-wvu-neutral--tan {
+    color: rgba(var(--bs-wvu-neutral--tan-rgb), var(--bs-text-opacity)) !important;
+}
+.wvu-overflow-hidden {
+    color: var(--bs-body-color);
+}
+
+================================
+
+01net.com
+
+CSS
+html,
+body {
+    color: ${#090702} !important;
+}
+
+================================
+
+10fastfingers.com
+
+CSS
+#speedtest-main .hide-time {
+    color: transparent !important;
+}
+#inputfield {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+body,
+.container-modified > .row,
+#practice-main,
+#top1000-index-container,
+#text-practice,
+#content-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+#main-content-trenner {
+    background: var(--darkreader-neutral-background) !important;
+    border-bottom: 1px solid rgb(151, 141, 127) !important;
+}
+
+================================
+
+10minutemail.com
+
+CSS
+#main_content {
+    background-image: none !important;
+}
+
+================================
+
+123-3d.nl
+123accu.nl
+123inkt.nl
+123led.nl
+123schoon.nl
+
+CSS
+.main-panel-left,
+.main-panel-right {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+123mathe.de
+
+INVERT
+.entry-content img
+
+CSS
+body,
+.post-inner,
+ul.sub-menu {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+ul.sub-menu::after {
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+.progress-wrap {
+    box-shadow: var(--darkreader-neutral-background) 0px 0px 0px 3px inset !important;
+}
+
+================================
+
+1337x.st
+1337x.to
+x1337x.eu
+x1337x.se
+x1337x.ws
+
+CSS
+.torrent-tabs .tab-nav {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+1917.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+1fichier.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+1password.community
+
+INVERT
+div[class*="NodeBannerWidget_lia-container-bg"]
+img[alt="Brand Logo"]
+
+CSS
+div[data-testid="HtmlCustomComponentContent"] * {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+2700chess.com
+
+IGNORE IMAGE ANALYSIS
+.cg-wrap piece.rook.black
+.cg-wrap piece.knight.black
+.cg-wrap piece.bishop.black
+.cg-wrap piece.queen.black
+.cg-wrap piece.king.black
+.cg-wrap piece.knight.black
+.cg-wrap piece.pawn.black
+
+================================
+
+2gis.*
+
+INVERT
+#map
+path[d^="M34.8"]
+._oow7vi
+path[d^="M15.759"]
+
+CSS
+a,
+abbr,
+acronym,
+address,
+applet,
+article,
+aside,
+audio,
+b,
+big,
+blockquote,
+body,
+canvas,
+caption,
+center,
+cite,
+code,
+dd,
+del,
+details,
+dfn,
+div,
+dl,
+dt,
+em,
+embed,
+fieldset,
+figcaption,
+figure,
+footer,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+header,
+hgroup,
+html,
+i,
+iframe,
+img,
+ins,
+kbd,
+label,
+legend,
+li,
+main,
+mark,
+menu,
+nav,
+object,
+ol,
+output,
+p,
+pre,
+q,
+ruby,
+s,
+samp,
+section,
+small,
+span,
+strike,
+strong,
+sub,
+summary,
+sup,
+table,
+tbody,
+td,
+tfoot,
+th,
+thead,
+time,
+tr,
+tt,
+u,
+ul,
+var,
+video {
+    color: var(--darkreader-neutral-text) !important;
+}
+div[style^="--bg-color"] {
+    --bg-color: var(--darkreader-neutral-background) !important;
+}
+div[style="transform:rotateX(0deg)"] > svg[width="38"] path {
+    fill: ${black} !important;
+}
+button[data-hamburger] span {
+    background-color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+a[href="/"] > svg *
+
+================================
+
+3.basecamp.com
+
+CSS
+body,
+.nav__main {
+    background-color: ${white};
+}
+@media screen and (min-width: 768px) {
+    .panel--perma,
+    .panel--project {
+        box-shadow: rgba(0, 0, 0, 0.05) 0px -1px 10px, rgba(0, 0, 0, 0.1) 0px 1px 4px, rgb(24, 26, 27) 0px 10px 30px;
+    }
+}
+
+================================
+
+300gospodarka.pl
+300polityka.pl
+
+INVERT
+#logo
+img[alt="300Gospodarka"]
+img[alt="Zespół 300Gospodarki"]
+
+================================
+
+338canada.com
+
+CSS
+svg text:not([fill]) {
+    fill: var(--darkreader-neutral-text);
+}
+
+================================
+
+350.org
+map.350.org
+
+INVERT
+.dark\:bg-gray-700
+.dark\:bg-gray-700::after
+.dark\:text-gray-300
+.mapboxgl-canvas
+.mapboxgl-ctrl-compass > .mapboxgl-ctrl-icon
+.mapboxgl-ctrl-logo
+.mapboxgl-marker
+
+CSS
+mapbox-search-box > input {
+    --darkreader-bg--boxShadow: 0 0 10px 2px ${rgba(0, 0, 0, 0.05)}, 0 0 6px 1px ${rgba(0, 0, 0, 0.1)}, 0 0 0 1px ${rgba(0, 0, 0, 0.1)} !important;
+}
+
+================================
+
+37.com
+
+INVERT
+.logo37
+
+================================
+
+3dmark.com
+
+INVERT
+.logo
+.similar-results > g > rect
+
+================================
+
+40ton.net
+
+INVERT
+.td-main-logo
+
+================================
+
+4t-niagara.com
+
+CSS
+.download_link > h3,
+.buy_link > h3 {
+    color: ${#88c1ff} !important;
+}
+.download_link li,
+.buy_link li {
+    color: ${white} !important;
+}
+
+================================
+
+9game.cn
+
+INVERT
+.logo9game
+
+================================
+
+a11ywithlindsey.com
+
+INVERT
+.logo
+
+CSS
+:root {
+    --off-white: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+aad.org
+
+INVERT
+.header-AAD-logo
+
+================================
+
+aaha.org
+
+CSS
+.wrap1 {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+abandonia.com
+
+CSS
+.alt1G2 {
+    background-image: none !important;
+}
+.alt2G2 {
+    background-image: none !important;
+}
+
+================================
+
+abc11.com
+
+CSS
+.kQjLe {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+abc7ny.com
+
+CSS
+.FITT_Article_main,
+#FITTArticle {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+abcnews.go.com
+
+INVERT
+.navLogo
+#sections
+#search
+#notifications
+
+================================
+
+abiturma.de
+
+INVERT
+div.formula
+amp-img.latex-inline
+img[src^="/assets/compiled-latex/"]
+
+================================
+
+ableton.com
+
+INVERT
+.main-nav__logo
+.main-footer__basics__logo
+.main-footer__secondary__signature__logo
+
+CSS
+.body-text--manual figure img {
+    background-color: #DCDAD8 !important;
+}
+
+================================
+
+about.flipboard.com
+
+INVERT
+img.site-header__logo--full
+
+================================
+
+about.gitlab.com
+
+INVERT
+div.customer-logos__companies a
+
+CSS
+.progressbar {
+    background: black;
+}
+
+================================
+
+academic.oup.com
+
+INVERT
+img.oup-header-image[alt="Oxford Academic"]
+img.journal-footer-logo[alt="Oxford University Press"]
+img.society-logo[alt="American Medical Informatics Association"]
+img.society-logo[alt="GigaScience Press"]
+img.society-logo[alt="International Biometric Society"]
+img.society-logo[alt="Japan Society for Occupational Health"]
+img.society-logo[alt="Oxford"]
+img.society-logo[src$="_h1-965359043.svg"][alt$="Royal Statistical Society"]
+img.journal-logo[alt="Biometrics"]
+img.journal-logo[alt="Biometrika"]
+img.journal-logo[alt="GigaScience"]
+img.journal-logo[alt="Journal of Occupational Health"]
+img.journal-logo[alt="Journal of Petrology"]
+img.journal-logo[alt^="Journal of the American Medical Informatics Association"]
+img.journal-logo[alt^="Journal of the Royal Statistical Society"]
+img.journal-logo[alt="Oxford Academic Journals"]
+img.journal-logo[alt="Significance"]
+img.journal-logo[alt="Transactions of Mathematics and Its Applications"]
+img.journal-footer-affiliations-logo[alt="Biometrics"]
+img.journal-footer-affiliations-logo[alt="Biometrika"]
+img.journal-footer-affiliations-logo[alt="GigaScience"]
+img.journal-footer-affiliations-logo[alt="Journal of Occupational Health"]
+img.journal-footer-affiliations-logo[alt="Journal of Petrology"]
+img.journal-footer-affiliations-logo[alt^="Journal of the American Medical Informatics Association"]
+img.journal-footer-affiliations-logo[alt^="Journal of the Royal Statistical Society Series D"]
+a.society-links-logo > img
+ul.listOfImagesWithLabels div.imageContainer img
+div.informationRowHead img.informationLogo
+div.siteMainName img[alt="Oxford University Press"]
+img.chat-input-logo[alt="Oxford University Press"]
+svg.information-svg-icon path.inner-shape
+
+================================
+
+academy.abeka.com
+
+INVERT
+.logo img
+.center-align img
+
+================================
+
+academy.dqlab.id
+
+INVERT
+.menu img
+
+================================
+
+access.ing.de
+
+CSS
+.tile__info {
+    background-color: #fff !important;
+}
+
+================================
+
+access.the-scientist.com
+
+INVERT
+div.logo-container svg
+
+================================
+
+access.wgu.edu
+my.wgu.edu
+
+INVERT
+img[alt="WGU Logo"]
+.nav-hamburger
+
+================================
+
+accessiblepalette.com
+
+INVERT
+.swatch .hex
+
+IGNORE INLINE STYLE
+.swatch
+
+================================
+
+accesswire.com
+
+INVERT
+.v2-nav-logo
+
+================================
+
+account.live.com
+
+INVERT
+.ms-Grid-col.ms-sm8.ms-lg4
+.ms-Grid-col.ms-sm4.ms-hiddenMdDown.pullout-textwrap
+.ms-Grid-col.ms-sm2 img
+.pullout-link-text
+.pullout-icon:not(.ms-Icon--SkypeCircleCheck)
+.pullout-textwrap span
+
+CSS
+img[class="ShowMoreLoading"] {
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important;
+}
+
+================================
+
+account.microsoft.com/profile
+
+INVERT
+.ms-StackItem div div img[src*="svg?n"]
+
+================================
+
+account.orchid.com
+
+INVERT
+.walletconnect-qrcode__image
+
+================================
+
+account.proton.me
+account.protonvpn.com
+
+CSS
+.qr-code {
+    border: 5px solid white !important;
+}
+
+IGNORE INLINE STYLE
+.logo *
+.qr-code *
+
+================================
+
+account.ui.com
+
+CSS
+div[class^="Toggle-module_switcher"] {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+input[class^="Toggle-module_input"] {
+    background-color: initial;
+}
+div[class^="Modal-module_content"] form > div > canvas {
+    border: 5px solid white !important;
+}
+
+================================
+
+account.xiaomi.com
+
+CSS
+.mi-profile-layout__profile {
+    background-image: none !important;
+}
+
+================================
+
+accounts.fedoraproject.org
+
+INVERT
+.navbar-brand
+
+================================
+
+accounts.google.com
+
+INVERT
+img[src$="signin_tapyes.gif"]
+
+CSS
+#countryList div[role="option"][data-value] > div > div > div[style] {
+    background-image: url('//ssl.gstatic.com/i18n/flags/48x32/nobevel/66bdb7a1bbbdbf86a67de382fac49ecc/flags.png') !important;
+}
+
+================================
+
+accounts.hetzner.com
+dns.hetzner.com
+konsoleh.hetzner.com
+robot.hetzner.com
+
+INVERT
+.top-bar-link > img
+.d-flex > img
+#panel_dropdown_btn > img
+#user_dropdown_btn > img
+
+================================
+
+accounts.spotify.com
+
+INVERT
+.spotify-logo
+
+================================
+
+accounts.zoho.com
+
+INVERT
+div#product_img.tfa_totp_mode
+span.zoho_logo
+.zwHDots
+
+================================
+
+accuweather.com
+
+INVERT
+.allergy-icon
+.icon-search
+img[src$="arrow-right-black.svg"]
+
+CSS
+.today-label,
+.y-axis-label,
+.x-axis-day-label,
+.x-axis-month-label {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+acer.com
+
+INVERT
+.firstHeader .logos
+
+CSS
+.contSectionBen img {
+    filter: brightness(50%) sepia(40%) !important;
+}
+.contSectionBen .textOverBen {
+    position: inherit !important;
+}
+
+================================
+
+acmicpc.net
+
+INVERT
+.cm-s-lucario.CodeMirror
+
+================================
+
+aconvert.com
+
+CSS
+.css-checkbox input + span::after {
+    color: transparent !important;
+}
+
+================================
+
+acorn.utoronto.ca
+
+CSS
+.acorn-classic.page-container .academic-history .sessionHeader,
+.acorn-classic.page-container .academic-history .credit-earned-section,
+.acorn-classic.page-container .academic-history .average-section,
+.acorn-classic.page-container .academic-history .courses,
+.acorn-classic.page-container .academic-history .coursesHeader,
+.acorn-classic.page-container .academic-history .academic-history-report .gpa-listing,
+.acorn-classic.page-container .academic-history-recent table .emph {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+act.dsausa.org
+
+INVERT
+.dsa-sibd-logo
+.text--centered > .pure-img
+
+CSS
+.ak-page-header {
+    background-color: #ec1f27 !important;
+}
+
+================================
+
+action.com
+
+CSS
+.bg-black {
+    background-color: transparent !important;
+}
+
+================================
+
+actioncardapp.com
+
+INVERT
+.logo
+
+================================
+
+ad.nl
+
+CSS
+.instanews-page-main-content {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+ada.org
+
+INVERT
+.logo
+
+================================
+
+adata.com
+
+INVERT
+.logo-nav
+
+================================
+
+addic7ed.com
+
+INVERT
+.tablecorner img
+
+CSS
+.NewsTitle {
+    background-color: rgb(0, 62, 81);
+}
+.language {
+    background-color: rgba(7, 73, 89);
+}
+
+================================
+
+addons.mozilla.org
+
+INVERT
+div[class="Rating Rating--small"]
+img.SecondaryHero-module-icon
+
+IGNORE IMAGE ANALYSIS
+.Icon-youtube
+span.Permission-description::before
+
+================================
+
+adguard-dns.io
+
+INVERT
+.animation__video
+.footer__logo
+.header__logo
+.map__point-icon
+.map__point-city
+.servers-info__queries
+
+CSS
+.animation__video {
+    z-index: 0 !important;
+}
+.map__point-city,
+.servers-info__map {
+    filter: invert(1) hue-rotate(120deg) brightness(250%) !important;
+}
+
+================================
+
+adguard-vpn.com
+
+INVERT
+.header__logo
+
+================================
+
+adguard.com
+
+INVERT
+a.header__logo
+svg.reviews__icon-topic
+.article__section--list-ico .md__list .md__img
+.article__content--title-ico .article__section .md__title .md__img
+.p-header-logo.p-header-logo--image img
+.icon--gray-chrome
+.icon--gray-edge
+.icon--gray-opera
+.icon--gray-firefox
+
+IGNORE IMAGE ANALYSIS
+.icon--gray-opera
+.icon--gray-firefox
+
+================================
+
+admin.google.com
+
+INVERT
+.qV6brd img
+
+================================
+
+admin.migadu.com
+
+CSS
+.container {
+    background-image: none !important;
+}
+
+================================
+
+admin.shopify.com
+
+CSS
+.variant-auto {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.variant-secondary {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.level-1 {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.banner {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+aeroin.net
+
+INVERT
+img.tdb-logo-img
+
+================================
+
+afterpay.com
+
+INVERT
+div[class^="navigation_logo"]
+
+================================
+
+aftership.com
+
+CSS
+#sapper div.multi-track-input {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+aftonbladet.se
+
+CSS
+a[href$="plus_plusikon"] > :nth-child(1) {
+    color: ${white};
+}
+
+================================
+
+agroclima.ipma.pt
+
+INVERT
+a.navbar-brand img
+div.col-auto img
+
+================================
+
+ai2.appinventor.mit.edu
+
+CSS
+.blocklyDraggable text {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+aiming.pro
+
+INVERT
+#left_side_bar > div.logo > a > img
+
+================================
+
+airbnb.*
+airbnb.*.*
+
+INVERT
+input[name="categoryScroller"] + div img
+
+CSS
+.atm_26_qvc13o {
+    background-image: none !important;
+}
+
+================================
+
+aistudio.google.com
+
+CSS
+:root .light-theme {
+    color-scheme: light !important;
+}
+[data-darkreader-scheme="dark"] .light-theme {
+    color-scheme: dark !important;
+}
+
+================================
+
+akademy.kde.org
+edu.kde.org
+dot.kde.org
+forum.kde.org
+
+CSS
+body,
+#footer {
+    background: ${rgb(225, 227, 228)} !important;
+}
+
+================================
+
+akasa.com
+
+INVERT
+.logo
+
+================================
+
+akcemed.pl
+
+INVERT
+.td-main-menu-logo
+.footer-logo-wrap
+
+================================
+
+akinator.com
+
+INVERT
+.bubble
+.bubble-body
+
+CSS
+.bubble {
+    background-color: ${black} !important;
+    color: ${white} !important;
+}
+.bubble-body {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+.question-number {
+    color: ${white} !important;
+}
+
+================================
+
+alamy.com
+
+CSS
+.bg-opacity-0 {
+    background-color: transparent !important;
+}
+
+================================
+
+aldi.us
+
+IGNORE INLINE STYLE
+.company-logo-content *
+
+================================
+
+alertus.com
+
+INVERT
+.Header-branding
+[src^="https://images.squarespace-cdn.com"]
+
+================================
+
+alexpage.de
+
+CSS
+#page {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+alfies.at
+
+CSS
+[class*="searchbox"] * {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+alfredapp.com
+
+INVERT
+[src*="macworld.png"]
+[src*="tuaw.png"]
+[src*="eddy_awards.png"]
+[src*="appstorm.png"]
+[src*="tnw.png"]
+[src*="search.jpg"]
+[src*="clipboard.jpg"]
+[src*="control.jpg"]
+[src*="konami-code.png"]
+[src*="oatmeal404.jpg"]
+[src*="query-history.png"]
+
+================================
+
+alibaba.com
+
+CSS
+.gallery-card {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+aliexpress.*
+aliexpress.*.*
+*.aliexpress.*
+
+INVERT
+.group-title-img
+.EYoOU
+path[d^="M0 4C0"]
+.rax-text-v2.AIC-PI-MobPriceText.rax-text-v2--overflow-hidden.rax-text-v2--singleline
+
+CSS
+a[class^="SnowOrderDetails_Product__imageWrap"],
+div[class^="SnowOrderList_ProductImage__imageWrapper"],
+a[class^="RedOrderDetailsProductsV2_Product__imageWrap"],
+div[class^="RedOrderList_ProductImage__imageWrapper"] {
+    background-color: #fff !important;
+}
+.comet-icon[class*="rating--top"] {
+    color: ${yellow} !important;
+}
+._2E4Wz {
+    background-color: ${yellow} !important;
+}
+.group-title-ctn {
+    background: var(--darkreader-neutral-backgroun) !important;
+}
+
+IGNORE INLINE STYLE
+svg[class^="ali-kit_Rating__star"]
+
+================================
+
+alipay.com
+
+INVERT
+#J_logoHomeUrl
+.global-logo
+
+CSS
+.qrcode-detail-img {
+    background-color: white !important;
+}
+.authcenter-background {
+    z-index: 0 !important;
+}
+.authcenter-head,
+.authcenter-foot,
+.authcenter-body-login,
+.authcenter-body-logo > a {
+    z-index: 1 !important;
+}
+
+================================
+
+aljazeera.com
+
+INVERT
+#site-logo > img
+.navbar-brand > img
+#navbar-hamburger-mobile
+
+================================
+
+all-ett.com
+
+INVERT
+img[class="header__logo-image"]
+
+CSS
+.color-scheme {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.article__wrapper {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+allconnect.com
+
+INVERT
+.mininav-header__logo-image
+
+================================
+
+allegrolokalnie.pl
+
+INVERT
+.mlc-masthead__branding
+.mlc-site-footer__branding
+
+================================
+
+allelitewrestling.com
+
+CSS
+div[data-testid^="svgRoot-comp-"] {
+    fill: var(--corvid-fill-color,var(--fill)) !important;
+}
+
+================================
+
+allestoringen.*
+downdetector.*
+downdetector.*.*
+xn--allestrungen-9ib.*
+
+INVERT
+#map_container
+#map-card
+
+================================
+
+allmacworld.com
+
+INVERT
+.logo
+.tie-appear.post-thumbnail
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/blocs-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/waves-v11-complete-download-free/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/3dequalizer-4-for-mac-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/sylenth1-for-mac-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/synapse-audio-legend-free-download/"]
+
+================================
+
+allrecipes.com
+
+INVERT
+.checkbox-list-checkmark::before
+.external-link-icon
+.icon-ellipsis > svg
+.icon-email-outline
+.icon-search
+.icon-share-favorite
+.rating-bar-wrapper
+img[src="/img/profile.png"]
+.mntl-header__close-icon
+.mntl-header__menu-icon
+.mntl-header__nav-panel-close-icon
+
+================================
+
+allspice.io
+
+INVERT
+[data-mesh-id="SITE_HEADERinlineContent"] img
+
+================================
+
+alphacoders.com
+
+INVERT
+.main
+.main > *
+#page_header
+#page_header > *
+
+================================
+
+alphashooters.com
+
+CSS
+.site-container {
+    --darkreader-bg--site-container-background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+alt.hololive.tv
+
+INVERT
+video[src*="bg.mp4"]
+video[src*="first.mp4"]
+img[src*="logo_2line_gradient_color.svg"]
+svg
+
+================================
+
+altlinux.org
+
+INVERT
+.mw-wiki-logo
+
+================================
+
+alza.*
+m.alza.*
+
+CSS
+:root {
+    --darkreader-neutral-background: ${#ebe3d5};
+    --darkreader-neutral-text: ${#1a1b1a};
+}
+#boxc .box,
+.detail-page {
+    background: linear-gradient(180deg, ${#f5f5f5} 0,${#fff} 20px) !important;
+}
+footer {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+.titleValue,
+#boxc .box a.name,
+#boxc .box div.Description,
+#boxc .box .box-gbb-rating__text span {
+    color: var(--darkreader-neutral-text) !important;
+}
+#tabs ul > li a {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+amalgamatedbank.com
+
+CSS
+.page-banner .banner-image {
+    z-index: auto !important;
+}
+
+================================
+
+amap.com
+
+INVERT
+.amap-info
+.amap-menu
+.imgfeed[style*="place_default.jpg"]
+.logo-img
+#subway-svg
+#themap
+.title01-logo > a > img
+
+================================
+
+amazingmarvin.com
+
+INVERT
+.header-title
+
+================================
+
+amazon.*
+amazon.*.*
+
+INVERT
+#banner-image
+#ordersContainer .a-box.order-attributes img
+div.a-section.vse-lb-video-metadata
+div.vse-video-content
+div.vse-video-title
+div.vse-video-labels
+i.a-icon-search
+img[src*="smile-logo"]
+img[src*="full_bleed_pin"]
+img[src*="heart-off"]
+img[src*="search"]
+img[src*="vector_bold"]
+.a-icon-arrow.a-icon-small.arrow-icon
+.a-icon-close
+.a-icon-extender-expand
+.a-icon-next
+.a-icon-popover
+.a-icon-previous
+.a-icon-section-collapse
+.a-icon-section-expand
+.a-link-nav-icon
+.currencyINR
+.ssf-share-trigger:not(.a-button)
+.utility-bar-icon
+.a-icon-small-add
+.a-icon-small-remove
+.a-icon-small-trash
+.navFooterLine.navFooterLogoLine > a > img
+._recommendation-cards_style_bnp-card-icon__3_OCs
+.bnp-feature-card-description-row > div > img
+._YWItY_bnp-card-icon_T0dX_
+.card-icon
+.b-item .b-flex img
+#nav-bell
+#nav-search-submit-text.nav-sprite
+div.lists-desktop-rio-icons
+img.switcher-img
+#ab-nav-checkout-popover-dropdown-container
+#ab-nav-checkout-cart-count-container
+img.left-nav-heading
+#ure-list-actions-popover > img
+#grid-view-switcher > img
+#list-view-switcher > img
+i.a-icon.a-icon-collapse
+i.a-icon.a-icon-expand
+img.aok-align-center.aok-inline-block.overflow-menu-center-dot
+img[src*="amazon_pay.png"]
+.benefit-list-item .benefit-icon-container img
+#plans-compare-table img
+i.a-icon-dropdown
+
+CSS
+.banner-border {
+    background-color: ${white} !important;
+    background-image: none !important;
+}
+div.milestone.notReached .milestone-marker::before {
+    border-color: var(--darkreader-neutral-text);
+}
+span.milestone-bar {
+    z-index: 0;
+}
+span.milestone-bar_foreground {
+    background-color: #4DC2B4;
+}
+span.milestone-bar_background {
+    background-image: linear-gradient(var(--darkreader-neutral-text) 40%, #181a1b00 0px);
+}
+[class*="image-display"],
+[class*="imageDisplay"],
+.a-image-container img,
+.a-list-item img,
+.a-section img,
+.a-section,
+[class*="imageContainer"] img,
+[class*="productImageContainer"] *,
+[data-pf=DESKTOP] [class*="img"] *,
+[class*="ryp__review-candidate-new__product-image"],
+[class*="VariationOptionItem__swatchImageOverlay"] {
+    mix-blend-mode: unset !important;
+}
+.bg-no-repeat .color-squid-ink-dark {
+    color: #161e2d !important;
+}
+.abn-desktop-footer-app-qr > img {
+    background-color: white !important;
+}
+#pickupInformation-container img {
+    border: 20px solid white !important;
+}
+.dv-player-fullscreen > div:nth-child(1) {
+    background-color: black !important;
+}
+.b-list-group > .b-item {
+    background: transparent !important;
+}
+#febd69 {
+    background-color: #febd69 !important;
+}
+#quick-view-container ul.a-pagination.a-dots li.a-selected {
+    background-color: ${#007185} !important;
+}
+.nav-arrow {
+    border-top-color: #a7acb2 !important;
+}
+[class*="VariationOptionItem__swatchImageOverlay"] {
+    background-color: transparent !important;
+}
+div.a-section.maple_ab_module1 * {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+IGNORE INLINE STYLE
+.s-color-swatch-inner-circle-fill
+
+================================
+
+americanas.com.br
+
+CSS
+img[class*="LazyImage"] {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+ametek.com
+
+INVERT
+.ametek_logo
+
+================================
+
+amfam.com
+
+INVERT
+.SiteHeader__logo-img
+
+================================
+
+amtrak.com
+
+INVERT
+.am-simple-dropdown__control-caret
+.farefinder-dash
+img[alt="Click to add the number travelers and discount types"]
+img[alt="Close"]
+img[alt="More information about accessible travel requests."]
+img[alt="Open"]
+img[alt="Passenger"]
+img[alt="Passenger Types and Discounts"]
+img[alt="Plus Icon"]
+img[alt="Switch departure and arrival stations."]
+.mat-checkbox-ripple::before
+
+CSS
+.hero-banner-and-slides .full-width-img,
+.hero-banner-and-slides .hero-banners__img-container {
+    z-index: auto !important;
+}
+.promocode-input,
+.value {
+    background-color: inherit !important;
+}
+
+================================
+
+amys.com
+
+CSS
+.body-with-illustration.pp,
+.contact-us-footer.pp,
+.dealer-link.pp,
+.dealer-search.footer-strip.pp,
+.featured-jobs.pp,
+.featured-product.pp,
+.love-letters-feedback.pp,
+.social-media-feed.pp .posts a.twitter,
+.social-media-feed.pp ul.juicer-feed .feed-item.j-twitter,
+.social-media-feed.pp ul.juicer-feed li.placeholder.j-twitter,
+.subscribe.pp,
+.template-product .related-products.pp,
+.two-col-images-detailed.pp,
+header.main-head,
+.pick-patty.pp.body-with-illustration::after,
+.template-campaign-page .slideshow.pp::before,
+.template-campaign-page .testimonials.pp::before,
+.three-image-cta.pp.body-with-illustration::after,
+header.main-head .inner::after,
+nav.main-nav ul.children,
+.latest-news.pp h2,
+.latest-news.pp > span.herb {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+
+================================
+
+androidauthority.com
+
+INVERT
+header > a > svg
+header > div > button > svg
+footer > div > div > a > svg
+
+CSS
+footer {
+    background-image: none !important;
+}
+
+================================
+
+androidcentral.com
+
+INVERT
+.site-logo
+
+CSS
+.lazy-loaded {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+androidpolice.com
+
+INVERT
+.header-logo svg
+
+================================
+
+ang.pl
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+angrymetalguy.com
+
+INVERT
+.plbrand
+
+CSS
+.thepage {
+    background-color: ${white} !important;
+}
+.content-pad {
+    background-color: ${white} !important;
+}
+
+================================
+
+anibrain.ai
+
+IGNORE INLINE STYLE
+div[class^="style__HexagonDiv"] *
+svg[class^="styles__SvgWithShadow"] *
+
+================================
+
+anilibria.tv
+
+CSS
+#oframeanilibriaPlayer pjsdiv:nth-child(12) pjsdiv:nth-child(2) pjsdiv,
+#oframeanilibriaPlayer pjsdiv:nth-child(14) pjsdiv:nth-child(2) pjsdiv {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+anilist.co
+
+CSS
+:root {
+    --color-background: 39,44,56 !important;
+    --color-foreground: 31,35,45 !important;
+    --color-foreground-blue: 25,29,38 !important;
+    --color-foreground-blue-dark: 19,23,29 !important;
+    --color-foreground-grey: 25,29,38 !important;
+    --color-foreground-grey-dark: 16,20,25 !important;
+    --color-text: 159,173,189 !important;
+    --color-text-light: 129,140,153 !important;
+    --color-text-lighter: 133,150,165 !important;
+}
+
+================================
+
+ankiweb.net
+
+CSS
+.sidebar {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+anon-co-eu.com
+
+INVERT
+img[alt="Anon-Co Radios Europe"]
+
+================================
+
+anon-co.com
+
+INVERT
+img[alt="Anon-Co"]
+
+================================
+
+answers.opencv.org
+
+CSS
+#header,
+body,
+#question-list,
+.short-summary,
+#ground {
+    background-image: none !important;
+}
+
+================================
+
+answers.unity.com
+
+IGNORE IMAGE ANALYSIS
+header.section-header div.shard::before
+
+================================
+
+ant.design
+
+INVERT
+html[data-prefers-color="light"] .code-expand-icon
+
+================================
+
+antagning.se
+
+INVERT
+.a-logo
+.burger
+.uhrlogo
+.expand-icon
+.favourite-active
+
+CSS
+select {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+antistorm.eu
+
+INVERT
+#map-area
+#map-controls-area
+#controlPlayPauseIcon
+#meteogram_temperature
+#meteogram_dewPoint
+#meteogram_cloudCover
+#meteogram_precipitation
+#meteogram_precipitationProbability
+#meteogram_pressure
+#meteogram_windSpeed
+img[src*="data:image/png;base64,iVBORw"]
+
+================================
+
+antywirus-nod32.pl
+
+CSS
+.module.infolinia {
+    background-image: none !important;
+}
+
+================================
+
+anytype.io
+
+IGNORE IMAGE ANALYSIS
+.img.home
+
+================================
+
+aol.com
+
+INVERT
+.logo
+
+================================
+
+aosc.io
+
+INVERT
+img[alt="logo"]
+article.leading-6 img
+
+CSS
+#app > div {
+    background-image: none !important;
+}
+
+================================
+
+aosogrenci.anadolu.edu.tr
+
+CSS
+.welcome {
+    background-image: none !important;
+}
+
+================================
+
+apartmentlist.com
+
+INVERT
+div[class*="LogoContainer"]
+div[class*="MenuButton"]
+
+================================
+
+apartments.com
+
+INVERT
+.logo
+
+================================
+
+apclassroom.collegeboard.org
+
+INVERT
+.overview-icon svg
+.Zoom--expander svg
+svg.icon--xmark
+.RI_header__button svg.svg-icon
+
+CSS
+.standalone_image img {
+    background-color: white;
+}
+.lrn .dap_inline,
+.lrn .lrn.lrn_widget pre {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+api.kde.org
+
+INVERT
+.center
+.image
+
+CSS
+.memdoc,
+.memproto {
+    background-image: initial !important;
+}
+
+================================
+
+api.rubyonrails.org
+
+CSS
+div.tree > ul > li {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+apidocs.snyk.io
+
+INVERT
+#api-docs
+
+================================
+
+apie.lrt.lt
+
+INVERT
+img[alt="LRT"]
+button[class^="Burger_burger"]
+
+================================
+
+apkpure.com
+
+INVERT
+img[src$="gp_logo.png"]
+
+================================
+
+apnews.com
+
+INVERT
+.hamburger-box
+.sticky-part > div svg
+.LeftRail > div svg
+.Banner
+.Banner-link
+
+================================
+
+apolloautomation.com
+
+INVERT
+button.pd-floating-icon__open > img
+div.rating
+
+CSS
+.chat-toggle > svg > path {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+app.betrybe.com
+
+INVERT
+section.quiz-result__template summary
+section.quiz-result__template summary .block-code
+
+CSS
+.home-projects details,
+.header button,
+.header a,
+.module-index-content {
+    background-color: transparent !important;
+}
+.header button:hover,
+.header a:hover,
+.module-index-content summary:active,
+.quiz-question label {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.quiz-question label p {
+    color: rgb(180, 200, 255) !important;
+}
+.quiz-question__alternatives label:hover,
+.quiz-question__alternatives input[type=radio]:checked + label {
+    background: initial !important;
+}
+
+================================
+
+app.circleci.com
+
+INVERT
+div[role="button"] svg[viewBox="0 0 300 100"]
+
+================================
+
+app.codesignal.com
+
+CSS
+.monaco-editor .cursor {
+    background-color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+app.corellium.com
+
+INVERT
+.brand
+.logo
+
+================================
+
+app.crowdmark.com
+
+CSS
+.grading-e-icon-button {
+    mix-blend-mode: normal;
+}
+
+================================
+
+app.daily.dev
+
+IGNORE INLINE STYLE
+.h-logo *
+
+================================
+
+app.datadoghq.com
+
+INVERT
+.HostMap-canvas
+
+CSS
+.log-dt-event.active,
+.log-dt-event.active:hover,
+.log-dt-event:hover {
+    background-color: rgb(37, 45, 58) !important;
+}
+svg text.time_cursor {
+    fill: ${black} !important;
+}
+
+================================
+
+app.element.io
+element.4d2.org
+element.sibnsk.net
+
+INVERT
+.cpd-theme-light .mx_NotificationBadge
+.cpd-theme-light .mx_ReplyPreview_header_cancel
+.cpd-theme-light .mx_RoomTile_menuButton::before
+.cpd-theme-light .mx_IconizedContextMenu_icon::before
+.cpd-theme-light .mx_RoomTile_notificationsButton::before
+.cpd-theme-light .mx_RoomTile_notificationsButton_show::before
+
+CSS
+.cpd-theme-dark .mx_NotificationBadge,
+.cpd-theme-dark .mx_ReplyPreview_header_cancel,
+.cpd-theme-dark .mx_RoomTile_menuButton::before,
+.cpd-theme-dark .mx_IconizedContextMenu_icon::before,
+.cpd-theme-dark .mx_RoomTile_notificationsButton::before,
+.cpd-theme-dark .mx_RoomTile_notificationsButton_show::before {
+    background: var(--cpd-color-icon-primary) !important;
+}
+.cpd-theme-dark .mx_MessageContextMenu_iconRedact::before {
+    background: var(--cpd-color-icon-critical-primary) !important;
+}
+.cpd-theme-dark .mx_AccessibleButton.mx_NotificationBadge {
+    background-clip: padding-box !important;
+    border: 3px solid rgba(38, 39, 43, 0.82) !important;
+}
+.cpd-theme-dark .mx_EventTile[data-layout="group"].mx_EventTile_selected > .mx_EventTile_line {
+    background-color: var(--cpd-color-bg-subtle-secondary);
+    box-shadow: rgb(235, 238, 242) 54px 0px 0px -50px inset;
+}
+.cpd-theme-dark .mx_ReplyChain {
+    border-left: 2px solid var(--username-color);
+}
+.cpd-theme-dark .mx_UserMenu,
+.cpd-theme-dark .mx_RoomHeader,
+.cpd-theme-dark .mx_TimelineSeparator > hr,
+.cpd-theme-dark .mx_LeftPanel_filterContainer {
+    border-bottom: 1px solid var(--cpd-color-gray-400) !important;
+}
+.cpd-theme-dark .mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle {
+    background-color: var(--cpd-color-text-primary) !important;
+}
+.cpd-theme-dark .mx_RoomSearch,
+.cpd-theme-dark .mx_RoomTile:hover,
+.cpd-theme-dark .mx_SpaceButton_icon,
+.cpd-theme-dark .mx_LeftPanel_exploreButton,
+.cpd-theme-dark .mx_RoomListHeader_plusButton,
+.cpd-theme-dark .mx_RoomTile.mx_RoomTile_selected {
+    background-color: var(--cpd-color-alpha-gray-300) !important;
+}
+.cpd-theme-dark .mx_SpaceButton_icon::before {
+    background-color: var(--cpd-color-text-secondary) !important;
+}
+.cpd-theme-dark .mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow .mx_SpaceButton_selectionWrapper {
+    border: 3px solid var(--cpd-color-icon-primary) !important;
+}
+.cpd-theme-dark .mx_IconizedContextMenu .mx_IconizedContextMenu_optionList:nth-child(n+2) {
+    border-top: var(--cpd-border-width-1) solid var(--cpd-color-gray-400);
+}
+.cpd-theme-dark .mx_ContextualMenu {
+    border: var(--cpd-border-width-1) solid var(--cpd-color-border-interactive-secondary);
+}
+.cpd-theme-dark .mx_Verified {
+    color: var(--cpd-color-icon-success-primary);
+}
+.cpd-theme-dark .mx_RightPanel {
+    border-left: 1px solid var(--cpd-color-gray-400);
+}
+
+================================
+
+app.estuda.com
+
+INVERT
+img[src*="latex"]
+
+================================
+
+app.getport.io
+
+CSS
+.ring-solid-gray-200 {
+    --tw-ring-color: var(--darkreader-selection-text) !important;
+    --tw-ring-opacity: 1;
+}
+.ring-1 {
+    box-shadow: var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 --darkreader-selection-text) !important;
+}
+
+================================
+
+app.grammarly.com
+
+CSS
+use.valueCircle_f6otssy {
+    stroke: url(#pb-gradient-0);
+}
+:root {
+    --highlight-bg: ${rgba(0, 0, 0, 0.2)};
+}
+.alerts-clarity {
+    --highlight-bg: ${rgba(57, 93, 207, 0.2)};
+}
+.alerts-engagement {
+    --highlight-bg: ${rgba(29, 203, 162, 0.2)};
+}
+.alerts-correctness {
+    --highlight-bg: ${rgba(255, 69, 103, 0.2)};
+}
+.alerts-delivery {
+    --highlight-bg: ${rgba(124, 58, 172, 0.2)};
+}
+[class*="-alerts-markSelectedHigh"],
+span[class*="markSelectedFocused"] {
+    background-color: var(--highlight-bg) !important;
+}
+[class*="-navigation-counterWrapper"] [class*="-navigation-counterContent"],
+[class*="-paidview-counter"] [class*="-paidview-counterContent"] {
+    fill: rgb(0, 0, 0, .9);
+}
+
+IGNORE INLINE STYLE
+use[class*="valueCircle_"]
+
+================================
+
+app.intercom.com
+
+CSS
+.embercom-prosemirror-composer-callout[style*="background-color: #e8e8e880"] {
+    background-color: ${#e8e8e880} !important;
+}
+.embercom-prosemirror-composer-callout[style*="border-color: #73737633"] {
+    border-color: ${#73737633} !important;
+}
+
+IGNORE INLINE STYLE
+.embercom-prosemirror-composer-callout
+
+================================
+
+app.kognity.com
+
+INVERT
+img.KogCalculator
+.content-image-figure > img[src*="png"]
+
+CSS
+body,
+.KogDashboard-insideLoader {
+    background: none var(--darkreader-neutral-background) !important;
+}
+img:not([src*="png"]):not([src*="svg"]) {
+    background-color: white !important;
+}
+
+================================
+
+app.misaka.io
+
+INVERT
+.login-cover
+img[alt="logo"]
+
+================================
+
+app.mysms.com
+
+CSS
+.message a {
+    color: grey;
+}
+
+================================
+
+app.roll20.net
+
+INVERT
+.sheet-hp
+.sheet-ac
+.sheet-textbox
+.sheet-name-container
+.sheet-attributes-container
+.sheet-attr-container button
+.sheet-hlabel-container
+.sheet-vitals
+.sheet-init button
+.sheet-spell-level
+.sheet-spell-level input
+.sheet-textbox .sheet-options
+.sheet-speed input
+.sheet-part select
+.sheet-resources .sheet-subcontainer
+.sheet-resources .sheet-label
+.sheet-subcontainer .sheet-top
+.sheet-textbox .sheet-label
+.sheet-attack .sheet-options
+
+CSS
+.sheet-attributes-container,
+.sheet-init,
+.sheet-speed,
+.sheet-trait,
+.sheet-part,
+.sheet-spell-level,
+.sheet-details {
+    color: ${white} !important;
+}
+
+================================
+
+app.standardnotes.org
+
+INVERT
+[aria-label="Challenge modal"] > svg > circle:first-child
+input[id^="react-tag-"]
+
+CSS
+search-options svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+search-options svg
+
+================================
+
+app.tandem.net
+
+INVERT
+img[src="/static/icons/apple.svg"]
+[data-tip-id=LanguageLevelIndicator] button div span
+
+CSS
+div[class*="styles_qrCode"] {
+    background-color: white !important;
+}
+
+================================
+
+app.timelyapp.com
+
+INVERT
+.Clock__clock_css_icon___LfBr6
+.Clock__stopwatch___2G-CB
+
+CSS
+.Day__container___1Fpnl.Day__showBackground___3CXnw {
+    background-image: none;
+}
+
+================================
+
+app.traderepublic.com
+
+IGNORE INLINE STYLE
+#chartPriceLine
+
+================================
+
+app.univerusrec.com
+
+CSS
+html {
+    background-color: #181a1b !important;
+}
+input,
+select,
+textarea {
+    color: --darkreader-selection-text !important;
+}
+
+================================
+
+app.ynab.com
+
+CSS
+.ynab-checkbox-button-square {
+    color: transparent;
+}
+
+================================
+
+app.youneedabudget.com
+
+CSS
+[data-darkreader-inline-fill] {
+    fill: ${black} !important;
+}
+
+================================
+
+apple.com
+*.apple.com
+
+INVERT
+.ac-slider-ax-track
+.controls-progress-indicator
+.rf-ccard-content-info
+
+CSS
+* {
+    --globalnav-background: var(--darkreader-neutral-background) !important;
+    --localnav-background: var(--darkreader-neutral-background) !important;
+}
+option {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+apple.com/leadership/
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+apple.com/macos/sonoma/
+
+INVERT
+.section-hero-lockup
+
+================================
+
+apple.com/shop/
+
+INVERT
+.as-localnav.as-localnav-scrim
+.localnav-title
+.as-localnav-menucta
+.as-localnav-browseall-menucta
+.as-localnav-browseall-list-title
+.as-localnav-browseall-listitem
+
+================================
+
+applepay.cdn-apple.com
+
+IGNORE INLINE STYLE
+app-clip-code *
+
+================================
+
+apps.microsoft.com
+
+INVERT
+.empty-star
+
+================================
+
+aprs-map.info
+
+INVERT
+img[src*="tile.openstreetmap.org/"]
+img[src*="tile.opentopomap.org/"]
+
+================================
+
+aprs.fi
+*.aprs.fi
+
+INVERT
+img[src*="maps.googleapis.com/maps/vt"]
+img[src*="tile.openstreetmap.org"]
+
+CSS
+#panel {
+    background-image: none !important;
+}
+
+================================
+
+apteka.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+.icon--logo
+
+================================
+
+aras.com
+
+CSS
+.alternate_color.banner__title.display-2,
+.alternate_color.banner__subtitle.display-5 {
+    color: var(--darkreader-neutral-text) !important;
+}
+.banner__title.display-2,
+.banner__subtitle.display-5 {
+    color: ${white} !important;
+}
+
+================================
+
+arcaea.lowiro.com
+
+INVERT
+img.stripe-stamp
+img.image-header
+.logout-button .button-text
+.arcaea-links .right-section .account-button .button-text
+.hexagon-title .line-title[data-v-8fecbf4d]
+.headline[data-v-41d9e8bb]
+img.lock
+img.line-dark
+
+IGNORE IMAGE ANALYSIS
+.memory-options .memory-select[data-v-85bcc7aa]
+.memory-options .memory-select.deselected[data-v-85bcc7aa]
+.memory-options .memory-select.disabled[data-v-85bcc7aa]
+.memory-options .currency[data-v-85bcc7aa]
+.memory-options .currency.deselected[data-v-85bcc7aa]
+.memory-options .currency.disabled[data-v-85bcc7aa]
+.memory-options .memory-select .selector[data-v-85bcc7aa]
+.logout-button[data-v-59affef8]
+.memories .memories-purchase[data-v-54ce7f86]
+.memories[data-v-54ce7f86]
+img.footer-logo
+.content .user .username
+.dark[data-v-a588730b]
+
+================================
+
+archenoah-kelkheim.de
+
+IGNORE IMAGE ANALYSIS
+.wsite-header
+
+================================
+
+architekturaibiznes.pl
+
+INVERT
+.icon-section
+a span.image-rwd-dzial-logo
+
+================================
+
+archive.org
+
+INVERT
+p + fieldset a svg
+#nav-search
+#nav-search .search-field
+.tabs-row
+.tab
+.activity-icon
+#branding
+.status-text
+.review-star
+
+CSS
+#search-input {
+    --input-background-color: var(--darkreader-neutral-background) !important;
+    --input-color: var(--darkreader-neutral-text) !important;
+}
+#about-container,
+.default-header {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+#right-column,
+#results {
+    background-color: var(--darkreader-background-ffffff) !important;
+    background-image: initial;
+}
+#sort-bar * {
+    color: var(--darkreader-text--ia-theme-primary-text-color) !important;
+}
+#sort-bar svg path,
+.caret-down-svg,
+.collapser-icon svg,
+.expand-date-picker-btn svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+#item-mediatype svg path {
+    fill: black !important;
+}
+.review {
+    color: var(--darkreader-neutral-text) !important;
+}
+.message {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+arelion.com
+
+INVERT
+div.tc-navigation-main__text
+div.tc-navigation-main__buttons
+img.tc-testimonial-expand__logo
+
+================================
+
+argos.co.uk
+
+IGNORE INLINE STYLE
+svg[class^="Checkboxstyles"]
+
+================================
+
+ario-player.sourceforge.net
+
+INVERT
+div.header
+
+CSS
+div.main,
+#menu li a,
+#menu li {
+    background-image: none !important;
+}
+
+================================
+
+ark.no
+
+CSS
+.mix-blend-multiply {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+ars.particify.de
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.mat-mini-fab {
+    box-shadow: none !important;
+}
+.mat-card {
+    background-color: #{gray} !important;
+    box-shadow: none !important;
+}
+.mat-chip {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+arstechnica.com
+
+CSS
+.listing,
+.video-thumbnail {
+    background-blend-mode: initial !important;
+}
+.article-single figure img {
+    mix-blend-mode: initial !important;
+}
+
+IGNORE INLINE STYLE
+#site-header svg *
+
+================================
+
+artifacts.dev.testing-farm.io
+
+CSS
+pre {
+    background-color: ${rgb(224, 224, 224)} !important;
+}
+
+================================
+
+artofproblemsolving.com
+
+INVERT
+.latex
+.latexcenter
+
+================================
+
+artsy.net
+
+CSS
+[aria-checked="false"][role="checkbox"] svg path {
+    fill: transparent !important;
+}
+
+IGNORE INLINE STYLE
+[role="checkbox"] svg *
+
+================================
+
+arxiv.org
+
+INVERT
+span.MathJax img
+
+CSS
+.abstract {
+    background-color: transparent !important;
+}
+
+================================
+
+asahilinux.org
+
+INVERT
+.header-logo
+
+================================
+
+asana.com
+
+INVERT
+.siteHeader__logo
+.DatePickerCalendarDate--today .DatePickerCalendarDate-button::after
+
+CSS
+.MultiColorIcon--unselected .MultiColorIcon-path--fadedBlack {
+    fill: var(--darkreader-bg--color-icon) !important;
+}
+.MultiColorIcon-path--white {
+    fill: var(--darkreader-text--color-icon-foreground) !important;
+}
+.DailySummaryInboxThread--selected,
+.TaskAddedToPotInboxThread--selected,
+.InboxExpandableThread.InboxExpandableThread--selected,
+.PortfolioItemRow {
+    background: var(--darkreader-neutral-background) !important;
+}
+.PortfolioItemRow:hover {
+    background: ${#FFF} !important;
+}
+.HomePageContent {
+    background-image: none !important;
+}
+div.PeopleWidgetCarousel-gradient.PeopleWidgetCarousel-gradient--right {
+    display: none;
+}
+
+================================
+
+asciinema.org
+
+IGNORE INLINE STYLE
+polygon
+polyline
+
+================================
+
+askjohnmackay.com
+
+INVERT
+[src$="ask-john-mackay-logo.png"]
+[src$="side-banner-05.gif"]
+[src$="reasonwhy.jpg"]
+
+CSS
+body,
+header,
+#site-footer,
+#live-search {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+askmen.com
+
+IGNORE IMAGE ANALYSIS
+.askmen__logo
+
+================================
+
+askvg.com
+
+INVERT
+.site-header img
+
+================================
+
+askwoody.com
+
+CSS
+.banner,
+.content {
+    background-image: none !important;
+}
+
+================================
+
+assetstore.unity.com
+
+CSS
+div[style^="background-color:var(--color-bg-gray-5)"] {
+    --color-bg-gray-5: var(--darkreader-neutral-background) !important;
+}
+h2[style*="color:var(--color-font-header)"] {
+    --color-font-header: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+astro.build
+
+CSS
+hero-card .card {
+    --darkreader-bg--tw-gradient-stops: var(--darkreader-bg--tw-gradient-from), var(--darkreader-neutral-background), var(--darkreader-bg--tw-gradient-to) !important;
+}
+
+IGNORE INLINE STYLE
+#navlogo svg path
+
+================================
+
+astroproxy.com/dashboard/settings/profile/2fa
+
+CSS
+.card-body .col-md-6 > div > svg > rect[width="200"] {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+asus.com
+
+INVERT
+span.mobile-menu-toggle.mobile
+em#searchopen.icon-search
+#af-header .af-inner .logo
+
+IGNORE IMAGE ANALYSIS
+#af-header .af-inner .logo
+li.nav-Rog a
+
+================================
+
+atcoder.jp
+
+CSS
+#fixed-server-timer {
+    color: #333;
+}
+.ace-tm .ace_indent-guide {
+    opacity: .3;
+}
+
+================================
+
+athome.abeka.com
+
+INVERT
+.logo img
+.center-align img
+
+================================
+
+atlas.herzen.spb.ru
+guide.herzen.spb.ru
+job.herzen.spb.ru
+
+INVERT
+img[src="/images/logo.png"]
+hr
+
+CSS
+body,
+.body,
+table,
+tbody,
+tr,
+td,
+.corner_bottom {
+    background: none !important;
+}
+
+================================
+
+atlassian.net
+*.atlassian.net
+
+INVERT
+img[src*="https://github.githubassets.com/favicon.ico"].smart-link-icon
+.sc-jTzLTM
+img[src^="https://latexmath.bolo-app.com/render/"]
+img[src*="MathJax-SVG"]
+span[aria-label="Confluence"]
+
+CSS
+span.code,
+code.code {
+    background-color: rgba(240,246,252,0.15) !important;
+}
+.ghx-parent-group,
+.ghx-issue {
+    background-color: rgba(119, 183, 255, 0.05) !important;
+}
+span.loader-wrapper a,
+.css-s0tfqx,
+.css-1vn31bx,
+.css-1gx5gpx,
+.css-wvfva4 {
+    background-color: rgba(240,246,252,0.1) !important;
+}
+.css-1yfnrso,
+.aui-flag,
+.aui-message {
+    box-shadow: 0 0 20px rgba(240,246,252,0.15) !important;
+}
+.css-1ua1xqz {
+    background-color: rgba(65, 65, 83, 0.6) !important;
+}
+code:first-of-type {
+    background-image: linear-gradient(to right, rgba(255,255,255,0.03),rgba(255,255,255,0.03) calc(1ch + 16px),transparent calc(1ch + 16px),transparent) !important;
+}
+.sc-1jjaulc-0 {
+    background-color: ${rgba(3, 9, 15, 0.02)} !important;
+    box-shadow: 0 0 4px ${rgba(3,9,15,0.15)} !important;
+}
+.sc-186t4q4-1 {
+    background-color: ${rgba(3, 9, 15, 0.02)} !important;
+}
+div.zgsxji-0.jMIyWM > div > div > div > div {
+    background-color: var(--darkreader-bg--ds-surface, #181a1b) !important;
+}
+#ak-main-content,
+.pfb8c3-0.dpzKHj,
+._11q7vuon {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+#jira-issue-header,
+#jira-issue-header-actions {
+    background-color: rgb(29, 32, 33) !important;
+}
+.ak-editor-panel[data-panel-type="note"] {
+    background-color: ${rgb(217, 200, 228)} !important;
+}
+.ak-editor-panel[data-panel-type="info"] {
+    background-color: ${rgb(172, 217, 242)} !important;
+}
+.ak-editor-panel[data-panel-type="error"] {
+    background-color: ${rgb(255, 220, 211)} !important;
+}
+.ak-editor-panel[data-panel-type="warning"] {
+    background-color: ${rgb(238, 229, 187)} !important;
+}
+.ak-renderer-document hr,
+.ProseMirror hr {
+    background-color: rgb(69, 70, 72) !important;
+}
+.ProseMirror hr.ak-editor-selected-node {
+    background-color: rgb(0, 101, 255) !important;
+}
+.jira-issue-status-lozenge {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.fabric-text-color-mark {
+    --darkreader-text--custom-text-color: var(--custom-text-color);
+}
+#content-body {
+    --ds-surface: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.ak-editor-content-area *
+span[aria-label="Jira Software"] *
+
+================================
+
+atptour.com
+
+INVERT
+.match .stats-item .scores.scores--strike::before
+
+IGNORE IMAGE ANALYSIS
+.match .stats-item .scores.scores--strike::before
+
+================================
+
+audible.com
+
+INVERT
+.navigation-header-logo img:not(img[src*="inverse"])
+
+================================
+
+audible.com/webplayer
+audible.de
+
+INVERT
+#adbl-cloud-player-controls
+.hero-img > img
+
+CSS
+.adbl-page > #center-0 {
+    background-color: #0e0d0c !important;
+}
+.adblCloudPlayerContainer {
+    height: 99999vh !important;
+}
+.adblCloudPlayerContainer .bc-range-progress,
+.bc-range input[type="range"]::-moz-range-thumb,
+.bc-range input[type="range"]::-webkit-slider-thumb {
+    background-color: #f7991c !important;
+}
+.bc-range input[type="range"]::-moz-range-track,
+.bc-range input[type="range"]::-webkit-slider-runnable-track {
+    background: rgba(255,255,255,.5) !important;
+}
+
+================================
+
+audio-technica.com
+
+INVERT
+.o-header__logo
+
+================================
+
+audycje.tokfm.pl/widget
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+auspost.com.au
+
+CSS
+[data-testid="ShipmentListItem"] {
+    background-color: ${#f5f5f5} !important;
+}
+[data-testid="ShipmentListItem"]:hover {
+    background-color: ${#f9f9f9} !important;
+}
+
+================================
+
+auth.adguard.com
+
+INVERT
+.header__logo path[fill="#000"]
+
+================================
+
+auth0.com
+
+INVERT
+button[data-handler="authorise-github"] > img.icon.icon-default
+
+================================
+
+auto.lukoil.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+autodesk.com
+
+INVERT
+.uh-logo-container
+
+================================
+
+autoweek.com
+roadandtrack.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not(nav#sidepanel img, footer img):not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i])
+nav#sidepanel img:not([src$="primary=%2523ffffff" i], [src$="primary=%2523b4b3b3" i])
+div[data-tracking-id="topNavSponsor"] img
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
+avanti24.pl
+
+INVERT
+.box-logo
+
+================================
+
+avast.com
+
+INVERT
+.avast-logo
+
+================================
+
+avg.com
+
+INVERT
+.bi-nav-toplink
+
+================================
+
+avito.ru
+
+INVERT
+a[class^="Logo-"] > svg > path
+a[class^="header-logo"]
+.item-extended-phone
+.item-price-old::before
+.contacts-phone-3KtSI
+.button-content-phone_size_l-1O5VB
+._39EVKDP-9p1BREJQ3fhILl._2sPEvPi-1aWpcq1ggVph1C._4wLX_6jxKYoWRyE1U1WcZ
+[class^="suggest-graySuggestCategoryImg"]
+ymaps[class$="ground-pane"]
+[class*="price-yellowHighlight"]
+
+CSS
+div[class^="item-preview-image"] {
+    z-index: 0 !important;
+}
+
+IGNORE INLINE STYLE
+[class*="styles-module-content"]
+
+================================
+
+avlab.pl
+
+INVERT
+img[src*="avlab-logo"]
+img[alt*="logo"]
+.elementor-widget-wrap div div a.elementor-icon svg
+.elementor-social-icons-wrapper
+
+================================
+
+aws.amazon.com
+
+INVERT
+a.lb-trigger
+.hover .axis-box rect
+.img-wrapper
+img[alt^="WEB_FreeTier"]
+.lb-is-lazyloaded
+.lb-none-v-margin.lb-img
+.lb-tiny-iblock .cq-dd-image
+
+CSS
+.header-background {
+    fill: none !important;
+}
+
+================================
+
+axios.com
+
+INVERT
+a[data-cy="axios-logo-main"]
+
+================================
+
+azs.tatneft.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="default-cluster"] > ymaps
+
+================================
+
+azs.teboil.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+azsgazprom.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+azure.microsoft.com
+
+INVERT
+.card .ocr-img
+.img-fluid
+.section-master__image
+
+================================
+
+azurlane.koumakan.jp
+
+INVERT
+.mwe-math-element
+
+CSS
+.rarity-1,
+.rarity-2 {
+    background: #999 !important;
+}
+.rarity-3 {
+    background: #5fa8bf !important;
+}
+.rarity-4 {
+    background: #846dbf !important;
+}
+.rarity-5 {
+    background: #aa5 !important;
+}
+.rarity-6 {
+    background: linear-gradient(120deg,#bbbf8a,#7abf7f,#67afbf,#bf6bbf) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.mw-wiki-logo
+
+================================
+
+bab.la
+
+INVERT
+.logo-flash
+
+================================
+
+babyem.co.uk
+
+INVERT
+div.elementor-social-icons-wrapper a.elementor-icon
+input::placeholder
+
+================================
+
+babylonbee.com
+
+INVERT
+.header-logo
+.img-fluid.mb-2.d-none.d-sm-block
+
+================================
+
+backblaze.com
+
+CSS
+.rt-headingxlred-bodym > p {
+    color: ${white} !important;
+}
+.nav2_link,
+.footer_link,
+.footer_textlink {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+backpack.tf
+
+IGNORE INLINE STYLE
+span[data-key="paint"] i.fa-circle
+div.paint
+.stats-graph g.highcharts-tracker > rect
+
+================================
+
+bahai.org
+
+INVERT
+header img[src*="svg"]
+header div[url*="svg"]
+
+CSS
+header,
+.jyBFrT {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+div[bottom="0px"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+bahai.us
+
+INVERT
+img[src="https://www.bahai.us/wp-content/themes/bahai2019/assets/images/bahai_logo_black.svg"]
+img[src*="say_hello.png"]
+
+CSS
+.site-footer {
+    background-blend-mode: multiply !important;
+}
+
+================================
+
+bahaiteachings.org
+
+INVERT
+blockquote::before
+blockquote::after
+blockquote.wp-block-quote::before
+blockquote.wp-block-quote::after
+.container-big::after
+.top-info__social__link
+.event-topics__search__block
+.footer__info__text::after
+
+CSS
+.input-search {
+    color: var(--darkreader-neutral-text) !important;
+}
+.author-page-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+img[src*="404-img"] {
+    visibility: hidden;
+}
+@media (max-width: 1023.5px) {
+    .header__mobile {
+        background: var(--darkreader-neutral-background);
+    }
+}
+
+================================
+
+bahnhof.net
+
+CSS
+.contact-form_section {
+    background-image: none !important;
+}
+
+================================
+
+baidu.com
+
+INVERT
+.s-ctner-contents .s-loading img
+#s_side_wrapper .qrcode-tooltip .qrcode
+.float-wrap_giJYT .qrcode_3mmyy
+.tang-pass-pop-login .compose-left-container .tang-pass-qrcode .tang-pass-qrcode-imgWrapper img
+.op_exactqa_word_how_read
+.icon-more_3rjs0
+.logo-image_7qphJ
+.icon_7FBoR
+.footer_3cBPx .open-icon_2jlej
+.source_1Vdff .openIcon_19C1c
+._ai-ask-back_1hre3_1 ._icon-btn-container_1hre3_135 ._icon_1hre3_117
+._ai-ask-back_1hre3_1 ._ai-ask-back-category_1hre3_36 ._category-item-icon_1hre3_102
+.praise-wrapper_dsvKk .wrap_DBK48.like_WjauW
+.s-weather-wrapper .s-mod-weather .weather-mod .city-wather .show-icon .weather-icon
+.living-icon_6Bb3h
+._partial-image_zc167_124
+.cos-pc .brand-logo_6Lv5s .img-light_7jMUg
+.single-card-wrapper_2nlg9 .title-icon_3YCj_
+.med-logo_33GA7 span
+.title-contanier_RY4Rg .title-icon-row_ktIjk img
+.med-logo_5Iirk span
+.titlt-prefix-icon_4KdDB
+#guaranteePopper.guarantee-pc .popover-content .title .bao-icon-new svg
+.exam-tab_1oog6 .exam-title_32Y60 .exam-tit-img_1pVD5
+.pc-code-img_11zj5
+.privacy-img
+
+CSS
+.cos-pc,
+:root {
+    --cos-color-bg-raised: #000000 !important;
+    --darkreader-bg--cos-color-bg: ${#cfcfe9} !important;
+    --darkreader-bg--cos-color-bg-dent: ${#d1d1d5} !important;
+    --darkreader-bg--cos-color-bg-page: ${#eaeae6} !important;
+    --darkreader-bg--cos-color-bg-primary-light: ${#c1c1cf} !important;
+    --darkreader-bg--cos-color-bg-raised: ${#c1c1cf} !important;
+    --darkreader-bg--cosd-color-bg-primary: #a99af2 !important;
+    --darkreader-border--cosd-color-text-primary: #a99af2 !important;
+    --darkreader-selection-background: #8ab4f8 !important;
+    --darkreader-text--cos-brand-dqa-0: #a99af2 !important;
+    --darkreader-text--cos-brand-search-0: #9ac4ff !important;
+    --darkreader-text--cos-color-text-link: #8ab4f8 !important;
+    --darkreader-text--cos-color-text-primary: #8ab4f8 !important;
+    --darkreader-text--cos-dqa-color: #a99af2 !important;
+    --darkreader-text--cos-link-color-text-hover: #9ac4ff !important;
+    --darkreader-text--cosd-color-text-primary: #a99af2 !important;
+}
+#head_wrapper #s_lg_img,
+#head_wrapper.s-ps-islite #s_lg_img,
+.index-logo-src,
+index-logo-srcnew {
+    display: none !important;
+}
+.s-p-top .index-logo-aging-tools,
+.index-logo-peak {
+    display: inline !important;
+}
+#head_wrapper .s_btn,
+.wrapper_new .s_btn_wr .s_btn,
+.pftab .pftab_hd .cur .tab-underline {
+    background-color: #8ab4f8 !important;
+    color: #000000;
+}
+#head_wrapper #kw,
+.wrapper_new .s_ipt_wr {
+    border-color: rgb(97 97 97);
+}
+p.pass-form-logo {
+    background-image: url(https://www.baidu.com/img/PCfb_5bf082d29588c07f842ccde3f97243ea.png);
+    height: 44.9px;
+    margin-left: 20px;
+}
+.login-type-tab .switch-item.activ::after,
+.wrapper_new #s_tab .cur-tab::after,
+.s-ctner-menus .s-menu-item-underline,
+.indicator-thumb_6Z7pY,
+.select_3ZzKD .select-wrapper_17vIt .scroll-wrap_2W76t .scroll-bar_2QbLd,
+.nav_3xYGl .tab-li_1-F1N.is-active_2p-0t::after,
+.s-skin-layer .choose-page-btn .skin-page-number-btn,
+.s-skin-layer .nav-underline,
+.definition-item_1CSUm .percentage_5pEV9 .jindu_43UUC .jindu-light_2Z1VG {
+    background-color: #8ab4f8 !important;
+}
+.tang-pass-pop-login-color-blue .pass-button:hover,
+.page_2muyV strong,
+.c-btn:hover,
+.page_2muyV a:hover .page-item_M4MDr,
+#page .n:hover,
+.new-pmd .c-text-blue，
+.btn-primary_2s82F:hover:not([disabled]),
+.ask_4pvUb,
+.wrapper_new #u .lb,
+.new-pmd .c-text-blue,
+.sc-tag.sc-caption-new.tag_bxvNe,
+.nvl-bookstore-wrap_3AHiL .bookinfo_1k-rc .read-btn_2j2Ar,
+.head-container_1ASW4 .head-right_2OyG6 .play-btn_2PbE2,
+.active-page-item_wYYY-,
+.active-page-item_wYYY-:hover,
+.publisher-wrap_x5sK8 .opt-btn_fUCxn,
+.wrap_f1met:hover,
+.button_1I6J3:hover,
+.add-site-ok-btn_3-jRW:hover,
+.add-site-ok-btn_3-jRW,
+.sc-button.sc-secondary:hover:not([disabled]),
+.pag-item_3QXUa.active_3zqTy,
+.text-area-box_4e4nT .publish-btn_5BhsJ,
+.sc-secondary_4cFZu,
+.btn_UbC6G,
+.btn_1N-yB:hover,
+.calc-oprate_24c8k .calc-key-equal_HothV,
+.new-tag_4ozgi .pc-tag_2Nde8,
+.tag_377sF,
+.soutu-env-new .soutu-layer .soutu-url-btn-new,
+.soutu-env-new .soutu-layer .upload-wrap,
+.avator-wrap_L2zSM .consulting-btn_dYXy1:hover,
+.c-btn-primary,
+.offical-tag_1tgnd {
+    background-color: #8ab4f8 !important;
+    color: #000000 !important;
+}
+.wrapper_new .iptfocus.s_ipt_wr,
+.item__tbGV .dot_30fkr,
+#head_wrapper #kw:focus,
+.wrapper_new .iptfocus.s_ipt_wr,
+.publisher_TpAsB.border_NWmBE:hover,
+._operative_shkz3_56,
+.wrapper_new .peak-down #u .s-top-img-wrapper,
+.wrapper_new.wrapper_s .soutu-env-new .soutu-layer .soutu-url-wrap,
+.wrapper_new.wrapper_s .soutu-env-new .soutu-layer #soutu-url-kw,
+.s-top-right .s-top-username .s-top-img-wrapper,
+.wrapper_new #u .s-top-img-wrapper {
+    border-color: #8ab4f8 !important;
+}
+.a-se-st-single-video-zhanzhang-capsule,
+.new-pmd .c-text-blue-border,
+.star-wrap_5Zapf .tag_16tnk,
+.tag_1vuJL.primary_6QEFO,
+.new-pmd .c-gap-right-small,
+.cos-color-border-primary-light,
+.baozhang-r-tip .opui-honourCard4 .opui-honourCard4-title,
+.new-tag_4ozgi .pc-tag_2Nde8 {
+    border-color: #8ab4f888 !important;
+}
+.wrapper_new #form .bdsug-new,
+#head_wrapper #form .bdsug-new {
+    border-bottom-color: #8ab4f8 !important;
+    border-left-color: #8ab4f8 !important;
+    border-right-color: #8ab4f8 !important;
+}
+.tang-pass-pop-login-color-blue .pass-button {
+    background-color: ${#dadad4} !important;
+    color: #ffffff !important;
+}
+a {
+    color: #8ab4f8;
+}
+a em,
+em {
+    color: rgb(255 98 98);
+}
+a:hover {
+    color: #9ac4ff;
+}
+.opr-toplist1-link_2Ag1v a:hover {
+    color: #8ab4f8 !important;
+}
+.btn-primary_2s82F {
+    background-image: none !important;
+}
+.tag-selected_lD4sS,
+.tag-common_8ztfL:not(.tag-selected_lD4sS):hover {
+    background-color: ${#cfcfe9} !important;
+    color: #8ab4f8 !important;
+}
+.ask_4pvUb {
+    background-color: #a99af2 !important;
+    color: #000000 !important;
+}
+.cos-pc .item-word_2Fvt9:hover,
+._ai-ask-back_1hre3_1 ._ai-ask-back-category_1hre3_36 ._category_1hre3_50 ._active_1hre3_110,
+._ai-ask-back_1hre3_1 .wd-tag,
+._ai-ask-back_1hre3_1 ._icon-btn-container_1hre3_135 ._btn-text_1hre3_190,
+.cos-pc .btn-group_4wwGy:hover .exp-icon_1SF8P,
+.cos-pc .btn-group_4wwGy:hover .exp-text_4wc20,
+.pcStyle_Tm3GW .copy_4xoef:hover,
+.pcStyle_Tm3GW .textbox_2W0Tw:hover {
+    color: #a99af2 !important;
+}
+.cu-border._content-border_zc167_4,
+.re-box_2CJ9w,
+.aladdin_1n6KS,
+.cosc-card-shadow,
+.pc-container_5bj1N,
+.card-shadow_df59z,
+.op-ly_ticket_train-main.c-border,
+.new-pmd .c-border,
+.cu-border._content-border_zc167_4,
+.card-pc_flYtA,
+.card-pc_Z8Fq0,
+.re-box-shadow_1FfgR,
+.zuowen-content_2nnxI,
+.aladdin_5FSBd,
+.cos-pc .songs-content_5ZWPu {
+    background-color: ${#eaeae6};
+    border: solid, 0px !important;
+    border-radius: 16px !important;
+}
+.cos-pc .is-group_1urbd,
+.c-group-wrapper .result-op[id="1"],
+.weather-days-wrapper_3LzsB.no-peak_7mtt8 {
+    background-color: ${#eaeae6};
+    border-top-left-radius: 16px !important;
+    border-top-right-radius: 16px !important;
+}
+.c-group-wrapper .result-op:not(:last-child),
+.profession_5Z1LF {
+    background-color: ${#eaeae6};
+}
+.c-group-wrapper .result-op:last-child,
+.living_3kOkQ {
+    background-color: ${#eaeae6};
+    border-bottom-left-radius: 16px !important;
+    border-bottom-right-radius: 16px !important;
+}
+.dqa-markdown_5emil .dqa-code-span {
+    background-color: #ffffff0c !important;
+    border: #FFFFFF22, solid, 1px !important;
+}
+.fold_1udxT,
+.more_49t85,
+.cover-container_1Nem2,
+.sc-fold-switch-mask,
+.cos-fold-switch-mask,
+.more_4JpcZ {
+    background-image: linear-gradient(0deg, ${#eaeae6} 0px, ${#eaeae6cc} 30%, ${#eaeae699} 55%, ${#eaeae600} 80%) !important;
+}
+._vertical-gradient_zc167_197 {
+    background-image: linear-gradient(to top, ${#eaeae6}, ${#eaeae600}) !important;
+}
+.med-wz-desc-wrapper_7tenp {
+    background-image: linear-gradient(-90deg, ${#eaeae6} 0px, ${#eaeae6ff} 40%, ${#eaeae600} 100%) !important;
+}
+.indicator-track_7H9n0,
+._sc-divider-horizontal_1rtxp_1::after,
+.new-pmd button.c-btn,
+.pc-down-pc_1SaAU .pc-down-btn_3ndGY {
+    background-color: ${#b0b0bf} !important;
+}
+.bg_2LxZD,
+._tabs-nav-selected_1n2to_52,
+.pc_1nx5T .more_Sq0v0 .more-btn_jca8M:hover,
+.box-item_6rvVp:hover,
+.tabs-wrapper_6xKju .tab_6PkmF.active_1YDbU,
+.more_3uhsr .more-btn_iB6t3:hover,
+.vote-tab_26NoS ul li.active_76SWb,
+.single-card-more-line_336It,
+.cos-pc .demo-question_227j3 .demo-list_7oJi2 .demo_4QeQv:hover,
+.see-more-wrap_gKBWt .see-more-line_3Q8nJ,
+.calc-oprate_24c8k .base-calc_27A59 .calc-key-number_1fqx4,
+.head-container_1ASW4 .head-right_2OyG6 .find-lrc-btn_ayH7_,
+.inpt_disable_3UETE,
+.custdom_input_25IQU,
+.time_pop_1-CDl .input_from_1ITZ-,
+.inpt_disable_16KeJ,
+.exam-tab_1oog6 .select-item_5zPMB,
+.tab-wi_2Rp7j,
+.pc-query-content-wrapper_9xudv .pc-query-content-box_5dDvI .operate-box_7cLzn .audio-box_2QevP,
+.sc-city-header-tab-active,
+._ai-ask-back_1hre3_1 ._ai-ask-back-category_1hre3_36 ._category-item_1hre3_74:hover,
+#guaranteePopper.guarantee-pc .popover-content .actions .btn:hover {
+    background-color: ${#c1c1cf} !important;
+}
+.content_27h2V,
+.rs-link_2DE3Q,
+.item_3WKCf,
+.wrap_f1met,
+._select-entry_9e3yq_48,
+.header-btn_68kgy {
+    background-color: ${#d4d4df} !important;
+}
+._tabs-nav_1n2to_4,
+.sc-button.sc-sublink,
+.sc-button-new.sc-sublink,
+.rankWrapPc_1TcEJ,
+.content_2YLYk,
+.pc_Al2N0 .box-item_4dDrB,
+.pc_1nx5T .more_Sq0v0 .more-btn_jca8M,
+.box-item_6rvVp,
+.pc_1nx5T .list-row_6egLi:hover,
+.list-row-detail_GspLu,
+.item-selected_3Em1g,
+.item-selected_3Em1g .left-circle-bg_4laYb,
+.item-selected_3Em1g .right-circle-bg_5w7A6,
+.item_2Y7S3:hover,
+.more_3uhsr .more-btn_iB6t3,
+.op-ly_ticket_train-tabs-nav,
+.develop_3ZJsP,
+.item_2q0df,
+.new-pmd .c-gap-bottom-middle,
+.custom-bar_XvJUN .nav-box_3tac9,
+.content-list_6tfRu .scard-item_6vzi9 .scard-audio-copy_4I4tP,
+.tags_2yHYj,
+.tag-item_1yRaQ,
+.pag-item_3QXUa,
+.tabs-container_2lLWT .c-tabs-nav,
+.exam-tab_1oog6,
+.fy-star-box_2Bckj .words-record_5zVy0,
+.orginal_38HZ2 .orginal-bg_5BENF,
+.pc-result-content-box_3u7bx .operate-wrapper_1jO4y,
+.select_3ZzKD,
+.footer-king-container_1EeMH .king-touch-wrapper_3qk1I .king-item_3qDSp,
+.sc-city-header-city-search,
+.race-item_1u-Bl:hover,
+.rank-list_1Oklt:hover,
+.c-song-item_66iAf:hover,
+.new-pmd .c-gap-right-large,
+#guaranteePopper.guarantee-pc .popover-content .actions .btn,
+.button-wrapper_1q1Ke.button-theme_6xA8r {
+    background-color: ${#cfcfe9} !important;
+}
+.button_sx9Ei:hover {
+    background-color: ${#b7b7bf} !important;
+    color: #8ab4f8 !important;
+}
+.item_3WKCf:hover,
+.rs-link_2DE3Q:hover,
+.single-card-more_2npN-:hover,
+.btn_1N-yB,
+.see-more-wrap_gKBWt:hover,
+.see-more-wrap_gKBWt:hover .see-more-content_2Bljh,
+.sc-button.sc-sublink:hover,
+.sc-button-new.sc-sublink:hover,
+.custom-bar_XvJUN .nav-box_3tac9 .nav-item-checked_2-wma,
+.tags_2yHYj:hover:not(.touch_2GI_H),
+.tag-container_ksKXH .tag-selected_1iG7R,
+._more_w7nnv_23:hover,
+.pag-item_3QXUa:hover,
+.button_sx9Ei,
+.sc-city-content-city-item-text:hover,
+.sc-city-header-search-word:hover,
+.sc-button,
+.sc-button-new,
+.tag-item_UHf7p:hover {
+    background-color: ${#c1c1cf} !important;
+    color: #8ab4f8 !important;
+}
+.nvl-bookstore-wrap_3AHiL .bookinfo_1k-rc .read-btn_2j2Ar:hover,
+.zk-header_39T7V .line_26Rhs,
+.sc-city-content-active-nav::before {
+    background-color: #8ab4f8 !important;
+}
+.select_3ZzKD .select-wrapper_17vIt .select-board_2vss_ .select-scroll_3h0Ij .select-color_7Q5Mg,
+.title_1WDM0 .text-wrap_PR4ro:hover .icon-title_rJo3i,
+.tool_3HMbZ:hover,
+#user .username:hover,
+.a-se-st-single-video-zhanzhang-capsule,
+.opr-toplist1-title_2gF7E:hover .icon-title_1swfn,
+.opr-toplist1-title_2gF7E:hover .icon-right_2arJu,
+.opr-toplist1-update_39A0r .toplist-refresh-btn_2ky31:hover,
+.opr-toplist1-update_39A0r .toplist-refresh-btn_2ky31:hover .opr-toplist1-hot-refresh-icon_2B5DX,
+.new-pmd .c-text-blue-border,
+.hovering_1RCgm:hover,
+.more-wrap_1ixZo .more-link_PaaxA:hover,
+.s-top-left-new .mnav:hover .s-bri,
+.s-top-left-new a:hover,
+.wrapper_new #u > a:hover,
+.s-mod-setweather .setweather-content .lunar-mod .lunar-sevenday,
+.s-mod-setweather .setweather-content .lunar-mod .lunar-setting-btn:hover .lunar-settint-text,
+.s-weather-wrapper:hover .show-city-name,
+.s-weather-wrapper:hover .show-icon-temp,
+.s-top-right .s-top-right-text:hover,
+.s-top-right .s-top-username:hover .user-name,
+.s-top-userset-menu a:hover,
+.s-skin-layer .hover-nav4ie6,
+.s-skin-layer .skin-nav:hover,
+.s-news-item:hover .s-news-item-title,
+.hot-news-wrapper .s-rank-title .title-text:hover,
+.hot-news-wrapper .s-rank-title .title-text:hover .arrow,
+.dustbin:hover,
+.nativead-dustbin:hover,
+.play-tts:hover,
+.pause-tts:hover,
+.hot-news-wrapper .s-rank-title .hot-refresh:hover .hot-refresh-text,
+.hot-news-wrapper .s-rank-title .hot-refresh:hover .refresh-icon,
+.hot-news-wrapper .s-news-rank-content .title-content:hover,
+.wrapper_new #u .bdpfmenu a:hover,
+.wrapper_new #u .usermenu a:hover,
+.star-wrap_5Zapf .tag_16tnk,
+.tag_1vuJL.primary_6QEFO,
+.fold-btn-text_3r8hd:hover,
+.new-pmd .c-select-item:hover,
+.new-pmd .c-select-item-selected,
+.selectorContainer_5CicL .selectItem_1bUAj:hover,
+.select_7oJYi:not(.disable_3yF3S):hover,
+.pc_ZVQ8P .tab_6PkmF:hover,
+.pc_5QPD0 .box-item_6rvVp:hover .desc_47O7H,
+.load_4cwYw:hover .icon_roUEV,
+.header-container_Hgukk .right_1NVQT .img_62hlT .img-wrapper_5LRJT,
+._paragraph_lzhxo_2.lg:hover,
+._load_15s63_25:hover ._icon_15s63_40,
+.card_1FDsA .card-title_3mXrq .more-text_3Oa53:hover,
+.hot-item_1473U .item-mid_vrw25:hover,
+#head_wrapper #form .bdsug-new .bdsug-store-del:hover,
+.soutu-env-new .soutu-layer .soutu-close-new:hover,
+#head_wrapper #form .bdsug-new > div span:hover,
+#head_wrapper #form .bdsug-new > div a:hover,
+._selected_9e3yq_14,
+._selectItem_9e3yq_23:not(._disabled_9e3yq_19):hover,
+._selectItem_9e3yq_23:not(._disabled_9e3yq_19):active,
+.header-btn_68kgy:hover,
+.load_3HN2V:hover .icon_11Qc4,
+.fold-btn-icon_XSMXB,
+.c-group-title a:hover,
+.c-group-title a:hover > i,
+.c-group-title a:hover + i,
+.c-group-title a:hover .c-group-arrow-icon,
+.exam-tab_1oog6 .select-item_5zPMB,
+.tab-wi_2Rp7j .tab-con_7JHHa .tab-con-top_75xiK .tab-con-head_381pW .tab-count_69vPs,
+.sc-search-link,
+._search-link_ajims_1:hover ._suffix_ajims_14,
+.title_1WDM0 .text-wrap_PR4ro:hover .icon-right_38uzr,
+.sc-city-content-nav:hover,
+.sc-city-header-tab:hover,
+.s-hotsearch-wrapper .s-hotsearch-content .title-content:hover,
+.s-hotsearch-wrapper .s-hotsearch-title .title-text:hover,
+.s-hotsearch-wrapper .s-hotsearch-title .title-text:hover .arrow,
+.s-hotsearch-wrapper .s-hotsearch-title .hot-refresh:hover .c-icon,
+.s-hotsearch-wrapper .s-hotsearch-title .hot-refresh:hover .hot-refresh-text,
+.new-pmd .c-tools-tip-con .c-tip-menu li a:hover,
+.baozhang-r-tip .opui-honourCard4 .opui-honourCard4-title,
+.baozhang-r-tip .honourCard4-more-info,
+.button_sx9Ei .content_7L4g2 {
+    color: #8ab4f8 !important;
+}
+.cos-pc .box_5nmMD:hover {
+    background-color: #BBBBFF22 !important;
+}
+.selected_3I0vG {
+    background-color: #2f54ef !important;
+}
+.festival_8Y6ks,
+.button_sx9Ei:hover {
+    background-color: rgb(255 100 100 / 8%) !important;
+}
+.detail-bg_7nBI0 {
+    background-image: linear-gradient(${#cfcfe9}, ${#cfcfe900}) !important;
+}
+.custom-bar_XvJUN .date-type-right_2eYZr,
+.around-page-left_OFyr5 {
+    background-image: linear-gradient(90deg, ${#cfcfe9}, ${#cfcfe900}) !important;
+}
+.select-detail_1rVdi .title_6KsjR .line_Gv0I9 {
+    background-color: rgba(26, 50, 150, 0.3);
+}
+.text-area-box_4e4nT .text-area_5EkLk,
+.op-ly_ticket_train-tabs-nav-li.op-ly_ticket_train-tabs-nav-selected,
+.tabs-content_3ZTqE,
+.see-more-wrap_gKBWt .see-more-content_2Bljh,
+.op-map_flight-tabs-nav-li.op-map_flight-tabs-nav-selected,
+.desc-common_3sbkZ,
+.interaction_66WRZ,
+.baike-slink-wrapper_7k8vl,
+.baike-wrapper_6AORN,
+.wrapper_s .fir-margin_2dpDf,
+.wrapper_l .fir-margin_2dpDf,
+.tabs-container_2lLWT,
+.tabs-container_2lLWT .c-tabs-nav .tab-selected_3LAkk,
+.new-pmd .c-input input,
+.s-mod-setweather,
+.s-top-userset-menu,
+.s-top-left-new .s-top-more,
+.soutu-env-new .soutu-layer .soutu-state-normal,
+.soutu-env-new .soutu-layer .soutu-error,
+.soutu-env-new .soutu-layer .soutu-waiting,
+.soutu-env-new .soutu-layer .soutu-drop-tip,
+.pop_over_svvNd,
+.pop_over_AuuUs,
+.file_type_16eh4 .file_li_2nywH,
+.pop_over_ppVmY,
+.time_pop_1-CDl .dis_able_A9pol,
+.time_pop_1-CDl .time_li_3_ArK,
+#wrapper.wrapper_new .bdpfmenu,
+#wrapper.wrapper_new .usermenu,
+.wrapper_new #u .bdpfmenu a,
+.wrapper_new #u .usermenu a,
+.c-tip-con,
+#content_left .search-source-wrap .search-source-content:hover .search-source-popup,
+#guaranteePopper.guarantee-pc .popover-content .popover-inner,
+.sc-city-selector-content,
+.sc-city-content-content-wrapper,
+.sc-city-content-nav-row,
+.item-selected_3Em1g .left-circle_77jIg,
+.item-selected_3Em1g .right-circle_1eiAS {
+    background-color: ${#eaeae6} !important;
+}
+.wrapper_new #s_tab .s-tab-item:hover::before {
+    color: rgb(224 224 224) !important;
+}
+.wrapper_new #s_tab .s-tab-item::before {
+    color: rgb(178 178 178) !important;
+}
+.demo-question_227j3 .demo-list_7oJi2 .ai-bgprops_2FVDG {
+    background-color: rgb(127 114 253 / 9%) !important;
+}
+.sc-button,
+.sc-button-new {
+    background-image: none !important;
+}
+.head-name-sign_3sFI- {
+    background-color: rgb(53 164 233);
+}
+.calc-oprate_24c8k .calc-key-equal_HothV:hover {
+    background-color: #9ac4ff !important;
+}
+.sc-button.sc-sublink,
+.sc-button-new.sc-sublink {
+    color: rgb(209, 209, 209) !important;
+}
+.pc_5KjyO .more_3uhsr .more-btn_iB6t3:hover,
+.pc_5QPD0 .box-item_6rvVp:hover .text_UWEZE,
+.wrapper_new #form .bdsug-new ul li:hover,
+.wrapper_new #form .bdsug-new ul li:hover span,
+.wrapper_new #form .bdsug-new ul li:hover b,
+.sc-search-link:hover,
+.sc-search-link:hover .suffix,
+.page-btn_1XR1p:hover,
+._search-link_ajims_1:hover,
+.cos-pc .sc-fold-switch-text:hover,
+#container.sam_newgrid .c-showurl-hover,
+.detail-btn_2Ar6f:hover .arrow-icon_49DBU {
+    color: #9ac4ff !important;
+}
+.boiling-all_29kBD .boiling-wrapper_fhywn .boiling-contain_3r2Lv .row-left_1OGNu .boiling-right_3Etl4 .boiling-btn_29fbf:hover {
+    background-color: ${#c1c1cf} !important;
+    color: rgb(255 126 126) !important;
+}
+.boiling-all_29kBD .boiling-wrapper_fhywn .boiling-contain_3r2Lv .row-left_1OGNu .boiling-right_3Etl4 .boiling-btn_29fbf {
+    background-color: ${#cfcfe9} !important;
+    color: rgb(255 100 100) !important;
+}
+.circle_iCmiK .number_2xOZd {
+    color: black !important;
+}
+.soutu-env-new .soutu-layer .soutu-close-new {
+    color: #EEEEEE !important;
+}
+#container.sam_newgrid .result .c-tools .c-icon,
+#container.sam_newgrid .result-op .c-tools .c-icon,
+#content_left .search-source-wrap .iconfont {
+    color: #ffffff40 !important;
+}
+._feedback-icon_pbmk1_13 {
+    fill: #ffffff66 !important;
+}
+.pause-icon_7omnL,
+.orginal_38HZ2 .orginal-bg_5BENF .orginal-slow-au_50ah1 svg {
+    color: #8ab4f8 !important;
+    fill: #8ab4f8 !important;
+}
+.new-pmd .c-text-authoritative {
+    background-color: rgb(255 165 91 / 20%) !important;
+    color: rgb(239, 161, 103) !important;
+}
+.tab-wi_2Rp7j {
+    border-color: ${#cfcfe9} !important;
+}
+.exam-tab_1oog6 .select-item_5zPMB::before {
+    background-image: radial-gradient(circle at left top, rgba(0, 0, 0, 0) 0.09rem, ${#c1c1cf} 0px) !important;
+}
+.exam-tab_1oog6 .select-item_5zPMB::after {
+    background-image: radial-gradient(circle at right top, rgba(0, 0, 0, 0) 0.09rem, ${#c1c1cf} 0px) !important;
+}
+.sc-city-content-nav-row {
+    margin-right: 0px !important;
+}
+
+================================
+
+baike.baidu.com
+
+INVERT
+.formula
+
+IGNORE IMAGE ANALYSIS
+.wiki-lemma .lemmaWgt-posterBg
+
+================================
+
+baitoru.com
+
+CSS
+mark {
+    background-color: #cc4;
+    color: black;
+}
+
+================================
+
+bakabt.me
+
+INVERT
+span.icon.hd
+span.icon.lossless
+
+CSS
+.series {
+    background-size: 100% 100% !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.series
+
+================================
+
+balena.io
+
+INVERT
+.Header__main-logo
+
+================================
+
+bandaancha.eu
+
+CSS
+.psCr img {
+    z-index: 0 !important;
+}
+.psCr header,
+.psCr footer {
+    z-index: 1 !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#hdr
+
+================================
+
+bandcamp.com
+allochiria.com
+
+INVERT
+.bclogo.white
+.vol-control
+.progress
+.buffer
+.seek-control
+#material-close
+
+CSS
+.ui-dialog {
+    background-image: none !important;
+}
+
+================================
+
+bandshed.net
+
+CSS
+#content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+banki.ru
+
+INVERT
+.header__logo
+
+CSS
+.comment:nth-child(even) {
+    background-color: ${#f5f5f5} !important;
+}
+
+================================
+
+bankier.pl
+bankier.tv
+
+INVERT
+.m-nav-header__logo
+.o-home-smart-box__header > .a-anchor > .a-image >  img[class="a-image__img"]
+.hamburger
+.icon > img
+.menu-sidebar__close-menu > img
+img[class="menu-sidebar__logo-img"]
+img[alt*="Bankier.pl"]
+img[src*="logo-smart.svg"]
+a[href="https://www.bankier.pl/"]
+img[alt="Bankier.TV"]
+.m-quote-list__anchor img.a-image__img
+a.more-link
+
+CSS
+button.btn.period {
+    color: #000 !important;
+}
+
+================================
+
+bankofamerica.com
+
+INVERT
+.main-nav-top-logo img
+
+CSS
+.fsdnav-sub-nav-left {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ad-acct-layout,
+.ad-acct-detail-card-layout,
+.thrfwl-body,
+.ad-summary-container,
+.olb-summary-widget-container {
+    background-image: none !important;
+}
+
+================================
+
+barnesandnoble.com
+
+INVERT
+.logo-img
+
+================================
+
+basecamp.com
+
+INVERT
+.top-nav__logo
+
+================================
+
+baselinker.com
+
+CSS
+.form-control {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: ${black} !important;
+}
+
+================================
+
+battlelog.battlefield.com/bf3
+
+INVERT
+:not(.active) > .serverguide-cell-ranked-wrapper > div
+:not(.active) > .serverguide-cell-pb-wrapper > div
+:not(.active) > .serverguide-cell-type-wrapper > div
+.common-button-medium-grey
+.common-kittimes-overlay
+.serverguide-headercells
+table.common-table > thead > tr > th
+.leaderboard-venice-specific > thead > tr > th
+#selected-server-settings .selected-server-setting
+.assignments_list .progress_bar
+.sodaSlider-arrow-left
+.sodaSlider-arrow-right
+
+CSS
+.common-button-medium-grey > p {
+    color: #000 !important;
+}
+.base-button-arrow-almost-gigantic,
+.base-button-arrow-gigantic,
+.base-button-arrow-large,
+.btn.btn-primary,
+.base-button-arrow-large-drop {
+    color: #000 !important;
+}
+.common-button-medium > p,
+.common-button-large > p {
+    color: #000 !important;
+}
+.common-selector-alt li.selected {
+    color: #262626 !important;
+}
+.progress-bar .progress-bar-inner,
+.common-percentbar-container div {
+    background-color: ${#353535} !important;
+}
+#selected-server-settings .selected-server-setting {
+    color: ${#888} !important;
+}
+.assignments_details li {
+    background-blend-mode: soft-light !important;
+}
+#assignments-progress a {
+    background-blend-mode: soft-light !important;
+    background-color: ${#e8e8e8} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.serverguide-headercells
+table.common-table > thead > tr > th
+.leaderboard-venice-specific thead tr th
+.base-item-ribbon-small
+
+================================
+
+bbb.*
+
+CSS
+div[class^='scrollableList'] {
+    background: none !important;
+    box-shadow: none !important;
+}
+
+================================
+
+bbc.co.uk
+bbc.com
+*.bbc.co.uk
+*.bbc.com
+
+INVERT
+.orb-nav-section .orb-nav-blocks
+.orb-icon .orb-icon-arrow
+[class*="NavigationLink-LogoLink"] > span > svg
+span[class*="LogoIconWrapper"]
+
+CSS
+.wr-icon-weather-type__svg-background,
+.wr-icon-rain__svg-background,
+.wr-icon-wind-direction__svg-background,
+.wr-icon-gel__svg-background {
+    opacity: 0% !important;
+}
+.wr-value--windspeed {
+    color: ${#dad7d2} !important;
+}
+.wr-c-environmental-data__icon-text {
+    color: ${#dcd9d4} !important;
+}
+.haCQWq,
+.fFEZuA {
+    filter: invert(90%) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+bbs.chinauos.com
+bbs.deepin.org
+
+INVERT
+.post_tip
+
+CSS
+.post_edit p {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+bbs.thinkpad.com
+club.lenovo.com.cn
+
+CSS
+body[style] {
+    box-shadow: inset 0px 0px 0px 9999px var(--darkreader-neutral-background);
+}
+
+================================
+
+bbs.wenxuecity.com
+
+INVERT
+.logo
+
+================================
+
+beefpoint.com.br
+
+INVERT
+#Top_bar #logo img
+
+================================
+
+behance.net
+
+INVERT
+div[class^="PrimaryNav-logoWrap"]
+
+================================
+
+benevity.com
+
+INVERT
+.header_logo
+
+================================
+
+berlingske.dk
+
+INVERT
+.site-header__logo
+
+================================
+
+bestbuy.ca
+
+INVERT
+.centerContainer
+[class^="facetName"]
+[class^="title"]
+[class^="sortLabel"]
+[class^="headerText"]
+[class^="subTitle"]
+[class^="price"]
+[class^="soldByBestBuy"]
+[class^="availabilityMessage"]
+[class^="deliveryDate"]
+[class^="storesNearCity"]
+svg[class*="availabilityHeaderIcon"]
+
+CSS
+div[class*="backgroundContainer"] {
+    z-index: 0 !important;
+}
+body {
+    background-image: initial !important;
+}
+
+================================
+
+bestbuy.com
+
+CSS
+input[type="radio" i] {
+    background-color: initial;
+}
+
+================================
+
+bestchange.ru
+
+INVERT
+.tabs li a
+
+CSS
+body,
+.c-inner,
+.c-block .c-wrap,
+#content_table thead td,
+.content .intro,
+.c-block,
+#content_table tbody td,
+#content_reviews,
+.review_header,
+.review_middle,
+.review_bottom {
+    background-image: none !important;
+}
+
+================================
+
+besthealthmag.ca
+
+INVERT
+.logo-container
+
+CSS
+body,
+.hero-module .content-wrapper .col-middle .item .category,
+.editor-explore-title {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.content-wrapper a,
+.most-popular-section h2,
+.most-popular-section .most-popular-detail *,
+.editor-explore-title h2,
+.archive-headings,
+.archive-description,
+.post-title,
+.dek,
+.post-body,
+.brand-via,
+.entry-title,
+.listicle-card h2,
+.newsletter h3 {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+bestproducts.com
+bicycling.com
+cosmopolitan.com
+countryliving.com
+esquire.com
+goodhousekeeping.com
+housebeautiful.com
+oprahdaily.com
+prevention.com
+runnersworld.com
+seventeen.com
+sex.cosmopolitan.com
+womansday.com
+womenshealthmag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] div:not(.nav-bar-container) > button[aria-label="Sidepanel Button"] > svg:not([style="--primary:#ffffff;"])
+nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i])
+nav[data-tracking-id="topNav"] svg:is([alt="Logo"], [alt="Caret Right Icon"])
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
+div.footer svg[alt="Logo"]
+footer.footer img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%2523d4d4d4" i])
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
+bet.com
+cmt.com
+logotv.com
+paramountnetwork.com
+southpark.cc.com
+vh1.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+betanews.com
+
+CSS
+.sectionTop,
+.editorial .header,
+.tabbed .tabs li:not(.active),
+.tabbed .tabs li:not(.active) a {
+    background-image: none !important;
+}
+.tabbed .tabs li:not(.active) a {
+    background-color: ${#d9d9ff} !important;
+}
+
+================================
+
+betano.*
+
+CSS
+.tab-row,
+.bet-activity-card,
+.total-amounts {
+    background-color: ${#fff} !important;
+    color: ${#302505} !important;
+}
+
+================================
+
+betterbird.eu
+
+CSS
+#content {
+    background: transparent;
+}
+#content::before {
+    background-image: url("/betterbird-bg.svg");
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: "";
+    display: block;
+    height: 870px;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 1) 100%);
+    opacity: 7%;
+    position: absolute;
+    top: 170px;
+    width: 870px;
+}
+
+================================
+
+bettercap.org
+
+INVERT
+.copy-to-clipboard
+[src$="mitm.jpg"]
+[src$="proxy.png"]
+[src$="with-hsts.png"]
+[src$="sslstrip2.png"]
+
+CSS
+.copy-to-clipboard {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+bfi.org.uk
+
+INVERT
+img[src$="bfi_logo_transp.png"]
+img[src$="national-lottery-logo-color.png"]
+img[src*="sight-and-sound-logo-280x69.png"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+bgp.he.net
+
+INVERT
+img[src="/helogo.gif"]
+img[src*="chart.googleapis.com"]
+img[src^="/graphs/"]
+
+================================
+
+bgr.com
+
+INVERT
+#hamburger-holder
+.nav-opener.close
+label[for^="subnav-button"]
+
+================================
+
+bible.optina.ru
+
+CSS
+body,
+#left,
+#right {
+    background-image: none !important;
+}
+
+================================
+
+bibleref.com
+
+CSS
+.scripture,
+.content,
+.content-commentary .expand {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+bibliotecapleyades.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+bienici.com
+
+INVERT
+.section-header
+.bv-form
+.hpFeaturesRow
+.hpContent
+#searchSideView
+.searchFilterViewContainer
+.searchItemPhoto
+#map
+.animatedSideContent
+#detailedSheetsNavigation
+
+================================
+
+bigberthaoriginal.*
+
+CSS
+.product-card-figure {
+    background-color: #f9f9f9 !important;
+}
+
+================================
+
+bigocheatsheet.com
+
+INVERT
+.gray
+
+CSS
+.green,
+.orange,
+.yellow,
+.yellow-green {
+    color: black !important;
+}
+
+================================
+
+bikester.no
+
+CSS
+.lightbox img {
+    mix-blend-mode: luminosity !important;
+}
+
+================================
+
+bilet.wielkopolskiebilety.pl
+
+INVERT
+.KW__headerContainer
+.logo
+.map-container
+img[src*="carriers/"]
+
+================================
+
+biletico.pl
+
+INVERT
+.biletico-logo
+
+================================
+
+bilety24.pl
+
+INVERT
+.logo
+
+================================
+
+bilibili.com
+
+INVERT
+.opus-formula-node
+
+CSS
+.login-scan-box {
+    background: white !important;
+}
+.bili-mini-content-wp .login_qrcode_tip {
+    height: 173px !important;
+    left: 0px !important;
+    top: 0px !important;
+    width: 173px !important;
+}
+.qrcode {
+    background: white !important;
+}
+body {
+    background: var(--darkreader-neutral-background) !important;
+}
+:root {
+    --bg1: var(--darkreader-neutral-background) !important;
+    --bg3: var(--darkreader-bg--bg3) !important;
+    --brand_blue_thin: var(--darkreader-bg--brand_blue_thin) !important;
+    --darkreader-bg--_container-color: rgba(0, 0, 0, 0) !important;
+    --graph_bg_thick: var(--darkreader-border--graph_bg_thick) !important;
+    --text1: var(--darkreader-neutral-text) !important;
+}
+.button {
+    color: var(--_label-text-color) !important;
+}
+
+================================
+
+biliomask.com
+
+INVERT
+div.header-title-logo
+
+================================
+
+binance.com
+
+CSS
+div.qr-code > canvas {
+    outline: solid 10px white !important;
+}
+div > input[type="checkbox"] + svg {
+    fill: transparent !important;
+}
+div > input[type="checkbox"]:checked + svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+label > svg circle {
+    fill: rgb(37, 40, 42) !important;
+}
+
+================================
+
+bing.com
+
+INVERT
+canvas[id^="Microsoft.Maps"]
+button[is="cib-button"] svg-icon
+.cs_txt_hq_bg .rms_img
+
+CSS
+.options-list-container,
+.b_wlcmTileWrap > *,
+cib-shared,
+cib-serp-feedback,
+cib-typing-indicator ~ .main-container,
+cib-see-more-container {
+    background: var(--darkreader-neutral-background) !important;
+}
+.option > *,
+cib-shared,
+cib-tooltip,
+cib-message,
+.disclaimer,
+.b_wlcmDesc,
+.b_vfly_b,
+.container>fieldset>legend {
+    color: var(--darkreader-neutral-text) !important;
+}
+.b_searchboxForm,
+.b_searchboxForm:hover,
+.b_focus .b_searchboxForm,
+#sw_as #sa_ul:not(:empty),
+cib-typing-indicator ~ .main-container,
+cib-see-more-container {
+    box-shadow: ${rgba(0, 0, 0, 0.1)} 0px 0px 0px 1px !important;
+}
+#b_results > li.b_ans.b_topborder,
+#b_results > li.b_ans.b_topborder.b_tophb.b_topshad {
+    box-shadow: ${rgba(13, 13, 13, 0.05)} 0px 0px 0px 1px !important;
+}
+.l_ecrd_imcolheader.gradient {
+    z-index: 2 !important;
+}
+#b_content {
+    background-image: none !important;
+}
+cib-tooltip,
+.attributions > .attribution-item > .background {
+    background: var(--darkreader-neutral-background) !important;
+}
+cib-message[type="text"]:not([serp-slot="right-rail"]),
+button.container > .item-content,
+button.container > .item-content::before,
+.container > .options-list-container,
+.container > .options-list-container li.option button:not([selected])::before,
+button.container[serp-slot="none"],
+button.container[serp-slot="right-rail"],
+#fbpgbt,
+#stop-responding-button,
+cib-feedback {
+    background: ${rgba(50, 50, 50, 0.1)} !important;
+}
+cib-message[type="text"]:not([serp-slot="right-rail"]),
+cib-shared > .content > .ac-container > .ac-textBlock {
+    color: var(--darkreader-text--cib-color-neutral-foreground) !important;
+}
+button.container[serp-slot="right-rail"]:hover {
+    background: ${rgba(0, 0, 0, 0.3)} !important;
+}
+button.container[serp-slot="none"] {
+    border: 1px solid var(--cib-color-brand-secondary-stroke) !important;
+}
+.attribution-container > .attribution-items > .attribution-item,
+.attribution-container > .attribution-items > button.expand-button,
+.ac-container.ac-adaptiveCard > .ac-textBlock > p > .tooltip-target + a > sup {
+    background: #050F2E !important;
+    color: #A2B7F4 !important;
+}
+div.icon > svg > g:nth-child(1) > path:nth-child(1) {
+    opacity: 0 !important;
+}
+.ac-container.ac-adaptiveCard > .ac-textBlock > p > .tooltip-target.hover {
+    background: var(--cib-color-stealth-primary-foreground-hover) !important;
+    color: var(--cib-color-brand-text-highlight-background) !important;
+    text-decoration-color: var(--cib-color-brand-text-highlight-background) !important;
+}
+.ac-container.ac-adaptiveCard > .ac-textBlock > p code {
+    background: rgba(255,255,255,0.2) !important;
+}
+.container > button:hover > svg-icon {
+    fill: var(--cib-color-neutral-primary-background) !important;
+}
+.content > .ac-container {
+    color: var(--darkreader-neutral-text);
+}
+#b_results .b_algo.b_deeplinks_bg_color_kc {
+    background-image: none !important;
+}
+:root {
+    --cib-color-background-serp-neutral: ${#FFFFFF} !important;
+    --cib-color-background-serp-primary: ${#F5F5F5} !important;
+    --cib-color-background-surface-app-primary: ${#FFFFFF} !important;
+    --cib-color-background-surface-app-quaternary: ${#FFFFFF} !important;
+    --cib-color-background-surface-app-secondary: ${#FFFFFF} !important;
+    --cib-color-background-surface-app-tertiary: ${#F0F0F0} !important;
+    --cib-color-background-surface-card-disabled: ${rgba(255, 255, 255, 0.4)} !important;
+    --cib-color-background-surface-card-primary: ${rgba(255, 255, 255, 0.7)} !important;
+    --cib-color-background-surface-card-secondary: ${rgba(255, 255, 255, 0.4)} !important;
+    --cib-color-background-surface-card-tertiary: ${#FFFFFF} !important;
+    --cib-color-background-surface-solid-base: ${#F5F5F5} !important;
+    --cib-color-background-surface-solid-primary: ${#F7F7F7} !important;
+    --cib-color-background-surface-solid-quaternary: ${#FFFFFF} !important;
+    --cib-color-background-surface-solid-secondary: ${#EEEEEE} !important;
+    --cib-color-background-surface-solid-tertiary: ${#F9F9F9} !important;
+    --cib-color-background-system-attention-primary: ${rgba(255, 255, 255, 0.5)} !important;
+    --cib-color-background-system-caution-primary: ${#FFF4CE} !important;
+    --cib-color-background-system-critical-primary: ${#FDE7E9} !important;
+    --cib-color-background-system-success-primary: ${#DFF6DD} !important;
+    --cib-color-foreground-accent-balanced-primary: ${#174AE4} !important;
+    --cib-color-foreground-accent-balanced-secondary: ${#1543CD} !important;
+    --cib-color-foreground-accent-creative-primary: ${#75306C} !important;
+    --cib-color-foreground-accent-creative-secondary: ${#692B61} !important;
+    --cib-color-foreground-accent-disabled: ${rgba(23, 74, 228, 0.3)} !important;
+    --cib-color-foreground-accent-precise-primary: ${#006880} !important;
+    --cib-color-foreground-accent-precise-secondary: ${#005E73} !important;
+    --cib-color-foreground-accent-primary: ${#174AE4} !important;
+    --cib-color-foreground-accent-quaternary: ${#3B3FB2} !important;
+    --cib-color-foreground-accent-secondary: ${#1543CD} !important;
+    --cib-color-foreground-accent-tertiary: ${#123BB6} !important;
+    --cib-color-foreground-neutral-disabled: ${rgba(17, 17, 17, 0.4)} !important;
+    --cib-color-foreground-neutral-quaternary: ${#616161} !important;
+    --cib-color-foreground-neutral-secondary: ${#666666} !important;
+    --cib-color-foreground-neutral-tertiary: ${#919191} !important;
+    --cib-color-foreground-system-attention-primary: ${#106EBE} !important;
+    --cib-color-foreground-system-attribution-primary: ${#006621} !important;
+    --cib-color-foreground-system-caution-primary: ${#9D5D00} !important;
+    --cib-color-foreground-system-critical-primary: ${#C42B1C} !important;
+    --cib-color-foreground-system-error-primary: ${#B10E1C} !important;
+    --cib-color-foreground-system-link-primary: ${#4007A2} !important;
+    --cib-color-foreground-system-neutral-primary: ${rgba(0, 0, 0, 0.45)} !important;
+    --cib-color-foreground-system-neutral-strong: ${rgba(0, 0, 0, 0.8)} !important;
+    --cib-color-foreground-system-success-primary: ${#0F7B0F} !important;
+}
+.sl-media-container-wrapper .media-container {
+    z-index: 0 !important;
+}
+#b_header,
+.hider-cr-wrapper {
+    z-index: 1 !important;
+}
+.cat-nav {
+    position: relative !important;
+    z-index: 1 !important;
+}
+.bg-gradient-to-r {
+    background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
+}
+
+IGNORE INLINE STYLE
+.b_header_bg
+.sp-tpwebicons.WIKI *
+
+================================
+
+biorxiv.org
+
+INVERT
+.blood_logo
+.logo-img
+#czilogo
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+bitbay.net
+
+INVERT
+.navbar-brand
+.logo
+.full-page-preloader
+
+================================
+
+bitbucket.org
+
+INVERT
+a[href="/product"]
+.registration-hero .form-prompt
+
+CSS
+div[data-testid="file-header"] {
+    background-color: ${rgba(33, 53, 89, 0.08)} !important;
+}
+span[data-testid="file-tree-file__comments"] > span {
+    color: var(--darkreader-neutral-text) !important;
+}
+span > svg {
+    color: var(--icon-primary-color) !important;
+}
+[type="button"][tabindex="0"],
+[data-testid="settingsButton"] {
+    background-color: ${rgba(33, 53, 89, 0.04)} !important;
+}
+code.code,
+[type="button"][tabindex="0"]:hover,
+[data-testid="settingsButton"]:hover {
+    background-color: ${rgba(33, 53, 89, 0.08)} !important;
+}
+.ak-navigation-resize-button {
+    box-shadow: ${rgba(33, 53, 89, 0.08)} 0px 0px 0px 1px,
+                ${rgba(33, 53, 89, 0.08)} 0px 2px 4px 1px !important;
+}
+[data-testid="pipeline-row"]:hover {
+    background: var(--darkreader-neutral-background) !important;
+    box-shadow: -4px 0 0 0 var(--darkreader-neutral-background), 4px 0 0 0 var(--darkreader-neutral-background) !important;
+}
+[data-testid="result-page"]>div>div:nth-child(3),
+[data-testid="result-page"]>div>div:nth-child(3)>div {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+[role="presentation"] svg *
+[aria-label="Bitbucket"] *
+
+================================
+
+bitcoinprice.com
+
+CSS
+.highcharts-button-box {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+bitcoinwisdom.com
+
+INVERT
+.site-branding
+
+================================
+
+bitly.com
+
+CSS
+.hero-content {
+    background-image: none !important;
+}
+
+================================
+
+bitwarden.com
+
+INVERT
+img[alt="Github Logo"]
+img[src$="forbes.png"]
+app-login img.logo
+
+IGNORE IMAGE ANALYSIS
+blockquote .blockquote-header
+
+================================
+
+bitwit.tech
+
+CSS
+.svg-primary {
+    fill: #375D69 !important;
+}
+.svg-primary-light {
+    fill: #4A7F8F !important;
+}
+.svg-primary-dark {
+    fill: #28444D !important;
+}
+.svg-secondary {
+    fill: #B88399 !important;
+}
+.svg-secondary-light {
+    fill: #E8A9C4 !important;
+}
+.svg-secondary-dark {
+    fill: #825F6E !important;
+}
+.svg-light {
+    fill: #ADCED9 !important;
+}
+.svg-outline {
+    fill: none !important;
+    stroke: #000000 !important;
+}
+.svg-primary-outline {
+    fill: none !important;
+    stroke: #ADCED9 !important;
+}
+.svg-secondary-outline {
+    fill: none !important;
+    stroke: #375D69 !important;
+}
+.theme-light {
+    display: none !important;
+}
+.theme-dark {
+    display: none !important;
+}
+.theme-darkreader {
+    display: block !important;
+}
+
+================================
+
+biznes.pap.pl
+
+CSS
+body,
+#copy {
+    background-image: none !important;
+}
+
+================================
+
+blablacar.*
+blablacar.*.*
+
+INVERT
+.kirk-topBar-left
+
+================================
+
+blackboard.com
+
+INVERT
+li[class^="js-multiple-answer-answer"][class$="selected-answer"]
+li[class^="js-answer"][class~="is-selected"][class$="answer-selected"]::before
+.true-false-answer.selected-answer
+
+CSS
+li[class^="js-multiple-answer-answer"][class$="selected-answer"]::before {
+    border-color: $var(--darkreader-neutral-background) !important;
+}
+li[class^="js-answer"][class~="is-selected"][class$="answer-selected"]::before {
+    border-color: $var(--darkreader-neutral-background) !important;
+}
+.true-false-answer.selected-answer::before {
+    border-color: $var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+blahdns.com
+
+INVERT
+[src="https://cdn.blahdns.com/logo.png"]
+[src="https://cdn.blahdns.com/kofi4.png"]
+.liberapay-btn > span
+svg
+
+================================
+
+blaupunkt.com
+
+INVERT
+.fusion-standard-logo
+
+================================
+
+blog.arelion.com
+
+INVERT
+img[src="https://blog.arelion.com/wp-content/themes/arelion-blog-theme-kopia/public/images/logo.svg"]
+img[src="https://blog.arelion.com/wp-content/themes/arelion-blog-theme-kopia/public/images/ico/search-icon.svg"]
+img[src="https://blog.arelion.com/wp-content/themes/arelion-blog-theme-kopia/public/images/ico/right-arrow.png"]
+
+================================
+
+blog.cloudflare.com
+
+INVERT
+img[alt="The Cloudflare Blog"]
+
+CSS
+body#main-body {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+.dn {
+    color: ${white} !important;
+}
+#nav {
+    background-color: ${white} !important;
+}
+main#post {
+    background-color: ${white} !important;
+}
+article.post-full {
+    background-color: ${white} !important;
+}
+article p {
+    color: ${slategray} !important;
+}
+code {
+    color: ${black} !important;
+}
+nav.pagination {
+    background-color: ${white} !important;
+}
+
+================================
+
+blog.csdn.net
+
+CSS
+html {
+    height: inherit !important;
+}
+.main_father {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+blog.documentfoundation.org
+
+INVERT
+img[alt*="The Document Foundation Blog"]
+
+================================
+
+blog.doist.com
+
+INVERT
+.db-header__logo-img
+
+================================
+
+blog.gingerbeardman.com
+
+CSS
+body.playdate {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+blog.mozilla.org
+
+INVERT
+.content > .logo > [href^="https://www.mozilla.org/"]
+.nav-global-donate > [href^="https://donate.mozilla.org/"]
+
+CSS
+.nav-global-donate > [href^="https://donate.mozilla.org/"] {
+    color: ${white} !important;
+}
+#page {
+    background-image: none !important;
+}
+
+================================
+
+blog.nightly.mozilla.org
+
+INVERT
+.content > .logo > [href^="https://www.mozilla.org/"]
+.nav-global-twitter a::before
+.nav-global-join a::before
+
+CSS
+.nav-util-search .fm-search input {
+    border-color: ${#999} !important;
+}
+
+================================
+
+blog.racket-lang.org
+
+CSS
+body {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+blog.scssoft.com
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+blogger.com
+
+INVERT
+.gb_ua
+.feedflare
+
+================================
+
+blogs.windows.com
+
+CSS
+.c-video__icon::before {
+    color: ${white} !important;
+}
+.item-single__content ::before {
+    background-color: var(--darkreader-text--wp--preset--color--black) !important;
+}
+
+================================
+
+bloomberg.com
+
+INVERT
+.navi-bar__button-icon
+.navi-sections__item--LiveNow::before
+.navi-sections__link--current::after
+
+CSS
+.navi {
+    border-color: var(--darkreader-border--color-black) !important;
+}
+
+================================
+
+blueberryroasters.pl
+
+INVERT
+div#logo
+
+================================
+
+bluemic.com
+
+INVERT
+.blue-logo
+
+================================
+
+boardgamearena.com
+
+INVERT
+.bgagame-kingoftokyo .player-board .player-hand-card
+
+CSS
+body {
+    background: none;
+}
+.bga-dropdown__list.bg-bga-whitebg {
+    background-color: rgb(35, 38, 39);
+}
+.bg-bga-gray-204 {
+    background-color: rgb(57, 61, 62);
+}
+.bgagame-agricola .game-content,
+.bgagame-agricola #right-side,
+.agricola_popin_container,
+.dijitTooltip .action-holder,
+.dijitTooltip .player-card {
+    color: #000;
+}
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-card .action-header,
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-card .action-desc,
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-card .action-footer {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/agricola/230120-1146/img/action_frame.png");
+}
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-s .action-header,
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-s .action-desc,
+:is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-s .action-footer {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/agricola/230120-1146/img/action_frame_s.png");
+}
+.bgagame-bandada .cardontable,
+.bgagame-bandada .playercard {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/bandada/221108-1032/img/birds312.png");
+}
+.bgagame-bandada #dicearea {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/bandada/221108-1032/img/dicecard.png");
+}
+.bgagame-carnegie .cng_timeline_image {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/carnegie/210812-1806/img/timelines.png");
+}
+.bgagame-catcafe .ctc_player_board {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catcafe_sheet.jpg");
+}
+.bgagame-catcafe .ctc_square {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/drawings_black.png");
+}
+.bgagame-catcafe .ctc_cat_footprint {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catfootprint.png");
+}
+.bgagame-catcafe .ctc_column_scoring {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/column_scoring.png");
+}
+.bgagame-catcafe .ctc_txt_flash {
+    color: #007f37;
+}
+.bgagame-catcafe .ctc_sub_scoring {
+    color: #000;
+}
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-dog-bonus-text,
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-trick-cost-text,
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-back-text {
+    color: #000;
+}
+:is(.bgagame-doglover, .dijitTooltip) .DOG-card-trait-warning-text {
+    color: maroon;
+}
+.bgagame-doglover .DOG-unfed .DOG-played-dog-card .DOG-card-placeholder .DOG-unfed-border {
+    border-color: #7e0000;
+}
+.bgagame-evergreen .eve_remaining-actions .stockitem {
+    filter: invert(100%);
+}
+.bgagame-kingoftokyo .player-evolution-card {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kingoftokyo/230710-1229/img/evolution-cards.jpg");
+}
+.bgagame-kingoftokyo .kot-evolution {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kingoftokyo/230710-1229/img/evolution-cards.jpg");
+}
+.bgagame-kingoftokyo .kot-evolution .description-wrapper {
+    color: #000;
+}
+.bgagame-kingoftokyo #table .player-table .player-name .outline {
+    -webkit-text-stroke: 4px #000;
+}
+.bgagame-legendraiders #bag {
+    background-image: url("https://i.imgur.com/ptX6Fv7.png");
+}
+.bgagame-littlefactory .cardClay,
+.dijitTooltip .cardClay {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card2.jpg");
+}
+.bgagame-littlefactory .cardCotton,
+.dijitTooltip .cardCotton {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card4.jpg");
+}
+.bgagame-littlefactory .cardGrain,
+.dijitTooltip .cardGrain {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card1.jpg");
+}
+.bgagame-littlefactory .cardStone,
+.dijitTooltip .cardStone {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card5.jpg");
+}
+.bgagame-littlefactory .cardWood,
+.dijitTooltip .cardWood {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card3.jpg");
+}
+.bgagame-littlefactory .cell3 {
+    color: #000;
+}
+.bgagame-lox :is(
+    .coinCountA, .coinCountB, .coinCountC, .coinCountD,
+    .figurineCountA, .figurineCountB, .figurineCountC, .figurineCountD,
+    .guildCountA, .guildCountB, .guildCountC, .guildCountD,
+    .reputationCountA, .reputationCountB, .reputationCountC, .reputationCountD
+) {
+    color: #000;
+}
+.bgagame-microdojo .barrak {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/microdojo/221116-1802/img/barraks.png);
+}
+.bgagame-microdojo :is(.barrak, .Objname) {
+    color: #000;
+}
+.bgagame-patchwork .cost-label {
+    color: #222;
+}
+.bgagame-rainforest .token {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/rainforest/230403-1628/img/Tokens.png);
+}
+.bgagame-riftvalleyreserve #rvr-score-ref-holder {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/riftvalleyreserve/221228-1440/img/score_ref_vert.png);
+}
+.bgagame-riichimahjong :is(.JMJ_tile_other_annot, .JMJ_tile_self_annot) {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/riichimahjong/220818-0132/img/mahjongg_japan_annot.png");
+}
+:is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
+    color: #000;
+}
+.bgagame-sixtyone :is(.sxt_leave, .sxt_location) {
+    color: #000;
+}
+.bgagame-splashdown .sd_playerinfo_icon,
+.bgagame-splashdown .lilypad,
+.bgagame-splashdown .fly,
+.bgagame-splashdown .frog,
+.bgagame-splashdown .possibleMove {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/splashdown/230808-1947/img/tokens.png);
+}
+.bgagame-takaraisland .woundtoken {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/takaraisland/170709-1847/img/wound.png);
+}
+:is(.bgagame-thegnomesofzavandor, .dijitTooltip) :is(.helper, .helper2) {
+    color: #000;
+}
+.bgagame-tickettoride .train-car-group-counter {
+    -webkit-text-stroke: 3px #000;
+}
+.bgagame-tobago .clue_card {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/tobago/190401-1859/img/clue_cards.png);
+}
+.bgagame-tobago .hut {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/tobago/190401-1859/img/hut.png);
+}
+.kd_invite_card div[class*="bg-card"] {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kado/250219-0834/img/cards.jpg");
+}
+.kd_card_back {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kado/250219-0834/img/cards.jpg");
+}
+.nex_plname {
+    color: #000;
+}
+.nex_metropad {
+    background-blend-mode: multiply;
+    background-color: #b0b0b0;
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/nextstation/220831-1241/img/mainpad_back.jpg");
+}
+.nex_scorepad {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/nextstation/221221-2031/img/scorepad.jpg");
+}
+.rr-card {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/romirami/240422-0303/img/card_number.jpg") !important;
+}
+#rr-market-contract .rr-card-container .rr-card {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/romirami/240422-0303/img/card_contract.jpg") !important;
+}
+.rr-player-container-contract .rr-card {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/romirami/240422-0303/img/card_contract.jpg") !important;
+}
+.tactic-card .card-text {
+    color: #404040;
+}
+.tundra .dijitTooltipContainer {
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAYCAYAAAA7zJfaAAAAIklEQVQIW2OQl5f/zwAm5OTkyCFkZWX/MxBByMjI/GeAEwB0riA1hmHf7AAAAABJRU5ErkJggg==");
+}
+
+IGNORE INLINE STYLE
+.bgagame-riftvalleyreserve :is(.rvr-rift, .rvr-stop, .rvr-svg-border)
+
+================================
+
+boardgamegeek.com
+
+CSS
+.legacy button,
+.legacy input,
+.legacy optgroup,
+.legacy select,
+.legacy textarea {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+bogleheads.org/forum
+
+INVERT
+body:not(html[data-darkreader-proxy-injected="true"] body)
+img:not(html[data-darkreader-proxy-injected="true"] img)
+span.site_logo:not(html[data-darkreader-proxy-injected="true"] span)
+div.imcger-quote-shadow:not(html[data-darkreader-proxy-injected="true"] div)
+div.imcger-quote-togglebutton:not(html[data-darkreader-proxy-injected="true"] div)
+
+CSS
+cite:not(html[data-darkreader-proxy-injected="true"] cite) {
+    background-color: ${rgb(24, 26, 27)} !important;
+}
+
+IGNORE INLINE STYLE
+cite
+
+================================
+
+boincstats.com
+
+CSS
+#sidebar {
+    background-image: none !important;
+}
+
+================================
+
+bol.com
+
+CSS
+.bg-brand-background-minimal {
+    background-color: --darkreader-neutral-background !important;
+}
+.bg-neutral-background-medium {
+    background-color: white;
+}
+.grid {
+    z-index: 1;
+}
+
+================================
+
+bol.de
+
+CSS
+.tm-artikelbild-wrapper {
+    z-index: 0 !important;
+}
+
+================================
+
+boligsiden.dk
+
+CSS
+.bg-black {
+    background-color: rgb(0 0 0/var(--tw-bg-opacity)) !important;
+}
+
+================================
+
+bom.gov.au
+
+CSS
+.weather-mood {
+    background: none !important;
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+.legend__segment
+.weather-mood
+
+================================
+
+bonfire.com
+
+INVERT
+.sw-Logo
+
+================================
+
+book.douban.com
+
+IGNORE IMAGE ANALYSIS
+.bigstar50
+.bigstar45
+.bigstar40
+.bigstar35
+.bigstar30
+.bigstar25
+.bigstar20
+.bigstar15
+.bigstar10
+.bigstar05
+.bigstar00
+.allstar50
+.allstar45
+.allstar40
+.allstar35
+.allstar30
+.allstar25
+.allstar20
+.allstar15
+.allstar10
+.allstar05
+.allstar00
+.rating
+.starb
+.collectors
+
+================================
+
+booking.com
+*.booking.com
+
+INVERT
+span[data-testid="header-logo"]
+.bui-calendar__control
+.-iconset-close
+.-iconset-navarrow_left
+.-iconset-navarrow_right
+.security-popup_close
+.sort_more_options__button
+.mb-ico
+.-iconset-review_great
+.-iconset-review_poor
+.-iconset-chat_bubbles
+.location_section_icon
+.hp-date-picker-icon
+.-streamline-info_sign
+.-streamline-person
+.-streamline-chat_bubbles
+.hp-policies-calendar-icon
+.-iconset-moon_crescent
+
+CSS
+#ss {
+    background-position: 16px center !important;
+    background-repeat: no-repeat !important;
+    background-size: 20px !important;
+}
+
+================================
+
+booking.uz.gov.ua
+
+CSS
+td:has(img[alt=QR]) {
+    background-color: white !important;
+}
+
+================================
+
+books.google.*
+books.google.*.*
+
+INVERT
+.jfk-button-img
+
+================================
+
+books.googleusercontent.com
+
+INVERT
+reader-rendered-page.-gb-image > img
+
+CSS
+reader-rendered-page.-gb-text {
+    filter: none !important;
+}
+
+================================
+
+books.zoho.eu
+
+CSS
+.scrollbox {
+    background: none !important;
+}
+
+================================
+
+boredpanda.com
+
+INVERT
+.logotype
+
+================================
+
+boringcompany.com
+
+CSS
+.tweak-overlay-parallax-enabled .Parallax-item {
+    z-index: 1 !important;
+}
+
+================================
+
+bostonacoustics.com
+
+INVERT
+img[alt="logo"]
+
+================================
+
+bowerswilkins.com
+
+INVERT
+.logo
+
+================================
+
+boxberry.ru
+
+INVERT
+.slider__image
+img[src$="cancel.png"]
+.box_img_block
+img[src$="Vector.png"]
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+================================
+
+bpmn.io
+
+IGNORE INLINE STYLE
+.djs-visual > *:not(text:not(rect + text))
+
+================================
+
+br.de
+
+CSS
+article h4,
+article h3,
+article p,
+article .css-lip0i6,
+article h5,
+.asso-gtm,
+.css-18ckx31 {
+    color: ${#323232} !important;
+}
+article,
+article section,
+article footer,
+.css-1fzo8jw,
+.css-efdc07,
+article .css-fhbsai,
+main h3,
+section.css-3copat section {
+    background-color: ${white} !important;
+}
+
+================================
+
+brack.ch
+
+CSS
+body,
+body > header,
+.popover,
+.popover-body {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.list-group-item,
+.modal-content {
+    background: var(--darkreader-neutral-background) !important;
+}
+a:not(.product__category):not(:hover) {
+    color: var(--darkreader-neutral-text) !important;
+}
+.bhaal1Vl:hover,
+.bhauyhAt:hover {
+    color: ${black} !important;
+}
+
+================================
+
+brainly.com
+
+INVERT
+.brn-rich-content > p > img
+
+================================
+
+brainly.pl
+
+INVERT
+[id^="TexFormula"]
+div.brn-qpage-next-answer-box__content > div > div > div img:not(.brn-qpage-next-attachments-viewer-image-preview__image)
+
+================================
+
+brave.com
+
+CSS
+section + img {
+    display: none !important;
+}
+
+================================
+
+breadfinancial.com
+
+INVERT
+.header-wrapper__logo
+
+================================
+
+breakthrough.news
+newenergyreport.com
+realsciencenews.com
+
+INVERT
+#MastheadLeft img
+
+================================
+
+breitbart.com
+
+INVERT
+#FootW #FWI p .parler
+
+================================
+
+bricklink.com
+
+INVERT
+.blp-header__logo-image
+a[href*="/inventory.asp"]
+a[href*="/wanted/list.page"]
+a[href*="/myCollection/main.page"]
+
+IGNORE INLINE STYLE
+td[align="RIGHT"]+td[bgcolor]
+.pciColorTabListItem
+tr td+td[bgcolor]
+
+================================
+
+brilliant.org
+
+INVERT
+[class*="b-sprite-landing"]
+[class*="b-sprite-publishers"]
+.logo
+
+================================
+
+broadcom.com
+
+INVERT
+#header .navBrand .navbar-brand
+
+================================
+
+bromite.org
+
+CSS
+body,
+#container {
+    background-image: none !important;
+}
+
+================================
+
+browser.kagi.com
+
+INVERT
+img[src="public/images/checkmark.svg"]
+img[src="public/images/cross.svg"]
+
+================================
+
+browserleaks.com
+
+INVERT
+a::before
+
+CSS
+body {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#nav-menu a::before
+
+================================
+
+brucebase.wikidot.com
+
+CSS
+.yui-nav li em {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.yui-nav .selected a em {
+    background-color: var(--darkreader-selection-background) !important;
+    color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+bsi.bund.de
+
+INVERT
+.c-branding__logo
+
+CSS
+.c-intro {
+    z-index: 0 !important;
+}
+
+================================
+
+buffer.com
+
+IGNORE INLINE STYLE
+div[class^="style__LogoWrapper"] *
+
+================================
+
+bugs.mojang.com
+
+INVERT
+#logo
+
+================================
+
+bugs.python.org
+
+INVERT
+img[title="has PR"]
+img[title="GitHub"]
+
+================================
+
+bugzilla.opensuse.org
+bugzilla.suse.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background);
+    background-image: url("https://bugzilla.opensuse.org/skins/contrib/openSUSE/noise.png"), linear-gradient(${#d7d3c8}, var(--darkreader-neutral-background) 400px);
+}
+
+================================
+
+build-electronic-circuits.com
+
+INVERT
+.tutorial-intro
+.tutorial-intro > *
+
+CSS
+.page-todo-list {
+    background-color: rgb(109, 85, 9) !important;
+}
+
+================================
+
+bulbagarden.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+bulbapedia.bulbagarden.net
+
+INVERT
+img.mwe-math-fallback-image-inline
+
+================================
+
+bulk.com
+
+INVERT
+.swatch-attribute.bp_size .swatch-option::before
+
+CSS
+.swatch-attribute.bp_size .swatch-option.selected::after {
+    filter: none !important;
+}
+
+================================
+
+bulldogjob.pl
+
+INVERT
+img[alt~="Bulldogjob"]
+img[src="/bulldog.guide.svg"]
+img[src="/bulldog.tte.icon.svg"]
+
+================================
+
+bulldogjob.pl/proxied/job-offers
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+burmester.de
+
+INVERT
+.header-logo
+
+================================
+
+burnaware.com
+
+INVERT
+img[alt="Burnaware"]
+
+================================
+
+businessinsider.com
+businessinsider.com.au
+businessinsider.com.pl
+businessinsider.co.za
+businessinsider.es
+businessinsider.jp
+businessinsider.mx
+insider.com
+it.businessinsider.com
+
+INVERT
+.account-text-not-logged-in
+.article-share_buttons
+.brand
+.brands-logo
+.drawer-heading.headline-bold
+.f-footer-logo
+.f-header-logo
+.f-header-editionLabel
+.footer_logo-bi
+.footer_social-links
+.header-logo
+.ins-drawer-button-area
+.ins-drawer-vertical-link
+.loginbar-icon-people svg
+.logo
+.logo-primary
+.logo-pair-wrapper
+.masthead-icon
+.menu-search-icon
+.menu-lang-icon
+.navSocial-item
+.navbar-brand
+.net-social
+.network-toggle
+.new-menu-logo
+.p-post-contentPrimeEntryPrice
+.qotd_socials
+.search-btn
+.site-logo
+.social-container
+.social-icons > .social
+.socialmedia-icon-list
+.verticals-listitem-label
+a[title="Business Insider España"]
+a[id="menu-hamburger-button"]
+a[href="/szukaj"]
+button[class*="drawer-dropdown-button"]
+button[class="unbutton"] > img
+div[class*="footer__LogoWrapper"]
+div[class*="footer__SocialWrapper"]
+div[class*="header__Wrapper"]
+section[class*="brands-social"]
+
+================================
+
+businesswire.com
+
+INVERT
+body > header div:first-child
+
+CSS
+#bw-home {
+    background-image: none !important;
+}
+
+================================
+
+buy.stripe.com
+checkout.stripe.com
+
+INVERT
+img.Icon
+svg.InlineSVG
+
+CSS
+:root {
+    --darkreader-bg--border-box-shadow: 0 0 0 1px ${#e0e0e0}, 0 2px 4px 0 ${rgba(0, 0, 0, 0.07)}, 0 1px 1.5px 0 ${rgba(0, 0, 0, 0.05)} !important;
+    --darkreader-bg--border-box-shadowless: 0 0 0 1px ${#c0c0c0};
+    --darkreader-bg--checkout-gray800: ${hsla(0,0%,10%,0.9)};
+}
+[style*="background-color: rgb(18, 26, 31)"],
+.App-Container:has(.App-Background[style*="background-color: rgb(18, 26, 31)"]) {
+    background-color: black !important;
+}
+.RadioButton {
+    background-color: ${white} !important;
+    box-shadow: inset 0 0 0 1px ${rgba(20, 21, 22, 0.4)} !important;
+}
+.RadioButton:checked {
+    box-shadow: inset 0 0 0 5px ${black} !important;
+}
+
+================================
+
+buzzsprout.com
+
+INVERT
+.icon_edit
+.icon_stats
+.icon_share
+
+================================
+
+byte.com
+
+CSS
+.description.show {
+    z-index: 0 !important;
+}
+
+================================
+
+c60.la.coocan.jp
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+c64os.com
+
+CSS
+img {
+    background: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+cabinet.tax.gov.ua
+
+INVERT
+cb-header-public div.logo-add a div.icon
+
+================================
+
+cad.onshape.com
+
+INVERT
+.os-svg-icon
+.os-form-field-container
+
+CSS
+.os-svg-icon {
+    filter: grayscale(1) brightness(0.6) contrast(5) brightness(1.5) !important;
+}
+.os-panel-selector-button {
+    border-color: transparent !important;
+}
+
+================================
+
+caddy.community
+
+INVERT
+.logo-big
+
+================================
+
+caddyserver.com
+
+INVERT
+#logo
+#zerossl-logo
+#footer-logo
+
+CSS
+.hero {
+    background-image: none !important;
+}
+
+================================
+
+cadeados.com.br
+
+INVERT
+.banner__item
+
+CSS
+.categories--justify,
+.footer::before {
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+.bt-whatsApp
+#alertWapp
+#msg1
+div.pht-whatsapp"
+
+IGNORE IMAGE ANALYSIS
+.bt-whatsApp
+#alertWapp
+#msg1
+div.pht-whatsapp"
+
+================================
+
+cadence.com
+
+INVERT
+.logo
+
+================================
+
+caf.fr
+
+CSS
+#theme-contenu-cnaf .row[class*="conteneur-"][class*="-cnaf"] > [class*="col-"],
+#theme-contenu-menu-background-cnaf {
+    background-image: none !important;
+}
+
+================================
+
+caiyunapp.com
+
+INVERT
+#icon_current
+#logo-name[src="/imgs/logo/logo-website.png"]
+#map_canvas
+
+================================
+
+cake.avris.it
+
+CSS
+line[style*="stroke: black"],
+polygon[style*="stroke: black"] {
+    --box-a: 0.1 !important;
+    stroke: white !important;
+}
+text {
+    fill: white !important;
+}
+
+IGNORE INLINE STYLE
+*
+
+================================
+
+caldigit.com
+
+CSS
+.elementor-widget-heading .elementor-heading-title[class*="elementor-size-"] > a {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+calendar.google.com
+
+INVERT
+div[style*="gm_add_black"]
+.wRfGxb > svg > path:first-child
+
+CSS
+div[role="checkbox"] > div > div > div {
+    border: 1px solid ${black} !important;
+}
+div[role="dialog"] div[role="slider"][data-saturation] div:nth-child(2) {
+    background-image: linear-gradient(to right,#fff 0%,rgba(255,255,255,0) 100%) !important;
+}
+
+IGNORE INLINE STYLE
+div[role="checkbox"]
+div[role="dialog"] div[role="slider"]
+div[role="dialog"] div[role="slider"] div[style]
+div[role="dialog"] div[role="button"][data-contrast]
+
+================================
+
+calibre-ebook.com
+
+IGNORE IMAGE ANALYSIS
+.tooltip
+#content-wrapper
+
+================================
+
+calvinklein.us
+
+INVERT
+.star:not(.star-active)
+.star-half
+
+================================
+
+canakit.com
+
+INVERT
+#homePageIcon
+
+================================
+
+candidates.ibo.org
+
+INVERT
+img#ibLogo
+
+================================
+
+canva.com
+
+INVERT
+#__next > div > section > div[style^="background-color"]
+img[src*="category-public.canva.com/icons/"]
+
+CSS
+._8aslVA svg path {
+    fill: ${black} !important;
+}
+html[data-darkreader-scheme="dark"].light {
+    ---mghVQ: linear-gradient(180deg,#1d063f,#03152c) !important;
+}
+
+================================
+
+canvas.*.edu
+
+INVERT
+.file_download_btn
+.ic-DashboardCard__action-badge
+
+CSS
+textarea[class*="-textArea"],
+[class*="numberInput_input"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+canvas.usask.ca
+
+CSS
+#questions .text img {
+    background-color: currentColor !important;
+}
+
+================================
+
+capitoltrades.com
+
+INVERT
+.site-logo
+
+================================
+
+caramba-switcher.com
+
+INVERT
+.t996__cover
+
+================================
+
+caranddriver.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] :is(img, svg)[alt="Logo"]
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+nav#sidepanel button[aria-label="Close"] svg
+div[data-tracking-id="topNavSponsor"] img
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/caranddriver/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main img[src^="/_assets/design-tokens/caranddriver/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel div.open + div a[data-id="mega-footer-social-link"] > img {
+    display: none !important;
+}
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
+cardgames.io
+
+INVERT
+.faceup
+
+IGNORE IMAGE ANALYSIS
+.dice
+
+================================
+
+cargurus.com
+cargurus.co.uk
+
+CSS
+.homepage.redesign .ddC2dBanner .ddBannerSection .ddBannerSectionFigure .ddBannerSectionFigureWrapper {
+    background-image: url(https://static-assets.cargurus.com/images/site-p2p/homePageBanner/DD_Mobile_606bb2f4286d575e9a21b2f3ac776e8dd33d0deccf409fe1598859361ce63c05.png) !important;
+}
+[class*="_imgZIndex"] {
+    z-index: 0 !important;
+}
+
+================================
+
+carifred.com
+
+CSS
+.clform,
+.headertable {
+    background: var(--darkreader--neutral-background) !important;
+}
+
+================================
+
+carmax.com
+
+CSS
+.recall__placeholder,
+.vehicle-history__placeholder {
+    background-color: ${yellow} !important;
+}
+#recall .recall__header *,
+#recall .recall--link span {
+    color: #2a343d !important;
+}
+#recall svg,
+.vehicle-history__placeholder .vehicle-history a svg {
+    fill: #053361 !important;
+}
+#recall a,
+.vehicle-history__placeholder .vehicle-history a {
+    color: #004487 !important;
+}
+
+================================
+
+cars.com
+
+CSS
+.ep-theme-spark {
+    --darkreader-bg--spark-color-background-action-checked: ${fff} !important;
+    --ep-card-color-background: ${#fff} !important;
+    --ep-tabs-tabs-color-background: ${#ddd} !important;
+    --spark-color-background-action-checked: ${fff} !important;
+    --spark-color-background-callout-cool: ${#ddd} !important;
+    --spark-color-background-inverse: gray !important;
+}
+.sds-input-container .sds-text-field:focus {
+    background-color: rgba(20,20,20,0) !important;
+    color: var (--darkreader-neutral-text) !important;
+}
+[part="button"] {
+    background: var(--darkreader-bg--spark-_color-black) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+[part="base"] {
+    color: var(--darkreader-text--ep-tab-color-text) !important;
+}
+input,
+select {
+    background-color: var(--darkreader-bg--ep-form-control-input-color-background) !important;
+    color: var(--darkreader-text--ep-form-control-input-color-text) !important;
+}
+
+================================
+
+casasbahia.com.br
+
+CSS
+.product-card__image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+castbox.fm
+
+INVERT
+.nav-item.right.msg
+.nav-item.right.upload
+.nav-item.right.search
+.userNav-img[src="https://s3.castbox.fm/webstatic/images/userIcon.06c408dc.png"]
+.heart
+.playbackRate.timing.icon
+
+================================
+
+catalog.update.microsoft.com
+
+CSS
+#headerBox,
+#searchButtonBox,
+#searchGlowBottomBox,
+#searchGlowPart4aBox,
+#searchGlowPart4bBox,
+#searchGlowPart8aBox,
+#searchGlowPart8bBox,
+#searchGlowTopBox,
+.ResultsHeaderTD,
+.dialogBody,
+.mainBody,
+.mainBodyHome,
+.tabInactive {
+    background-image: none !important;
+}
+
+================================
+
+catbox.moe
+*.catbox.moe
+
+INVERT
+header img
+
+CSS
+body {
+    background-image: none !important;
+}
+div.image {
+    z-index: 1 !important;
+}
+
+================================
+
+catit.com
+
+CSS
+.gb-inside-container {
+    text-shadow: ${white} 1px 1px 0px !important;
+}
+
+================================
+
+catt.rs/en/latest
+
+CSS
+code.literal {
+    background-color: unset !important;
+}
+
+================================
+
+cbc.ca
+
+INVERT
+.logo
+
+================================
+
+cbpp.org
+
+INVERT
+.navbar-brand
+
+================================
+
+cbsnews.com
+
+CSS
+.content__read-more {
+    color: var(--darkreader-neutral-color) !important;
+}
+
+================================
+
+cdaction.pl
+
+INVERT
+a[href="/"] svg
+footer > div > svg
+
+================================
+
+cdc.gov
+
+INVERT
+.cdc-logo path[fill="#000"]
+img[src="/niosh/images/si-no-left-vp4.png"]
+
+IGNORE INLINE STYLE
+.map-container svg g
+.legend-item
+
+================================
+
+cdimage.ubuntu.com
+
+INVERT
+.p-navigation__logo
+
+CSS
+#main {
+    background-image: none !important;
+}
+
+================================
+
+cdn.privacy-mgmt.com
+
+INVERT
+img.logo
+
+================================
+
+cdn5.dcbstatic.com
+
+CSS
+#image942Img {
+    display: none !important;
+}
+li {
+    list-style-image: none !important;
+    list-style-type: circle !important;
+}
+
+================================
+
+cdn77.com
+
+INVERT
+a[class^="Nav_logo"]
+
+================================
+
+cdp.contentdelivery.nu
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+cdrtools.sourceforge.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+celio.com
+
+INVERT
+.ec_account__user
+.ec_header__logo
+.ec_minicart__user
+.ec_search__link
+.ec_store__locator
+
+================================
+
+celum.ssg-service.com
+
+CSS
+body:hover {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+ceneo.pl
+
+INVERT
+[data-new-icon]::before
+.cat-prod-row__product-link::after
+.add-to-favorite::after
+
+IGNORE IMAGE ANALYSIS
+[data-new-icon="basket"]::before
+[data-new-icon="heart"]::before
+[data-new-icon="user"]::before
+
+================================
+
+center-pf.kakao.com
+
+CSS
+.box_bubble .txt_chat {
+    color: rgb(255 255 255);
+}
+
+================================
+
+central.proxyvote.com
+
+INVERT
+.custom-control-label::after
+
+================================
+
+centrum24.pl
+
+INVERT
+#mobile-applications .jumbotron
+.headerLogo.bankLogo
+img[src*="close-black.svg"]
+img[src*="GOALS.png"]
+.mc-close-x-button-svg
+
+================================
+
+centrumxp.pl
+
+INVERT
+.badge-partner
+.img-responsive
+
+================================
+
+cfos-emobility.de
+
+CSS
+.navbar {
+    background-image: none !important;
+}
+
+================================
+
+cfos.de
+
+CSS
+div[style*="keyboard-light.jpg"],
+div[style*="organizer-light.jpg"],
+div[style*="data-center-light.jpg"],
+div[style*="speed-dial-light.jpg"] {
+    background-image: none !important;
+}
+
+================================
+
+changkun.de
+
+CSS
+.content h2,
+h3 {
+    z-index: 0 !important;
+}
+
+================================
+
+charitynavigator.org
+
+INVERT
+img[alt="Charity Navigator Logo"]
+
+================================
+
+chase.com
+
+INVERT
+.single-logo-icon
+
+CSS
+.menu-button-item {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+chat.deepseek.com
+
+CSS
+:root {
+    --darkreader-bg--dsr-bg: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+chat.google.com
+
+CSS
+:root {
+    --gm3-color-primary-container: var(--darkreader-bg--message-send-upgrade-background-color) !important;
+    --pkw-background: var(--darkreader-neutral-background) !important;
+}
+.nF6pT.yqoUIf.Pxe3Yd:not(.xOWoLe) .rogmqd {
+    background-color: var(--darkreader-bg--message-send-upgrade-background-color) !important;
+}
+
+================================
+
+cheapshark.com
+
+CSS
+.header {
+    border-top: 10px solid #000 !important;
+}
+
+================================
+
+check.spamhaus.org
+
+INVERT
+.gradient-yellow
+header .curve
+header .logo
+
+================================
+
+chem.libretexts.org
+
+INVERT
+.internal
+
+================================
+
+chemspider.com
+
+INVERT
+#rsc-header-title
+
+CSS
+.item-image rect[style*="fill: rgb(255, 255, 255)"]:first-child {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+chess-results.com
+
+INVERT
+.FarbewT
+
+================================
+
+chessprogramming.org
+
+INVERT
+.mw-parser-output div[class^='float'] > a > img:not(.thumbimage):not(.thumbborder)
+.mw-wiki-logo
+
+CSS
+table.fentt div.sq {
+    background-color: #FFCE9E !important;
+    color: #D18B47 !important;
+}
+table.fentt div.pcbg {
+    color: white !important;
+}
+table.fentt div.pcfg {
+    color: black !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.mw-wiki-logo
+
+================================
+
+chilkatsoft.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+chinadigitaltimes.net
+
+INVERT
+.show-menu-button span
+
+CSS
+#main-header-wrapper {
+    background-image: none !important;
+}
+
+================================
+
+chinauos.com
+
+INVERT
+.brand
+
+CSS
+.choose {
+    background-image: none !important;
+}
+
+================================
+
+chipotle.com
+
+INVERT
+.banner-title
+.banner-subtitle
+.banner-legal
+
+================================
+
+christinamin9-ancientromancivilisation.weebly.com
+
+CSS
+.landing-page #main-wrap,
+.tall-header-page #main-wrap,
+.short-header-page #main-wrap,
+.no-header-page #main-wrap {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+chromeenterprise.google
+
+INVERT
+#post-linkedin
+.ce-accordion--caret
+.glue-carousel__navigation > li
+.ce-device-card__details-title--icon
+img[src*="hackerone"]
+img[src*="blackberry"]
+img[src*="samsung-knox"]
+img[src*="paloalto"]
+img[src*="onelogin"]
+img[src*="splunk"]
+img[src*="climate"]
+img[src*="topcoder"]
+img[src*="bailey-nelson"]
+img[src*="colgate"]
+img[src*="square"]
+img[src*="getty-image"]
+img[alt*="romevo"]
+img[alt="Pythian"]
+img[alt="Amazon"]
+img[alt="Softbank"]
+img[alt="Cameyo"]
+img[alt="Citrix"]
+img[alt="Nutanix Frame"]
+img[alt="Dustin"]
+
+CSS
+img[alt="Onix"],
+img[alt="USEN"],
+img[alt="Inmac"],
+img[src*="first-ipo"],
+img[src*="compass-group"],
+img[src*="doctor-dot-com"],
+img[src*="devoted-health"],
+img[alt*="See how people"] {
+    filter: invert(15%) !important;
+}
+#how-to-buy {
+    background-color: var(--darkreader-background-neutral) !important;
+}
+
+================================
+
+chromestatus.com
+
+INVERT
+sl-icon
+
+CSS
+* {
+    --button-color: ${black} !important;
+    --card-background: --darkreader-background-neutral !important;
+    --md-gray-700-alpha: var(--darkreader-text--default-color) !important;
+}
+header > aside > hgroup > a > h1,
+section.card,
+header#header[part=header],
+p.description {
+    color: var(--darkreader-text--default-color) !important;
+}
+chromedash-roadmap-milestone-card {
+    background-color: var(--darkreader-background-neutral) !important;
+}
+section.release {
+    background-color: transparent;
+}
+div.nav-dropdown-container > ul {
+    background: grey !important;
+}
+
+================================
+
+chtoes.li
+
+INVERT
+.illustration
+.menu-page
+.menu-item
+
+================================
+
+churchofjesuschrist.org
+
+INVERT
+svg
+
+CSS
+.container,
+#PFmainFooter {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ci.appveyor.com
+
+CSS
+select {
+    background-image: none !important;
+}
+
+================================
+
+cinedrome.ch
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+circleci.com/docs
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+circuit-diagram.org
+
+INVERT
+.components-list .item .image
+
+================================
+
+cisce.org
+
+INVERT
+.nav-wrapper
+hgroup
+
+================================
+
+citilink.ru
+
+INVERT
+div[class$="RatingDetail__progress_active"]
+
+CSS
+.OldPageLayout {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+.Icon
+
+================================
+
+cityam.com
+
+INVERT
+.site-logo__image
+.menu-item a::before
+
+================================
+
+citybuzz.pl
+
+INVERT
+img[alt="CityBuzz"]
+
+================================
+
+citymapper.com
+
+INVERT
+#map
+
+================================
+
+classroom.google.com
+
+INVERT
+img[src$="dark_create_class_arrow.svg"]
+img[aria-label="YouTube"]
+div[role="dialog"] ~ div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"])
+
+CSS
+div[role="toolbar"] div[role="button"] > div[class*='-']:not([onclick]):not(:link):not(:visited):not([style*="background-image"]):first-child,
+div[role="toolbar"] div[role="button"] > div[class*='-']:not([onclick]):not(:link):not(:visited) > :nth-child(2) > div,
+div[style="bottom: 0px;"] > div[style^="opacity:"] div[role="button"] > div:not([onclick]):not(:link):not(:visited),
+li[guidedhelpid="classworkTopicListGh"]:not(hover) > div {
+    opacity: 99% !important;
+}
+.OkLq5b {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+claude.ai
+
+INVERT
+img[src="/anthropic_app_icon.png"]
+
+CSS
+.bg-gradient-to-b {
+    background-image: linear-gradient(to bottom, hsl(var(--darkreader-neutral-background)/1), hsl(var(--darkreader-neutral-background)/0)) !important;
+}
+
+================================
+
+cleantechnica.com
+
+CSS
+body {
+    background-color: #1d1e1f !important;
+    background-image: none !important;
+}
+
+================================
+
+clever.com
+
+CSS
+img[alt="i-Ready icon"],
+img[alt="Google Meet icon"],
+img[alt="Google icon"] {
+    background-color: white !important;
+}
+.background-container {
+    z-index: 1 !important;
+}
+
+================================
+
+click.endnote.com
+
+INVERT
+img[src="/static/images/settings/web-of-science.png"]
+
+================================
+
+click.endnote.com/viewer?doi=
+
+INVERT
+canvas
+
+================================
+
+client.schwab.com
+
+CSS
+#quickQuoteContainer,
+.sdps-header__bar--primary,
+.fdic-container,
+.highcharts-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sdps-text-legal,
+.fdic-text {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+clients.servarica.com
+
+INVERT
+.logo
+
+================================
+
+cloud.databricks.com
+pages.databricks.com
+*.azuredatabricks.net
+
+INVERT
+.figure
+#sparkui-iframe-body #plan-viz-graph svg g.cluster rect
+#sparkui-iframe-body #plan-viz-graph svg g.node rect
+.monaco-editor .cursors-layer .cursor
+
+CSS
+text {
+    fill: ${black};
+}
+.cm-string {
+    color: rgb(132, 179, 235) !important;
+}
+.cm-keyword {
+    color: rgb(232, 121, 172) !important;
+}
+.cm-variable-2 {
+    color: rgb(97, 215, 255) !important;
+}
+li.CodeMirror-hint {
+    font-family: Source Code Pro, Menlo, monospace;
+}
+span[role="presentation"] {
+    color: ${black} !important;
+}
+.CodeMirror-cursor {
+    border-left-color: ${black} !important;
+}
+.ansiout {
+    color: ${rgb(85, 85, 85)} !important;
+}
+.rm-modal {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+cloud.digitalocean.com
+
+CSS
+.sc-cwHptR,
+.sc-eBMEME,
+.sc-tNXst,
+.sc-kOPcWz,
+.sc-DRugm,
+.sc-dtBdUo,
+.sc-dJiZtA,
+.sc-bMCYpw,
+.js-input,
+.ember-text-field {
+    background-color: inherit !important;
+}
+.sc-uVWWZ {
+    background-color: ${#dfe0e0} !important;
+}
+input[type="text"],
+input[type="text"]::placeholder {
+    color: var(--darkreader-neutral-text) !important;
+}
+.action-item {
+    color: var(--darkreader-neutral-text) !important;
+}
+.sc-cbPlza::before,
+.sc-gHCuMn::before,
+.sc-itktkY::before,
+.sc-dnreFw::before,
+.sc-hnCoju::before,
+.sc-eRdibt::before,
+.sc-jcdlHQ::before,
+[class*="Container"],
+[class*="LooseInteractionButton__InnerButton"],
+[class*="RoundButcon"] {
+    background: none !important;
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sc-hmdomO[data-active-item=""] {
+    background-color: ${#d0d3d3} !important;
+}
+.sc-gRtvSG {
+    background-color: ${#e2e3e3} !important;
+}
+
+================================
+
+cloudflare.com
+
+CSS
+.cover {
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+.footer-bottom-row-margin > div > a > svg > path
+
+================================
+
+cloudhostnews.com
+
+INVERT
+.site-title
+
+================================
+
+cloudinfrastructuremap.com
+
+INVERT
+canvas.mapboxgl-canvas
+
+================================
+
+cloudlinux.com
+
+INVERT
+img.mega-menu-logo
+
+================================
+
+cloudways.com
+
+INVERT
+.md-button.md-primary.md-raised
+
+================================
+
+club-3d.com
+
+INVERT
+header .navbar-brand.logo img
+.carousel-indicators .active
+img[src*="TDSYNNEXLogo%402x.png"]
+
+CSS
+font.text-o-color-1 * {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+cnbc.com
+
+INVERT
+.RenderKeyPoints-list li::before
+.WatchLiveRightRail-logo
+
+CSS
+div[class^="FeaturedStories-styles-makeit-background"]::before {
+    opacity: 0.1 !important;
+}
+
+IGNORE INLINE STYLE
+svg.ProPill-proPill *
+
+================================
+
+cnki.net
+
+INVERT
+.hello-yx-box
+.klogin_header_Logo
+.search-main > .input-box > .search-btn
+.Logo
+
+CSS
+.foot-top {
+    background-image: none !important;
+}
+.hello-yx-box {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+cnn.com
+
+INVERT
+[data-test="section-link"] > svg:not(.business-logo-icon)
+img.metadata-header__logo
+
+CSS
+#header-nav-container::before {
+    border-bottom-color: transparent !important;
+}
+
+IGNORE INLINE STYLE
+svg.cnn-badge-icon
+svg.cnn-badge-icon > rect
+svg.politics-logo-icon
+svg.business-logo-icon
+
+================================
+
+cnnbrasil.com.br
+
+INVERT
+img[alt="CNN Brasil V&G"]
+.menu__hamburguer span
+
+CSS
+.block__news__title:not(figcaption > .block__news__title):not(.carousel__item .block__news__title),
+.author__group a,
+.newReadMore__link:not(:hover),
+.read-too__post-title,
+div.single-content h2,
+div.single-content h3 {
+    color: var(--darkreader-text--clr-cnn-grey-5) !important;
+}
+:root:has([data-dark-theme="false"]) {
+    --cnntv-background: ${#f3f3f3};
+    --cnntv-background-1: ${#fff};
+    --cnntv-bege: ${#333};
+    --cnntv-dark-gray: ${#D8D8D8};
+    --cnntv-dark-gray-2: ${#373737};
+    --cnntv-light-gray: ${#B3B3B3};
+    --cnntv-light-gray-2: ${#AEAEAE};
+    --cnntv-light-gray-3: ${#676363};
+    --cnntv-light-gray-4: ${#ad9f9f};
+    --cnntv-search-input: ${#FFF};
+    --cnntv-text__white: ${#050505};
+}
+html[data-darkreader-scheme="dark"] [data-dark-theme="false"] .cnntv__theater--row img {
+    filter: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+footer.black .footer__follow__nav .youtube__social__media a
+
+================================
+
+cnnews.chosun.com
+
+INVERT
+.logo
+
+================================
+
+cobaltstrike.com
+cobalt-strike.github.io
+
+INVERT
+.navbar-brand
+
+================================
+
+coca-cola.com
+
+INVERT
+header .cmp-image__image
+
+================================
+
+code.qt.io
+
+INVERT
+td[class="logo"]
+select
+input
+
+================================
+
+codeberg.org
+codeberg-test.org
+
+CSS
+main header .header-background-image {
+    filter: brightness(50%) sepia(40%) !important;
+}
+main header .header-title {
+    z-index: 1 !important;
+}
+
+================================
+
+codecademy.com
+
+INVERT
+.CodeMirror-cursors
+.CodeMirror-selected
+span[class^="burger"]
+.cursor-solid
+
+================================
+
+codeforces.com
+
+INVERT
+#header > div:first-child img
+#userActivityGraph rect[data-items=""]
+.delete-resource-link
+.action-link img
+.non-decorated img[src$="tablesorter-bg.gif"]
+.tex-formula
+
+CSS
+.datatable,
+.datatable > div,
+.roundbox {
+    border-radius: 6px;
+}
+.lt,
+.rt,
+.lb,
+.rb,
+.ilt,
+.irt,
+.roundbox-lt,
+.roundbox-rt,
+.roundbox-lb,
+.roundbox-rb {
+    display: none;
+}
+.backLava,
+.leftLava {
+    border-radius: 4.5px;
+}
+.backLava,
+.leftLava,
+.bottomLava,
+.cornerLava {
+    background: ${#BEBEBE} !important;
+}
+.sidebar-menu ul li {
+    border-color: transparent !important;
+}
+.highlighted-row td,
+.highlighted-row th {
+    background-color: ${rgb(195, 205, 215)} !important;
+}
+#footer img[alt="TON"] {
+    border-radius: 50%;
+}
+.cfpp-navbar-item > a {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+#userActivityGraph rect
+
+================================
+
+codewars.com
+
+INVERT
+.logo
+
+================================
+
+codingame.com/ide
+
+CSS
+.cg-statement .statement-body span.var,
+.cg-statement .statement-body var {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+codio.com
+
+INVERT
+.cursor
+
+================================
+
+coffeewatch.org
+
+INVERT
+a[title="Logo"]
+
+================================
+
+coinbase.com
+
+CSS
+.hjbuvQ,
+.kfQbHv {
+    fill: ${black} !important;
+}
+
+================================
+
+coindesk.com
+
+INVERT
+svg[class^="desktop-navigationstyles__StyledLogo"]
+
+================================
+
+coingecko.com
+
+INVERT
+.highcharts-background
+
+================================
+
+coliss.com
+
+CSS
+body,
+#container3,
+#sidebar {
+    background-image: none !important;
+}
+
+================================
+
+color-hex.com
+
+INVERT
+img[src*="logo"]
+.bgwhite
+.bgwhite > .previewbox
+
+IGNORE INLINE STYLE
+.colordvaline
+.colordva
+.palettecolordiv
+.sp-val
+.sp-picker-container
+.sp-container
+.sp-thumb-inner
+.sp-preview-inner
+.sp-hue
+.colordivbig
+.hexcolor
+.red
+.green
+.blue
+.cyan
+.magenta
+.yellow
+.preview
+.previewbox
+td
+.wheel
+.overlay
+.colorwell
+
+================================
+
+colorhunt.co
+
+IGNORE INLINE STYLE
+.palette > div
+
+================================
+
+colorjs.io
+
+CSS
+a {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+colorpicker.me
+
+IGNORE INLINE STYLE
+html
+body
+button
+
+================================
+
+colors.dopely.top
+
+INVERT
+.footer
+.color-selector-icon
+
+CSS
+input.number-slider {
+    filter: invert(10%) saturate(0%) !important;
+}
+img[src*="svg"],
+.title {
+    filter: invert(50%) !important;
+}
+.accountDopely__letter,
+.editProfile__changeProfilePicture {
+    filter: saturate(0%) brightness(50%) !important;
+}
+div[class*="text"],
+a[class*="header"],
+.navbar-dropdown-item__logo,
+.navbar__listItem__button {
+    filter: saturate(0%) !important;
+}
+
+IGNORE INLINE STYLE
+.ExpandPalette *
+.toner-colors-container *
+.color-picker
+
+================================
+
+comdirect.de
+*.comdirect.de
+
+CSS
+:root {
+    --darkreader-bg--color--cd-lemon: 153, 147, 0 !important;
+}
+.layer__content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+comicfury.com
+
+CSS
+#wrapper {
+    background-color: inherit !important;
+    padding-bottom: 10px !important;
+}
+#footer {
+    margin-top: 0px !important;
+}
+
+================================
+
+comingsoon.net
+
+CSS
+body,
+main {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+comixology.com
+
+INVERT
+.comixology-logo
+.primary-heading
+.heading-content
+.try-now
+.unlimited-disclaimer
+
+================================
+
+comma.ai
+
+INVERT
+.comma-header-logo
+.comma-two-benefit-icon
+.comma-landing-reviews-logo
+
+================================
+
+commoncause.org
+
+CSS
+.wrap1 {
+    background-color: var(--darkreader-bg--c_b1t) !important;
+}
+
+================================
+
+commonvoice.mozilla.org
+
+INVERT
+div:not(.logo-container) > .main-logo
+.hero-box .fading
+.waves
+.mars + .screenshot
+#help-links img
+.button.outline.rounded.hidden-sm-down img
+.text-button.contribute-more-button.secondary path
+
+CSS
+.language-select .current {
+    --white: var(--darkreader-bg--white) !important;
+}
+
+================================
+
+commscope.com
+
+INVERT
+.commscope-logo
+
+================================
+
+community.cloudflare.com
+
+CSS
+:root {
+    --darkreader-text--primary-medium: ${gray} !important;
+}
+
+================================
+
+community.kde.org
+
+CSS
+.vector-sticky-pinned-container::after {
+    background: inherit;
+}
+
+================================
+
+community.mimecast.com
+
+CSS
+.cb-section_background {
+    mix-blend-mode: multiply !important;
+}
+
+================================
+
+community.notepad-plus-plus.org
+
+INVERT
+.forum-logo
+
+================================
+
+community.ntppool.org
+
+INVERT
+#site-logo
+
+================================
+
+community.progress.com
+
+CSS
+:root {
+    --lwc-colorContentAreaBackground: var(--darkreader-neutral-background) !important;
+    --lwc-pageHeaderColorBackground: ${rgb(243, 243, 243)} !important;
+}
+
+================================
+
+computerhope.com
+
+INVERT
+#text-tool > p > img
+
+================================
+
+computeruniverse.net
+
+CSS
+select.SortByBase_select__uXyP4,
+button[class*="Button_headerLightBlue"] {
+    background-color: #092846 !important;
+    color: rgb(232, 230, 227) !important;
+}
+select.SortByBase_select__uXyP4 option {
+    background-color: rgb(24, 26, 27) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.SortByBase_select__uXyP4
+
+================================
+
+comsol.com
+
+INVERT
+div.latex
+div.Eqn
+
+================================
+
+confectioneryproduction.com
+
+INVERT
+#mainLogo img
+
+================================
+
+confluence.*
+
+INVERT
+.gliffy-text-with-shape-parent-primary
+.gliffy-text-with-shape-parent-secondary
+.gliffy-text-with-shape-parent-tertiary
+.gliffy-text-with-shape-parent-highlight
+
+CSS
+.geDiagramContainer rect,
+.geDiagramContainer path {
+    filter: brightness(60%);
+}
+
+================================
+
+console.cloud.google.com
+
+CSS
+.cfc-ng2-region .cfc-text-title-3 {
+    color: var(--darkreader-neutral-text) !important;
+}
+.cfc-color-text-secondary {
+    color: ${#333} !important;
+}
+input[type=text] {
+    color: var(--darkreader-neutral-text) !important;
+}
+.cfc-outline-focus-indicator {
+    background: var(--darkreader-neutral-background) !important;
+}
+.bq-results-table-header-cell {
+    background: var(--darkreader-neutral-background) !important;
+}
+.monaco-editor .cursor,
+.monaco-editor .cursor-block,
+.monaco-editor .cursor-line {
+    background-color: ${#000000} !important;
+    border-color: ${#000000} !important;
+}
+
+================================
+
+consorsbank.de
+
+CSS
+img[src="/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand.jpg"] {
+    display: none;
+}
+img[src="/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand-mobil.jpg"] {
+    display: none;
+}
+div.select-dropdown > select {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+consumerlab.com
+
+INVERT
+#overlay-toggle > .collapsed
+.header-link-home
+
+CSS
+span[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: #550 !important;
+}
+
+================================
+
+contacts.google.com
+
+INVERT
+img[src*="rotate"]
+
+CSS
+img[src^="https://ssl.gstatic.com/social/contactsui/images/emptycontacts/emptycontacts_animation_"],
+div > c-wiz[data-p^='%.@.[[1,3'] > div > div > div > div > div:first-child {
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important;
+}
+
+================================
+
+containertoolbx.org
+
+CSS
+body,
+img,
+video,
+iframe {
+    filter: none !important;
+}
+
+================================
+
+convertio.co
+
+INVERT
+.logo svg > :last-child
+.api-cta-icon > svg
+.logos.no-select > *
+
+CSS
+.softobar.js-softobar,
+.footer {
+    background-color: #1c1f20 !important;
+}
+.ct-tab {
+    border-bottom-color: #525252 !important;
+}
+.footer-sitemap {
+    border-bottom-color: #3e3e3e !important;
+}
+.col.copyright > p.logo > a {
+    color: #9D9488;
+}
+.col.copyright > p.logo > a > svg > use {
+    filter: none !important;
+}
+
+================================
+
+cookiepedia.co.uk
+
+INVERT
+.main-logo
+.footer-logo
+
+================================
+
+coolblue.be
+coolblue.nl
+hotorangemedia.nl
+
+IGNORE INLINE STYLE
+.header__logo-image > path
+
+================================
+
+coolors.co
+
+CSS
+.generator_color {
+    color: #fff !important;
+}
+.generator_color.is-light {
+    color: #000 !important;
+}
+
+IGNORE INLINE STYLE
+#generator *
+
+================================
+
+coopgames.eu
+
+INVERT
+img[alt="Online Co-Op"]
+img[alt="Local Co-Op"]
+img[title="PS2"]
+img[title="PS3"]
+img[title="PS4"]
+img[title="PSP"]
+img[title="PS Vita"]
+img[title="DS"]
+img[title="3DS"]
+img[title="Switch"]
+
+================================
+
+copilot.microsoft.com
+
+INVERT
+button[is="cib-button"] svg-icon
+button[class$="icon-button"] svg-icon
+
+================================
+
+copitosystem.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+copytonotion.com
+
+INVERT
+.inline
+
+CSS
+svg.absolute {
+    visibility: hidden !important;
+}
+
+================================
+
+corriere.it
+
+INVERT
+.footer__content div div img
+
+================================
+
+corsair.com
+
+INVERT
+img.desktop
+img[src="/_ui/responsive/common/images/icon_cart_empty.png"]
+a.cart-close
+input#search-btn
+.swatch-white
+
+================================
+
+costplusdrugs.com
+
+INVERT
+img[src$="MCCP-wordmark-denim.png"]
+
+================================
+
+coupang.com
+mc.coupang.com
+
+INVERT
+.select--category--button
+img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#person"]
+img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#cart"]
+.main-section h2
+#categoryBestMenu > .category-anchor
+.category-best-title-ad-product
+
+================================
+
+courses.fit.cvut.cz
+
+CSS
+body {
+    color: #909090;
+}
+.App.in-search {
+    background-color: #212121 !important;
+}
+.UserMenu .user-initials {
+    background-color: #616161 !important;
+}
+.CoursesItem .column-info > a:hover {
+    color: #58c1ffba;
+}
+header {
+    background-color: #212121 !important;
+}
+pre {
+    color: #a8a6ab;
+}
+.header {
+    background: none;
+    border-bottom: 1px solid #676767;
+}
+main img {
+    opacity: 0.8;
+}
+a {
+    color: #58c1ffba;
+}
+
+================================
+
+cowkrakowie.pl
+
+INVERT
+.logo
+.nav-logo
+
+================================
+
+coze.com
+
+CSS
+.semi-spin-children * {
+    background: none;
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+cplusplus.com
+
+CSS
+#I_mid,
+#I_top {
+    background-image: none;
+}
+img[src$=".png"] {
+    background-color: white;
+}
+
+================================
+
+cppm3144.itdhosting.de
+
+CSS
+.ppm_button {
+    background: ${white} !important;
+}
+.tableContent img {
+    background-image: url("https://cppm3144.itdhosting.de/niku/ui/uitk/images/odf.png") !important;
+}
+
+================================
+
+cpulator.01xz.net
+
+INVERT
+.terminal-cursor
+.cm-s-neat span.cm-tag
+
+CSS
+div.dev_uart_term .terminal-cursor {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.cm-s-neat span.cm-tag {
+    color: #006000;
+}
+
+================================
+
+cqksy.cn
+
+INVERT
+td[background="image/Index_QI_CenterBar.gif"]
+
+CSS
+table {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+td[background="image/Index_QI_CenterBar.gif"],
+td[background="image/Index_QI_CenterBar.gif"] a {
+    color: ${white} !important;
+}
+
+================================
+
+crates.io
+
+IGNORE INLINE STYLE
+svg[class^="_logo"] *
+
+================================
+
+creality.com
+
+CSS
+a.product_title {
+    color: black !important;
+}
+div.core_main {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.main .core_img .core_img_K2_Plus
+.main .core_img .core_img_k1_max
+
+================================
+
+creative.com
+
+INVERT
+div.small-logo img.creative-logo
+body:not(body[class^="storepage"]) div#all img.creative-logo
+.sb-upgrade > h3
+.sb-upgrade > p
+.tws-series > h3
+.tws-series > p
+
+CSS
+.input::placeholder {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+creativecommons.org
+
+INVERT
+.icon-replace
+a.search::before
+
+CSS
+main a,
+footer a {
+    --underline-background-color: transparent !important;
+    background-position: 0% 93%,100% 93%,0% 93% !important;
+    background-repeat: no-repeat,no-repeat,repeat-x !important;
+    background-size: .05em 1px,.05em 1px,1px 1px !important;
+}
+.home-narrative .case-studies {
+    z-index: 0 !important;
+}
+
+================================
+
+creditkarma.com
+
+INVERT
+.navi-logo
+
+================================
+
+crowdfense.com
+
+INVERT
+.logo
+.mega-menu.menu-hover-line > li.menu-item > a::before
+
+================================
+
+crowdin.com
+
+INVERT
+.crowdin-navbar__logo
+svg.logo-icon-projects
+.file_type
+.file_type.file_folder.file_branch
+[class*=static-icon]
+
+CSS
+.main-menu-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+croxyproxy.com
+
+CSS
+html:not([__cpp]) > body {
+    background-image: unset !important;
+}
+
+================================
+
+crunchbase.com
+
+INVERT
+.identifier-nav
+.tab-label
+.header-container > img
+
+CSS
+.mat-tab-label-active {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+crutchfield.com
+
+INVERT
+.logo-module svg
+
+================================
+
+cruxvis.withgoogle.com
+
+CSS
+.input-wrapper {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+cryptostorm.is
+
+INVERT
+img[src*="lock.png"]
+img[src*="storm.png"]
+
+CSS
+body > div {
+    background-image: none !important;
+}
+
+================================
+
+cs61a.org
+
+CSS
+table#calendar td {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+css-tricks.com
+
+CSS
+.article-article {
+    background: ${white} !important;
+}
+
+================================
+
+cubawiki.com.ar
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+================================
+
+currys.co.uk
+
+INVERT
+img[class="productStickerImage w-auto"]
+
+================================
+
+curseforge.com
+
+IGNORE IMAGE ANALYSIS
+.e-generic-header
+
+================================
+
+cutlermaine.net
+
+CSS
+.sqs-block-button-element--medium:hover,
+.sqs-block-button-element--large:hover {
+    background: gray !important;
+}
+
+================================
+
+cxp.cengage.com
+
+INVERT
+.owl_item_container img[src*=".gif"]
+.ci-feedback img[src*=".gif"]
+label img[src*=".gif"]
+span.MathJax_SVG g[stroke="black"]
+
+CSS
+.owl_item_container img[src*=".GIF"] {
+    background-color: ${black};
+}
+font[color="white"] {
+    color: transparent !important;
+}
+div.tool-container.gradient > .controlButtons {
+    background-image: none;
+}
+div.tool-container.gradient {
+    box-shadow: none;
+}
+
+IGNORE INLINE STYLE
+span.MathJax_SVG g
+
+================================
+
+cyberlink.com
+
+INVERT
+.logo_pc
+
+================================
+
+cybernews.com
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+cynkra.com
+
+INVERT
+.btn-outline-dark
+.shadow
+.navbar-dark .navbar-brand
+.cynkra-logo-font
+
+CSS
+.btn-outline-secondary {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+cypress.io
+
+INVERT
+img[alt="Cypress Logo"]
+
+CSS
+.bg-gradient-to-r {
+    background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
+}
+
+================================
+
+cyprus-mail.com
+
+INVERT
+.custom-logo-link
+
+================================
+
+cysgliad.com
+
+INVERT
+img[src*="logo_cysill_arlein_cy.gif"]
+img[src*="hysbyseb_arlein.gif"]
+div > img.gwt-Image
+
+CSS
+body {
+    background-image: none !important;
+}
+div[tabindex] > div {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+textarea.cysilltextarea {
+    border: none !important;
+}
+
+================================
+
+czasnastopy.pl
+
+INVERT
+.brandinglogo-wrap
+
+================================
+
+czypada.pl
+
+INVERT
+#map
+
+================================
+
+czyztak.pl
+
+INVERT
+img[alt*="Logo"]
+
+================================
+
+d.hatena.ne.jp
+
+INVERT
+img[alt="Hatena Blog Tags"]
+
+================================
+
+d2l.ai
+
+INVERT
+img[src$=".svg"]
+
+================================
+
+d2l.lonestar.edu
+
+CSS
+.d2l-navigation-s-menu-item-root {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.d2l-twopanelselector-side {
+    --d2l-color-regolith: var(--darkreader-bg--d2l-color-regolith) !important;
+}
+
+================================
+
+daily.afisha.ru
+
+INVERT
+svg[class^="Logo"]
+.headline__open
+.search-icon
+.sprite-search-black-26
+mark
+
+================================
+
+dailydot.com
+
+INVERT
+h1.u-about-pitch
+
+CSS
+svg.main-logo.inline-flex g g[fill="#110133"] {
+    --darkreader-inline-fill: ${#110133} !important;
+}
+
+================================
+
+dailyexpose.uk
+
+INVERT
+.header-image
+
+================================
+
+dailymotion.com
+
+IGNORE INLINE STYLE
+div[class*="logoContainer"] a svg path
+
+================================
+
+dailywritingtips.com
+
+CSS
+blockquote {
+    z-index: 0 !important;
+}
+
+================================
+
+daltonmaag.com
+
+INVERT
+#panel-3 img
+
+================================
+
+danyk.cz
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+darcs.net
+
+INVERT
+#header > a > img
+
+================================
+
+darkbricks.net
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+darksky.net
+
+INVERT
+.currentLocationButton
+.searchButton
+span[class^="skycon swip"]
+#right-arrow
+#left-arrow
+
+================================
+
+dash.cloudflare.com
+
+INVERT
+a[data-testid^="link-homepage"]
+
+CSS
+.monaco-editor-background,
+.monaco-editor .margin {
+    background-color: ${rgb(226 229 231)} !important;
+}
+
+================================
+
+dashboard.stripe.com
+
+CSS
+[data-auto-transform-background="true"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+dashboard.thechurchapp.org
+
+INVERT
+#ember62
+
+================================
+
+datacamp.com
+*.datacamp.com
+
+CSS
+video#vjs_video_3_html5_api.vjs-tech {
+    background-color: rgb(175, 175, 175, 0.5);
+    transform: translate(0px, 0px) !important;
+}
+.css-hu6jey code {
+    color: var(--darkreader-neutral-text) !important;
+    mix-blend-mode: normal !important;
+}
+.css-hu6jey pre {
+    color: var(--darkreader-neutral-text) !important;
+    mix-blend-mode: normal !important;
+}
+.css-alxior code,
+pre {
+    color: ${#0f0f0f} !important;
+    mix-blend-mode: difference !important;
+}
+.css-1ebl8to code,
+pre {
+    color: ${#0f0f0f} !important;
+    mix-blend-mode: difference !important;
+}
+
+================================
+
+daum.net
+
+CSS
+.txt_pctop,
+.bg_login {
+    background-image: none !important;
+}
+
+================================
+
+dawn.com
+
+INVERT
+img[alt="Dawn Logo"]
+
+================================
+
+dc.sourceafrica.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+dcard.tw
+
+CSS
+#__next {
+    background-color: var(--color-main-dark) !important;
+}
+.atm_26_6oh0b4.atm_26_6oh0b4 {
+    background-color: var(--darkreader-bg--color-ui-background) !important;
+}
+.atm_leio7s_1647m0t svg {
+    fill: var(--darkreader-text--color-text-semi-light) !important;
+}
+.atm_2d_1nnff6z.atm_2d_1nnff6z {
+    background-color: var(--avatar-color) !important;
+}
+
+================================
+
+dd1.fr
+
+INVERT
+.container-fluid button img
+
+================================
+
+deadpixeltest.org
+
+CSS
+html {
+    background-color: transparent !important;
+}
+
+IGNORE INLINE STYLE
+body
+
+================================
+
+deadroots.net
+
+INVERT
+#header img
+
+================================
+
+debian.org
+*.debian.org
+*.debian.net
+
+INVERT
+.community img
+img[src*="openlogo-100.jpg"]
+img[src*="openlogo-50.png"]
+img[src*="openlogo-50.svg"]
+img[src*="openlogo-nd-75.png"]
+
+CSS
+body {
+    background-image: none !important;
+}
+.header-logged-out {
+    background-color: transparent !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#splash h1
+
+================================
+
+debijbel.nl
+
+INVERT
+.siteLogo
+.filter-item__link > img
+
+================================
+
+decathlon.in
+decathlon.nl
+decathlon.com.br
+
+CSS
+img {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+decathlon.pl
+
+INVERT
+.dkt_logo
+.benefit-icon
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+deccanchronicle.com
+
+INVERT
+img[src$="logo.png"]
+
+================================
+
+decisionproblem.com
+
+INVERT
+.qChip
+
+CSS
+#giftShopDiv {
+    color: ${white} !important;
+}
+.projectButton:disabled {
+    color: ${gray} !important;
+}
+
+================================
+
+deepl.com
+
+INVERT
+.dl_translator_link_container > img
+.dl_ad_pro__features_item::before
+.dl_logo_text
+img[class^="productNavigation-module--logoText"]
+img#languageSelectorIcon
+footer > div > div > div > div > a > img[alt="DeepL"]
+div[class^="socialMediaLinks"] > a
+div[class^="pageFooterV2-module--socialMediaLinks"] > a
+
+================================
+
+deeplearningbook.org
+
+INVERT
+.opened > img[src]
+
+CSS
+body {
+    background-color: transparent !important;
+}
+#page-container {
+    background-image: none !important;
+}
+
+================================
+
+deepseek.com
+
+CSS
+.bg-cover,
+.bg-center {
+    background-image: none !important;
+}
+.bg-white\/50 {
+    background-color: ${rgba(200, 200, 200)};
+}
+
+================================
+
+deew.dev
+
+CSS
+[data-darkreader-inline-fill] {
+    fill: #dcdad7 !important;
+}
+
+================================
+
+deezer.com
+
+CSS
+.slider-track .gradient-default {
+    background-image: linear-gradient(1deg, var(--color-dark-grey-800) 13%, var(--color-white));
+}
+
+================================
+
+defectivebydesign.org
+
+INVERT
+.block--views-repeat-offenders-block .views-row img
+img[src*="DRM-free label"]
+
+CSS
+.block--views-repeat-offenders-block {
+    background: none !important;
+}
+.site-name a {
+    background: url('https://www.defectivebydesign.org/sites/all/themes/dbd2/images/dbd-logo.png') top left no-repeat;
+}
+.l-region--navigation .menu li a,
+.l-footer,
+.l-footer .block__title {
+    color: black;
+}
+
+================================
+
+deftpdf.com
+
+INVERT
+.header__logo
+
+================================
+
+degiro.*
+
+INVERT
+img#CybotCookiebotDialogPoweredbyImage
+img[alt="Logo"]
+img[src*="global/worldmap.png"]
+a.navbar-brand
+img.left-fill
+img.left-nofill
+img.right-fill
+img.right-nofill
+img[alt="Instagram"]:not(div.soc-icons img)
+img[alt="TikTok"]:not(div.soc-icons img)
+img[alt="Facebook"]:not(div.soc-icons img)
+img[alt="Twitter"]:not(div.soc-icons img)
+img[alt="LinkedIn"]:not(div.soc-icons img)
+img[src="assets/images/com/g12.png"]
+.btn.dropdown-toggle img
+img[alt="Search_white"]
+img.angle-up
+img.angle-down
+img.chevron-black
+#accordion a img
+img.logo
+.all-faqs- a::before
+.menu-item img
+.margin-loans-disclaimer img
+img[alt="ishares-partner"]
+img[alt="bnp-partner"]
+img[alt="societe-generale-partner.png"]
+img[alt="partner-hanetf"]
+img[alt="income-shares"]
+img[alt="partner-iex"]
+img.close-disclaimer
+img.img-fluid[src*="arrow_black_left.png"]
+img.default-icon[alt="thumb-up"]
+img.default-icon[alt="thumb-down"]
+.popup-wrapper .icon-btn
+img.default-icon[src*="plus_nofill_L.svg"]
+img.hover-icon[src*="plus_fill_L.svg"]
+.cta-dg-icon img.icon-black
+button.splide__pagination__page::before
+.btn--main-site::before
+
+CSS
+.disclaimer .content a.cls span {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.btn--main-site::before
+#backtotop
+
+================================
+
+deliciousreverie.co.uk
+
+CSS
+.bg-secondary {
+    background-color: var(--darkreader-background-ffffff);
+}
+
+================================
+
+delish.com
+elle.com
+harpersbazaar.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] a[aria-label="Delish"] svg[alt="Logo"]
+nav[data-tracking-id="topNav"] a[aria-label="ELLE"] :is(img, svg)[alt="Logo"]
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel a[aria-label="Harper's BAZAAR"] svg[alt="Logo"]
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
+dell.com
+
+INVERT
+.breadcrumbs
+.cat-banner-text
+.cfsf-ba-content-wrap
+.hpg-cat-item-wrap svg
+
+================================
+
+delphipraxis.net
+
+CSS
+.ipsNavBar_secondary {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ipsNavBar_secondary::before {
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+deltahub.io
+
+INVERT
+#ss-scrolling-logo-cloud a>img
+
+================================
+
+dennisbareis.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+deno.land
+
+INVERT
+img[src="/logo.svg"]
+
+================================
+
+dependencywalker.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+deraktionaer.de
+
+INVERT
+.close-dark
+
+================================
+
+designobserver.com
+
+INVERT
+.dologo
+
+================================
+
+deskmodder.de
+
+CSS
+#secondary {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+desmos.com
+
+INVERT
+.dcg-calculator-api-container .dcg-grapher-2d .dcg-graph-outer[role="img"]
+.dcg-calculator-api-container .dcg-grapher-3d
+
+CSS
+html[data-darkreader-scheme="dark"] .dcg-calculator-api-container :is(.dcg-graph-inner, .dcg-webgl-canvas) {
+    filter: contrast(90%) saturate(200%) !important;
+}
+.dcg-calculator-api-container .dcg-container.dcg-inverted-colors {
+    filter: hue-rotate(180deg) !important;
+}
+.dcg-calculator-api-container .dcg-grapher-3d .dcg-graph-outer {
+    z-index: 1;
+}
+.dcg-expression-top-bar {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.dcg-calculator-api-container .dcg-colored-icon
+.dcg-calculator-api-container .dcg-color-swatch
+
+================================
+
+detexify.kirelabs.org
+
+INVERT
+.symbol > img
+
+CSS
+.symbol > img {
+    background-color: rgba(0, 0, 0, 0) !important;
+    background-image: url(https://detexify.kirelabs.org/images/symbols-a95e7763.png) !important;
+}
+
+================================
+
+deutschepost.de
+dhl.de
+
+INVERT
+article > img
+.stage-item__image > img
+
+CSS
+div[data-shipment-id],
+article:has(>p[data-variant="body"]),
+div:has(>p[data-variant="body"]) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div > span:has(a) {
+    background-color: var(--darkreader-selection-background) !important;
+}
+#nolp > div:first-of-type {
+    background: linear-gradient(to left, ${rgb(255, 204, 0)} 0%, ${rgb(255, 204, 0)} 30%, ${rgb(255, 229, 127)} 79%, ${rgb(255, 240, 178)} 100%) !important;
+}
+
+================================
+
+dev.azure.com
+
+CSS
+:root {
+    --nav-header-background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+dev.dota2.com
+
+CSS
+.navtabs li a.navtab:hover,
+.navtabs li.selected a.navtab {
+    color: black !important;
+}
+
+================================
+
+dev.to
+
+INVERT
+img[src$=".svg"]
+path[d^="M19.099 23.508c0"]
+
+CSS
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+a,
+.content-classification-text {
+    color: $(#e8e6e3) !important;
+}
+
+================================
+
+devconnected.com
+
+INVERT
+.penci-hbg-logo-img
+
+================================
+
+developer.android.com
+source.android.com
+developer.android.google.cn
+tensorflow.org
+quantumai.google
+cloud.google.com
+webrtc.org
+
+INVERT
+.devsite-site-logo
+
+CSS
+:root {
+    --devsite-background-1: var(--darkreader-neutral-background) !important;
+    --devsite-background-3: ${#f1f3f4} !important;
+    --devsite-footer-background: var(--darkreader-neutral-background) !important;
+    --devsite-header-color-upper: var(--darkreader-neutral-background) !important;
+    --devsite-inline-code-background: ${#f1f3f4} !important;
+    --devsite-search-form-background-active: rgba(255, 255, 255, 0.05) !important;
+    --devsite-searchbox-active: rgba(255, 255, 255, 0.05) !important;
+    --devsite-searchbox-hover: rgba(255, 255, 255, 0.1) !important;
+    --devsite-searchbox-inactive: rgba(255, 255, 255, 0.05) !important;
+    --devsite-table-heading-background: var(--darkreader-neutral-background) !important;
+}
+devsite-search .devsite-searchbox::before {
+    background-color: unset !important;
+}
+.devsite-wrapper,
+button {
+    background-color: inherit !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+}
+devsite-header .devsite-top-logo-row-wrapper-wrapper,
+.devsite-article {
+    border-color: rgba(255, 255, 255, 0.05) !important;
+}
+[role="menu"],
+.toggle-button,
+devsite-book-nav .devsite-book-nav-filter,
+.devsite-nav-accordion,
+tr,
+code,
+devsite-code,
+devsite-selector,
+devsite-selector devsite-tabs[connected],
+devsite-recommendations,
+devsite-footer-promos .devsite-footer-promos-list,
+devsite-footer-utility .devsite-footer-sites,
+devsite-footer-linkboxes .devsite-footer-linkboxes-list,
+devsite-playlist .devsite-playlist--section-quiz,
+devsite-footer-promos {
+    border-color: rgba(255, 255, 255, 0.1) !important;
+}
+.devsite-breadcrumb-list {
+    background: none !important;
+}
+
+================================
+
+developer.apple.com
+
+INVERT
+.icon
+
+CSS
+.disabled {
+    color: ${gray} !important;
+}
+pre,
+.code-listing {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.screen-hero
+.screen-fonts
+.screen-tabs
+.screen-completion
+.screen-swiftui
+
+================================
+
+developer.chrome.com
+
+CSS
+.featured-card__title-bar > svg,
+.card-title-bar > svg,
+.navigation-rail__icon > svg {
+    fill: ${black} !important;
+}
+.search-box__btn > svg {
+    fill: ${white} !important;
+}
+
+================================
+
+developer.mozilla.org
+
+INVERT
+.copy-icon
+.bc-browsers > th > span::before
+.bc-platforms > th::before
+a.external::after
+.bc-has-history > .bc-history-link
+.ic-footnote
+.ic-non-standard
+.breadcrumbs-container li .breadcrumb-penultimate::after
+.breadcrumbs-container li .breadcrumb::after
+ul.main-menu .top-level-entry::before
+span.icon
+#browser_compatibility + a + figure .icon
+.bc-level
+.legend-icons
+
+CSS
+.logo-text,
+.search-results-list mark {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.main-page-content .code-example .copy-icon
+
+================================
+
+developer.roblox.com
+
+INVERT
+.logo
+
+================================
+
+developer.salesforce.com
+
+CSS
+.slds-tabs_card {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+developer.workday.com
+
+INVERT
+.minimap
+
+CSS
+.monaco-editor-background,
+.margin {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+developers.arcgis.com
+
+CSS
+a {
+    text-shadow: none !important;
+}
+
+================================
+
+developers.facebook.com
+
+INVERT
+img[alt^="Follow us on "]
+img[id="u_0_1e_Fc"]
+img[src^="https://scontent.fiev25-1.fna.fbcdn.net/v/t39.2365-6/306317286_5514106962009770_3327930304024114088_n.jpg"]
+
+================================
+
+developers.google.com
+
+INVERT
+.devsite-google-wordmark
+
+CSS
+:root {
+    --devsite-background-3: ${rgb(198, 198, 198)} !important;
+    --devsite-breadcrumb-list-background: var(--darkreader-neutral-background) !important;
+    --devsite-button-background: var(--darkreader-neutral-background) !important;
+    --devsite-footer-background: var(--darkreader-neutral-background) !important;
+    --devsite-header-color-upper: var(--darkreader-neutral-background) !important;
+    --devsite-searchbox-inactive: var(--darkreader-neutral-background) !important;
+}
+button,
+a.button,
+.devsite-landing-row-item {
+    border-color: var(--darkreader-border--devsite-select-border) !important;
+}
+.pre-style,
+code,
+pre {
+    background: var(--darkreader-neutral-background) !important;
+}
+.devsite-table-wrapper > table > thead > tr > th {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+devsite-selector {
+    background: var(--darkreader-neutral-background) !important;
+}
+devsite-book-nav .devsite-nav-title.devsite-nav-active {
+    background: var(--darkreader-bg--devsite-note-notice-background) !important;
+}
+
+================================
+
+devuan.org
+
+INVERT
+#logo
+
+================================
+
+dexie.org
+
+INVERT
+a[href="Download"]
+img[src$="logo-dexie-black.svg"]
+
+================================
+
+dhmo.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+di.com.pl
+
+INVERT
+img[alt*="Dziennik Internautów"]
+
+CSS
+div#naglowek {
+    background-image: none !important;
+}
+
+================================
+
+diamondsdirect.com
+
+INVERT
+[alt="Diamonds Direct Logo"]
+
+================================
+
+dianping.com
+
+INVERT
+.logo
+
+================================
+
+dice.com
+
+INVERT
+dialog input
+.seds-button
+
+CSS
+.match-not-logged-in-outer,
+.match-not-logged-in-row,
+.chip_chip__cYJs6,
+.sc-dhi-candidates-modal-2 {
+    background: var(--darkreader-neutral-background) !important;
+}
+a.link-label,
+.match-not-logged-in-outer a,
+.tertiary {
+    color: var(--darkreader-text--djv-color-dice-blue-dark) !important;
+}
+.location-display,
+.job-employment-type,
+.employment-type,
+.card,
+.time-stamp,
+.seds p,
+.seds h1,
+.seds h2,
+.seds h3,
+.seds h4,
+.seds h5,
+.seds h6,
+dialog :not(input) {
+    color: var(--darkreader-neutral-text) !important;
+}
+dialog input {
+    color: black !important;
+}
+.collapsed {
+    background: linear-gradient(rgba(24, 26, 27, 0) -7%, rgba(24, 26, 27, 0.58) 23%, rgb(24, 26, 27) 45%) !important;
+}
+.see-more-text {
+    background-color: #181a1b !important;
+}
+
+================================
+
+dicetower.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+dict.cc
+
+CSS
+#langbar {
+    background-image: none !important;
+}
+
+================================
+
+dictionary.cambridge.org
+
+INVERT
+.cb.hao.lpt-2
+.cb.hv-2.lmr-10
+
+================================
+
+dictionary.com
+
+INVERT
+.elu13lxtzrRO8E8WYUVn
+.tFCOipZXVYJAiob7tOp0
+
+================================
+
+dieselnet.com
+
+CSS
+:root {
+    --shd-bk2: transparent;
+    --shd-bkg: transparent;
+}
+html,
+body,
+article,
+#mpanel,
+.date {
+    background-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+.abox a>b {
+    color: var(--darkreader-neutral-text) !important;
+}
+.abox {
+    background-color: ${#eee} !important;
+}
+#footNote {
+    background-color: ${#ddd} !important;
+}
+
+================================
+
+differencebetween.net
+
+CSS
+body,
+#page-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+digg.com
+
+CSS
+.digg-story__title-link {
+    color: ${black} !important;
+}
+.digg-story__description {
+    color: ${black} !important;
+}
+
+================================
+
+digi.hu
+
+INVERT
+ol.flex-control-nav
+
+CSS
+body.not-front {
+    background-image: none;
+}
+
+================================
+
+digitalextremes.zendesk.com
+
+INVERT
+.logo
+
+================================
+
+disconnect.me
+
+INVERT
+img[src*="vpnCoverageMap"]
+img[alt="Toolbar button"]
+#press-strip > div > img
+
+CSS
+#accordion {
+    background-image: none !important;
+}
+
+================================
+
+discord.com
+
+INVERT
+div[class^="botPermissions"] > ul > li > div > div > span::after
+
+CSS
+div[class^="pill"][class*="wrapper"] > span[class^="item"],
+div[class*="modeUnread"] > div[class^="unread"] {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+nav[aria-label="Servers sidebar"] foreignObject {
+    border-radius: 100% !important;
+    mask: none !important;
+    transition: all .5s;
+}
+nav[aria-label="Servers sidebar"] foreignObject:hover {
+    border-radius: 30% !important;
+}
+path[class^="wavePath"] {
+    fill: ${rgb(226, 224, 220)} !important;
+}
+:root {
+    --num-grid-columns: 4 !important;
+    --page-gutter: 24px !important;
+    --page-max-width: 1260px !important;
+    --section-spacing: 56px !important;
+}
+@media screen and (min-width: 768px) {
+    :root {
+        --num-grid-columns: 8 !important;
+        --page-gutter: 40px !important;
+        --section-spacing: 80px !important;
+    }
+}
+@media screen and (min-width: 1024px) {
+    :root {
+        --num-grid-columns: 12 !important;
+        --section-spacing: 120px !important;
+    }
+}
+
+IGNORE INLINE STYLE
+div[class*="blobContainer"] > div > svg > mask
+div[class*="blobContainer"] > div > svg > mask > use
+div[class*="wrapper"] > svg > mask
+div[class*="wrapper"] > svg > mask > use
+div[class*="wrapper"] > svg > circle
+mask[id*="svg-mask-avatar-status"] > *
+mask[id*="svg-mask-status"] > *
+
+================================
+
+discourse.haskell.org
+
+INVERT
+.logo-big
+
+================================
+
+discourse.pi-hole.net
+
+INVERT
+#site-logo
+
+================================
+
+discover.com
+
+INVERT
+img#flag
+i.icon-help
+i.icon-search
+i.lock-icon
+div.welcome-text-wrapper
+div.slide--img.credit-card
+div.slide--img.personal-loan
+div.slide--img.home-loan
+
+================================
+
+discover.forem.com
+
+INVERT
+body > div:nth-child(1) > svg:nth-child(1)
+
+================================
+
+discovermagazine.com
+
+INVERT
+img[alt="Discover Magazine"]
+
+================================
+
+discovery.endeavouros.com
+
+INVERT
+.builder-item--logo .site-logo img
+
+================================
+
+discuss.pixls.us
+
+INVERT
+#site-logo.logo-big
+
+================================
+
+discussions.apple.com
+
+CSS
+#globalnav {
+    --globalnav-background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+disk.yandex.*
+docviewer.yandex.*
+
+INVERT
+.logo
+.create-resource-popup-with-anchor .ufo-icon__icon
+
+================================
+
+disney.*
+
+INVERT
+.disney-img
+
+================================
+
+distrowatch.com
+
+INVERT
+img[src="images/cpxtu/dwbanner.png"]
+
+CSS
+input,
+.NavMenu,
+select,
+td:not(.NewsDate):not(.NewsHeadline) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ditu.baidu.com
+map.baidu.com
+maps.baidu.com
+
+INVERT
+#activity-banner-panel
+.BMap_bubble_pop
+.BMap_contextMenu
+.BMap_cpyCtrl
+.BMap_scaleBarBG
+.BMap_scaleTxt
+.BMap_simple_bubble_pop
+.BMap_stdMpZoom
+.BMapLabel
+#bt_trafficCtrl
+.cbtlinetop
+.cbtToolBar
+.icon
+#iw_tool_icon
+.jump_back
+#map-operate
+#maps
+.message-banner
+#message-panel
+.more-device
+#nearby-searchbox-hint
+#nearby-searchbox-hint-center
+.route-button
+.tang-pass-qrcode-title
+#userSignPanel
+
+CSS
+#newuilogo {
+    filter: brightness(80%);
+}
+#sole-input {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+djrankings.org
+
+CSS
+body,
+li a,
+.moduleContentInner {
+    background-image: none !important;
+}
+
+================================
+
+djservice.se
+
+INVERT
+.shop_icon
+img[alt="Hem djservice.se"]
+img[alt="Qliro"]
+img.nav-column-logo
+img.listor3_box_logos_img
+img.carousel_logo_img
+
+CSS
+a:link,
+a:visited {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+dlagentlemana.pl
+
+INVERT
+div.f-grid-3.logo-column > a > img
+div.opineo-side-slider-widget > button
+.logo-bar img
+
+================================
+
+dle.rae.es
+
+CSS
+.bloque_publi DE,
+.spr_fundacionlacaixa,
+.spr_dle90x110,
+.spr_logo-enclave-rae,
+.spr_google-play-badge-100x39,
+.spr_badge-appstore-lrg-96x28,
+.spr_edtri,
+.spr_ay,
+.spr_cita,
+.spr_unidrae,
+.spr_consultas,
+.spr_pnwe2,
+img[src="/images/logos/ASALE2.png"],
+img[src="/images/logos/rae.png"],
+img[src="/images/LibroDeEstilo_300.jpg"],
+img[src="/app/doc/es/img/dle.jpg"],
+a[href="https://dej.rae.es"] > img.img-responsive.b-lazy.b-loaded,
+img[src="/images/logos/BCRAEl.jpg"] {
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important;
+}
+
+================================
+
+dmca.com
+
+INVERT
+img[alt="DMCA Logo"]
+
+================================
+
+dnd.su
+
+CSS
+input,
+select,
+textarea,
+.input-cast_time,
+.input-style,
+.input-select,
+.button,
+button:not(.lg-icon),
+.workshop__checkbox .workshop__label::before,
+.card-type,
+.paper-1,
+.desc .additionalInfo,
+.subsection .additionalInfo,
+.trumbowyg-editor .additionalInfo,
+.social-menu ul,
+#ya-site-form0 .ya-site-form__form .ya-site-form__input-text,
+#ya-site-form0 .ya-site-form__submit {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+dnd5e.wikidot.com
+
+CSS
+.feature {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.feature.offcolor {
+    background-color: ${rgb(255, 250, 180)} !important;
+}
+th {
+    background-color: ${rgb(230, 216, 170)} !important;
+}
+
+================================
+
+dndbeyond.com
+
+CSS
+.mon-stat-block,
+.mon-stat-block::before,
+.mon-stat-block::after,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.read-aloud-text,
+.more-info::after,
+.details-container::after {
+    border-image: none !important;
+}
+::selection {
+    background-color: var(--darkreader-selection-background) !important;
+}
+
+================================
+
+dns-shop.ru
+
+CSS
+.star-rating__star svg g path {
+    --darkreader-inline-fill: #afafaf !important;
+    stroke: var(--darkreader-inline-fill) !important;
+}
+.star-rating__star[data-state="selected"] svg g path {
+    --darkreader-inline-fill: #ffa319 !important;
+}
+
+================================
+
+dnscrypt.pl
+
+INVERT
+.logo
+
+================================
+
+dnsleaktest.com
+
+INVERT
+img[src$="logo.png"]
+img[src$="what-is-a-dns-leak.png"]
+img[src$="transparent-dns-proxy.png"]
+
+================================
+
+dnslytics.com
+
+INVERT
+img[src*="logo.png"]
+
+================================
+
+doba.pl
+
+INVERT
+.social
+img[src*="logo.png"]
+img[src*="/img/powiaty/"]
+
+================================
+
+dobreprogramy.pl
+
+CSS
+header a[href="/"] svg {
+    fill: #fff !important;
+}
+
+================================
+
+doc.qt.io
+
+CSS
+:root {
+    --content-bg-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+doc.rust-lang.org
+
+CSS
+mark {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+docs.asciidoctor.org
+
+CSS
+.doc .admonitionblock td.content,
+.doc pre > code,
+.doc p code,
+.doc .colist > table code {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+docs.codacy.com
+
+INVERT
+div.footer-logo > img[alt="Codacy"]
+
+================================
+
+docs.dagster.io
+
+INVERT
+img[alt="Dagster logo"]
+
+CSS
+#__next > div {
+    background-image: none !important;
+}
+
+================================
+
+docs.expo.dev
+
+IGNORE INLINE STYLE
+tr svg *
+
+================================
+
+docs.gitlab.com
+
+CSS
+.site-sections {
+    background: none !important;
+}
+
+================================
+
+docs.google.com
+
+INVERT
+.docs-icon
+.punch-filmstrip-controls-icon
+#docs-editor canvas
+.docs-homescreen-icon
+.kix-equation-toolbar-icon
+.kix-equation-toolbar-palette-icon
+.cell-input
+.formula-content
+.docs-instant-button-bubble-icon-container
+.docs-gm .docs-dialog .modal-dialog-title-close::after
+.docs-preview-palette-item
+.goog-menuitem-checkbox
+.goog-dimension-picker-unhighlighted
+.goog-dimension-picker-highlighted
+#docs-star
+.rs-role-icon
+.toggle-link-icon
+.link-management-drop-down-icon
+.vs-icon
+.vpc-icon
+.docs-analytics-img
+.share-butter-copy-icon
+.doc-previews-indicator-popover .docs-link-bubble-mime-icon
+img[src$="googlelogo_dark_clr_74x24px.svg"]
+.exportUnderline
+.freebirdMaterialIconIconEl
+.quantumWizTogglePapercheckboxCheckMark
+#docs-titlebar-share-client-button .scb-button-icon:not([class*="white"])
+body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-button-icon
+g.punch-filmstrip-indicator > image
+.docs-gm .docos-icon-overflow-three-dots-size
+.docs-grille-gm3 .docs-sheet-status-avs .goog-flat-menu-button-dropdown
+
+CSS
+.docs-preview-palette-item {
+    border: transparent !important;
+}
+.cell-input {
+    background-color: ${black} !important;
+    color: ${white} !important;
+}
+.cell-input > span,
+.cell-input > font {
+    --darkreader-inline-color: ${white} !important;
+}
+.kix-cursor-caret {
+    border-color: ${black} !important;
+}
+.kix-selection-overlay {
+    background-color: var(--darkreader-selection-background) !important;
+    border: var(--darkreader-selection-background) !important;
+}
+.ia-invite-controls-area {
+    background-color: transparent !important;
+}
+.docs-gm .docs-revisions-switch .apps-ui-material-slide-toggle-thumb {
+    background-color: rgb(43, 46, 48) !important;
+}
+.docs-gm .docs-revisions-switch.apps-ui-material-slide-toggle-container-checked .apps-ui-material-slide-toggle-thumb {
+    background-color: rgb(9, 64, 155) !important;
+}
+.docs-text-ui-cursor-blink {
+    fill: ${black} !important;
+}
+.docs-title-input-label:not([style*="pointer-events: auto"]) > #docs-title-input-label-inner {
+    visibility: hidden !important;
+}
+input.docs-title-input {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.sketchy-text-background + g g rect {
+    fill: var(--darkreader-selection-background) !important;
+}
+.gb_Ha.gb_1a.gb_Nd {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.cell-input > span
+
+================================
+
+docs.google.com/picker
+
+INVERT
+#doclist div > div + div div[style="user-select: none;"]:not([role="tab"]):not([role="listbox"]):not([role="menuitemradio"]):not([role^="menu"]) > div:not([aria-pressed]):not([role="tab"]):not([class$="highlightsgrid"]):first-of-type
+#doclist div > div + div div[role="menu"] div[role="menuitem"][style="user-select: none;"] div[aria-label] div[data-tooltip] + div
+#doclist div > div + div label + input + div[style]
+img[src$="search-black.png"]
+
+================================
+
+docs.gtk.org
+
+CSS
+.emblem.deprecated {
+    background: var(--error-bg-color);
+    color: var(--darkreader-neutral-text);
+}
+a.current {
+    background: var(--darkreader-selection-background) !important;
+}
+svg .node a text {
+    fill: var(--darkreader-neutral-text);
+}
+
+================================
+
+docs.manim.community
+
+CSS
+.toc-drawer {
+    background: var(--darkreader-bg--color-background-primary);
+}
+.sidebar-search-container {
+    background: var(--darkreader-bg--color-admonition-background);
+}
+.sidebar-tree .current > .reference {
+    background: var(--darkreader-bg--color-admonition-title-background--admonition-todo);
+}
+
+================================
+
+docs.nestjs.com
+
+CSS
+:root {
+    --darkreader-bg--primary-accent-color: var(--primary-accent-color) !important;
+    --darkreader-bg--primary-color: var(--primary-color) !important;
+    --darkreader-bgimg--primary-gradient: var(--primary-3dp) !important;
+}
+
+================================
+
+docs.opencv.org
+
+CSS
+#header,
+.header,
+.navpath ul,
+.sm-dox,
+body {
+    background-image: none !important;
+}
+
+================================
+
+docs.sentry.io
+
+INVERT
+.index-logo > img
+a.hover-card-link[href="/platforms/apple/"] > .image-frame
+a.hover-card-link[href="/platforms/javascript/guides/nextjs/"] > .image-frame
+
+CSS
+.document-wrapper,
+.promo-banner {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+docs.soliditylang.org
+
+CSS
+.wy-body-for-nav {
+    background-color: unset;
+}
+
+================================
+
+docs.vyos.io
+
+CSS
+.wy-menu-vertical a {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+doctor.webmd.com
+
+CSS
+.profile-topcard {
+    background: ${white} !important;
+}
+
+================================
+
+doctorswithoutborders.org
+
+INVERT
+.site-logo
+
+================================
+
+documentfoundation.org
+
+INVERT
+.logo
+img[alt*="LibreOffice Initial Artwork Logo ColorLogoBasic"]
+
+================================
+
+documentliberation.org
+
+INVERT
+img[src="assets/Uploads/dlp/images/logo-calligra.png"]
+img[src="assets/Uploads/dlp/images/logo-libreoffice.png"]
+
+================================
+
+docusign.com
+*.docusign.com
+
+INVERT
+a[data-context="nav-main-logo"]
+img[data-qa="header-docusign-logo"]
+
+================================
+
+dominos.*
+
+INVERT
+.card--overlay > .card__header .card--overlay__close
+
+CSS
+svg.trackerbarimage:not(.complete svg.trackerbarimage) {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.stage:not(.complete) > .title > span {
+    color: var(--darkreader-neutral-background) !important;
+}
+.tracker-page-container div.tracker-module.pizza-tracker .tracker-container > div.stage.complete [class^="chevron-"] {
+    fill: #689d30 !important;
+}
+.tracker-page-container div.tracker-module.pizza-tracker .tracker-container > div.stage [class^="chevron"] {
+    stroke: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+donald.pl
+
+INVERT
+a[href="/"]
+
+================================
+
+doodle.com
+
+INVERT
+svg.d-checkmark .d-background
+
+================================
+
+doordash.com
+
+INVERT
+input[kind="RADIO"][id^="Toggle"]::after
+.mapboxgl-canvas
+
+================================
+
+dotaunderlords.gamepedia.com
+dota2.gamepedia.com
+dota2.fandom.com
+
+CSS
+#right-navigation {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#left-navigation
+
+================================
+
+dou.ua
+
+CSS
+.g-right-shadowed,
+.img::before,
+.img::after {
+    background-image: none !important;
+}
+
+================================
+
+douban.com
+book.douban.com
+movie.douban.com
+music.douban.com
+search.douban.com
+
+INVERT
+.nav
+
+CSS
+body * {
+    color: var(--darkreader-neutral-text);
+    mix-blend-mode: normal;
+}
+.nav-search .inp input {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+download.audiohero.com
+
+INVERT
+.wave_container
+
+================================
+
+downloads.khinsider.com
+
+CSS
+body {
+    background: none !important;
+}
+#faux {
+    background-image: none !important;
+}
+
+================================
+
+dp.ru
+
+INVERT
+.logo-image
+
+================================
+
+drawing.garden
+
+CSS
+html,
+body {
+    background-image: none !important;
+}
+
+================================
+
+dribbble.com
+
+INVERT
+.site-nav-desktop-logo
+
+================================
+
+drive.google.com
+
+INVERT
+div[role="menuitem"] svg
+div[role="dialog"][style^="width: 350px;"] div[role="button"][tabindex="0"]
+div[role="dialog"] ~ div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"])
+img[src$="type/audio/mp3"]
+div[role="listitem"] > div > div > div > svg[fill="#000000"] > path
+div[role="menu"] > div > div[role="menuitem"] > div > div > div
+div[data-label="nd"] > div > div > svg > path[fill="#000000"]
+div[role="document"] > div[role="button"] .a-b-c
+div > svg > circle[fill="white"]
+img[src*="empty_state_trash"]
+div[tabindex="-1"][role="toolbar"] > div > div > div > svg > path[d^="M10 18h4v-2h-4v2zM3"]
+button[class="ao-search-infolder ao-hint"]
+button[aria-checked="true"] > div > svg > path
+button[aria-checked="true"] > div > span > svg > path
+
+CSS
+span[data-type="spelling"] {
+    mix-blend-mode: normal !important;
+}
+div[role="menu"] div[role="menuitem"][class*=" "] > div > div > div,
+div[role="button"][aria-disabled="true"] > div {
+    filter: invert(50%) !important;
+}
+#request-access-icon,
+img[src="https://ssl.gstatic.com/docs/doclist/images/empty_state_details.png"] {
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important;
+}
+:root {
+    --dt-secondary-container: ${#f1f3f4} !important;
+}
+button[guidedhelpid="new_menu_button"] {
+    background-color: ${#dbdde0} !important;
+}
+div[data-target="autopurgebanner"] > section {
+    background: ${#dbdde0} !important;
+}
+div[role="toolbar"] div[role="button"],
+div[role="toolbar"] div[role="presentation"][data-active="true"] > div[role="presentation"] {
+    mix-blend-mode: normal !important;
+}
+
+IGNORE INLINE STYLE
+div[role="presentation"] svg
+div[data-label="nd"] > div > div > svg > path[fill="#000000"]
+
+================================
+
+drive.google.com/picker
+
+INVERT
+div[role="menu"] div[role="menuitem"]:not([class*=" "]) > div > div > div
+div[role="button"][tabindex="0"]
+
+CSS
+div[role="menu"] div[role="menuitem"][class*=" "] > div > div > div,
+div[role="button"][aria-disabled="true"] > div {
+    filter: invert(50%) !important;
+}
+
+IGNORE INLINE STYLE
+svg[class=""]
+svg[class=""] *
+
+================================
+
+droid-life.com
+
+CSS
+.collection-posts__list .preview__picture {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+dropbox.com
+
+INVERT
+.dl-dropbox
+.drops-empty-page-header-image
+.restorations-education__df-help__image
+.search__view--empty img
+.plan-status-section__icon img
+.dropbox-logo__type
+iframe[class^="previewhtml _previewContent"]
+.toggle.toggle-block__toggle.dig-Toggle
+.toggle.toggle-block__toggle.dig-Toggle.dig-Toggle--isToggled > span::after
+.shared-with-members.audience-box.u-pad-top-xs.u-pad-bottom-s.u-mar-bottom-xs > .c-loader
+.hp-card-carousel-dots
+.loading-loading > .loading-img
+
+CSS
+.rc-inline-action-bar-container.brws-file-row-inline-action-bar {
+    background: var(--darkreader-bg--color__core__secondary) !important;
+}
+svg.dig-GlyphLogo.dig-Waffle-row-logo path[fill="var(--color__glyph__accent)"] {
+    --darkreader-inline-fill: var(--color__glyph__accent) !important;
+}
+svg.dig-GlyphLogo.dig-Waffle-row-logo path[fill="var(--color__glyph__primary)"] {
+    --darkreader-inline-fill: var(--darkreader-text--color__standard__text) !important;
+}
+.dig-LabelGroup > div > input[aria-checked="false"] {
+    background-color: var(--darkreader-bg--color__core__secondary) !important;
+}
+.dig-LabelGroup > div > input[aria-checked="true"] {
+    background-color: var(--darkreader-text--color__core__secondary) !important;
+}
+
+IGNORE INLINE STYLE
+.home__suggest_image path
+.selection-preview-pane__icon path
+.dig-WordmarkLogo path
+
+================================
+
+drupal.org
+
+CSS
+input[type="image"] {
+    background: none;
+}
+
+================================
+
+drvhub.net
+
+INVERT
+.vendors-block a img
+
+CSS
+.hero {
+    background-color: ${white} !important;
+    background-image: none !important;
+}
+
+================================
+
+ds.163.com
+
+INVERT
+.c-slogan--normal
+
+================================
+
+dsausa.org
+
+INVERT
+.navbar-toggler-icon
+.swiper-container-horizontal .swiper-pagination-bullet
+
+================================
+
+dspguide.com
+
+CSS
+#divPage {
+    background-image: none !important;
+}
+
+================================
+
+dtf.ru
+
+INVERT
+mark
+
+================================
+
+duckduckgo.com
+
+INVERT
+.is-active.js-tw-card.bg-clr--white.tw-card > .tw-card__footer > a.js-tweet-action.tw-card__action.tw-card__link > [src="/assets/common/slider/twitter-like.svg"]
+[src="https://duckduckgo.com/assets/icons/thirdparty/wikipedia.svg"]
+
+CSS
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-1.card > .card-body > h3,
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-2.card > .card-body > h3,
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-3.card > .card-body > h3,
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-1.card > .card-body > p,
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-2.card > .card-body > p,
+.justify-content-center.align-items-center.flex-lg-column.flex-md-row.card-3.card > .card-body > p,
+.js-hiring-open-pos.join__btn.mt-5.btn.col-sm-auto.col {
+    color: var(--darkreader-neutral-background) !important;
+}
+.logo_homepage {
+    background-image: url("https://duckduckgo.com/assets/logo_homepage.alt.v108.svg") !important;
+}
+.header__logo {
+    background: no-repeat center url("https://duckduckgo.com/assets/logo_header.alt.v108.svg") !important;
+}
+
+IGNORE INLINE STYLE
+#color_picker_container .sample
+.zci--color_codes .circle
+
+================================
+
+duden.de
+
+INVERT
+.segment::before
+
+================================
+
+duolingo.com
+
+INVERT
+.Z392z
+._24NNT
+[data-test="skill-icon"] + div img
+
+CSS
+button[aria-disabled="true"] {
+    opacity: 0.3 !important;
+}
+button.WOZnx::before,
+div._3C_oC::before {
+    background-color: transparent !important;
+}
+
+IGNORE INLINE STYLE
+div[data-test="challenge-translate-prompt"] svg *
+div[data-test="challenge challenge-translate"] svg *
+
+================================
+
+dvizhcom.ru
+
+INVERT
+.mobile-header-icon:nth-last-of-type(3)
+.mobile-header-icon:nth-last-of-type(2)
+.mobile-header-icon:nth-last-of-type(1)
+
+================================
+
+dw.com
+
+CSS
+#bodyMover {
+    background-image: none !important;
+}
+
+================================
+
+dynadot.com
+
+INVERT
+img[data-src="/tr/mainsite2023/navbar-logo-dark-2023.png"]
+img[data-src="/tc/img/logo/navbar-logo.svg"]
+.icons-line img
+
+================================
+
+dziennik.pl
+
+INVERT
+img[alt="Dziennik"]
+
+================================
+
+dziennikbaltycki.pl
+dzienniklodzki.pl
+dziennikpolski24.pl
+echodnia.eu
+expressbydgoski.pl
+expressilustrowany.pl
+gazetakrakowska.pl
+gazetalubuska.pl
+gazetawroclawska.pl
+gk24.pl
+gloswielkopolski.pl
+gol24.pl
+gp24.pl
+gra.pl
+gs24.pl
+i.pl
+kurierlubelski.pl
+motofakty.pl
+naszemiasto.pl
+*.naszemiasto.pl
+nowiny24.pl
+nowosci.com.pl
+nto.pl
+pomorska.pl
+poranny.pl
+sportowy24.pl
+strefaagro.pl
+strefabiznesu.pl
+strefaedukacji.pl
+stronakobiet.pl
+stronazdrowia.pl
+telemagazyn.pl
+to.com.pl
+wspolczesna.pl
+
+INVERT
+.atomsArticleFoot__tools svg
+.atomsCommentsExposition__icon svg
+.atomsGalleryButtonsNavigation__left svg
+.atomsGalleryButtonsNavigation__right svg
+.atomsNavigationBreadcrumbs__content svg
+.atomsNavigationFooterLinks__logo
+.atomsNavigationIconsIcon
+.atomsNavigationIconsList a svg
+.atomsSocialmediaExposition__content svg
+.componentsGalleryNavbar__btn_close
+.componentsGalleryNavbar__logo
+.componentsNavigationMenu__logo
+.componentsNavigationNavbar__href
+.componentsNavigationTopnavbar__icons div span svg
+a[href="https://i.pl/firmy"] svg
+a[href="https://i.pl/szukaj"] svg
+
+CSS
+svg path[d^="M154.992 47.9999H128L13"],
+svg path[d^="M64 28L68 24V15.9999H82"] {
+    fill: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+.componentsNavigationNavbar__href svg *
+
+================================
+
+dzienniknaukowy.pl
+
+INVERT
+.top-logo
+
+================================
+
+dziennikprawny.pl
+
+INVERT
+a[href="/"]
+.fullba
+
+CSS
+.fullba {
+    background-image: none !important;
+}
+
+================================
+
+e.foundation
+
+INVERT
+img.attachment-full.size-full
+
+================================
+
+ea.com
+
+INVERT
+.left_context .context dl dd.select
+.modifyMobilePhoneBtn
+
+CSS
+img[src*="white-bg-ea-bg-global-white"] {
+    display: none !important;
+}
+body.origin-com,
+.left_context .context {
+    background-image: none !important;
+}
+.body_foot .language .select_language .languageText,
+.buttonstyle_3 span,
+.origin-ux-drop-down-selection > span,
+.origin-ux-button-primary > span,
+.origin-ux-button-secondary > span {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+eapteka.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+================================
+
+earthday.org
+
+INVERT
+.navbar-brand
+
+================================
+
+earthquake.usgs.gov
+
+INVERT
+img[src*="services.arcgisonline.com"]:not([src*="World_Imagery"])
+
+================================
+
+easybib.com/guides
+
+INVERT
+.hamburger-toggle svg
+
+================================
+
+easypost.com
+
+INVERT
+.logo
+.progress-bar
+
+================================
+
+eatthis.com
+
+INVERT
+svg.site-logo
+
+CSS
+.header-leading-authority {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+ebay.*
+ebay.*.*
+
+CSS
+html,
+body {
+    background-image: none !important;
+}
+.ifh-container button.icon-btn > svg {
+    fill: ${#191919} !important;
+}
+.vim.x-breadcrumb {
+    border: none !important;
+}
+:root {
+    --color-foreground-primary: ${#191919} !important;
+    --color-neutral-7: ${#191919} !important;
+}
+.seo-card--image {
+    mix-blend-mode: initial !important;
+}
+.seo-card__image-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+    mix-blend-mode: initial !important;
+}
+
+================================
+
+eblocker.org
+
+INVERT
+.site-logo-img
+figure[class="aligncenter size-large is-resized"]
+
+================================
+
+ebok.pgnig.pl
+
+INVERT
+img[src*="logo"]
+
+================================
+
+ebok.vectra.pl
+
+CSS
+.side-floater {
+    background-image: none !important;
+}
+
+================================
+
+ebooks.cpm.org
+
+INVERT
+img[alt="Review and Preview problems below"]
+
+================================
+
+economist.com
+
+INVERT
+#ds-wordmark-1843 path:nth-child(5)
+
+CSS
+.css-1xqo7ld {
+    color: transparent;
+}
+
+IGNORE INLINE STYLE
+#ds-economist-logo > path
+.ds-share-link > svg > g > circle
+
+================================
+
+eda.yandex.ru
+
+INVERT
+.DesktopHeader_logo
+.DesktopLiteHeaderLayout_desktopLogoImage
+.UiKitOrderStep_icon
+.DesktopHeaderBlock_linkIcon
+.Profile_chevronIcon
+.DesktopCatalogPageSort_sliderIcon
+.DesktopHeader_menuIcon
+ymaps > ymaps > ymaps > canvas
+
+================================
+
+edclub.com
+
+CSS
+object {
+    color-scheme: initial !important;
+}
+
+================================
+
+edmworldmagazine.com
+
+INVERT
+.q_logo
+
+================================
+
+edmworldshop.com
+
+INVERT
+.site-nav__link--burger
+.site-header__logo-image
+
+================================
+
+edstem.org
+
+CSS
+.tab-bar-dark .active .tbb-tab-side .fill {
+    fill: rgb(34, 37, 38) !important;
+}
+.tab-bar-dark .tbb-tab-side .fill {
+    fill: rgb(26, 28, 29) !important;
+}
+
+================================
+
+edu.tbank.ru
+
+CSS
+app-layout {
+    background: ${white};
+}
+.logo[_ngcontent-ng-c3482887522] {
+    display: none;
+}
+.logo_dark[_ngcontent-ng-c3482887522] {
+    display: block;
+}
+
+================================
+
+education.github.com
+
+INVERT
+img[alt="GitHub Education"]
+.octicon-logo-github
+
+================================
+
+education.yandex.ru
+
+CSS
+#fix-color__white .lc-text-block {
+    color: ${black} !important;
+}
+#fix-color__black .lc-text-block {
+    color: ${white} !important;
+}
+
+IGNORE INLINE STYLE
+.lc-text-block
+
+================================
+
+eduke32.com
+
+CSS
+.main {
+    background-image: none !important;
+}
+
+================================
+
+edulastic.com
+
+INVERT
+img.keyboardButton
+
+================================
+
+eduserver.ru
+
+CSS
+section.content {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+eevblog.com
+
+CSS
+#main_content_section > div > span,
+#quickModForm > div > span,
+#main_content_section > span {
+    mix-blend-mode: color !important;
+}
+.frame,
+.plainbox,
+#header,
+#content_section,
+#footer_section {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+eeworld.com.cn
+*.eeworld.com.cn
+
+INVERT
+.header-logo-search-login
+.logo_l
+
+================================
+
+efa.mvv-muenchen.de
+rad.mvv-muenchen.de
+
+INVERT
+.personalization
+.swap
+.footer_btn
+.footer_btn_main
+
+CSS
+#incr_date,
+#incr_time,
+#decr_date,
+#decr_time {
+    filter: invert(100%) hue-rotate(180deg) brightness(80%) !important;
+}
+#search_fields_wrap .no_a img,
+.fav {
+    filter: invert(100%) hue-rotate(180deg) brightness(350%) !important;
+}
+#main_nav_wrap,
+#mail_feedback,
+#minimized_container,
+.mined_ctr,
+.ui-dialog .ui-dialog-titlebar,
+.leaflet-popup-content-mdv-title,
+.ui-widget-header {
+    background-color: rgb(59,59,59) !important;
+    border-bottom-color: rgb(123,123,123) !important;
+}
+#main_nav > li a {
+    border-color: rgb(59,59,59) !important;
+    color: rgb(123,123,123) !important;
+}
+p img {
+    filter: invert(100%) hue-rotate(180deg) brightness(100%) !important;
+}
+[title="Fussweg"] {
+    filter: invert(100%) hue-rotate(180deg) brightness(100%) !important;
+}
+.text_field {
+    background-color: rgb(11, 14, 15);
+    border-color: rgb(255 255 255);
+}
+input::placeholder {
+    color: rgb(255, 255, 255) !important;
+}
+.leaflet-tile-pane {
+    filter: invert(90%) hue-rotate(180deg) brightness(120%) !important;
+}
+.leaflet-marker-pane {
+    filter: brightness(75%) !important;
+}
+input[type=radio]:checked + label {
+    border-color: white !important;
+    border-width: 1px;
+}
+input::placeholder {
+    color: white !important;
+    font-weight: bold;
+}
+.historyitem {
+    color: white !important;
+}
+
+================================
+
+eff.org
+
+INVERT
+#masthead .branding a
+#masthead #main-menu-nav form.search-site button[type="submit"]
+
+CSS
+select > optgroup,
+select > optgroup > option {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+#masthead #main-menu-nav .pane-main-nav-menu > ul > li a::before {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+elastic.co
+
+CSS
+code {
+    mix-blend-mode: unset !important;
+}
+
+================================
+
+elearning.utdallas.edu
+
+INVERT
+.contentBox.contentBox-edit
+.content.clearfix
+
+================================
+
+electrical-symbols.com
+
+INVERT
+.table-striped img
+
+================================
+
+electrical4u.com
+
+INVERT
+img[src*="equation"]
+
+================================
+
+electricitymap.org
+
+INVERT
+.name
+.circular-gauge
+img[alt="logo"]
+.capacity
+.mapboxgl-canvas
+
+================================
+
+elektronik-kompendium.de
+
+INVERT
+img[src*="formel/"]
+img[src*="schalt/"]
+
+================================
+
+element.io
+
+INVERT
+.header--logo--img
+.ems-nav__logo
+
+================================
+
+elementalmatter.info
+
+INVERT
+[src$="atom.gif"]
+[src$="periodic-atomic.gif"]
+
+CSS
+td {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+elementary.io
+
+IGNORE INLINE STYLE
+.logotype-svg
+
+================================
+
+eletimes.com
+
+INVERT
+.tdb-logo-img
+
+================================
+
+elicit.com
+
+CSS
+div#main > div[class^="framer"] {
+    mix-blend-mode: unset !important;
+}
+
+================================
+
+elitepvpers.com
+
+INVERT
+.inlineimg
+img[src*="images/elitepvpers/buttons/"]
+
+CSS
+body,
+td[id="userbarbg"],
+.alt1,
+.alt1Active,
+.alt2,
+.alt2Active,
+.panel,
+.panelsurround,
+.thead,
+.vBulletin_editor,
+.fieldset,
+.ticker,
+#contentshadowwhite,
+td[id="navbg"],
+td[id="navstart"],
+.signature-preview,
+.cwcontent,
+.cwalt {
+    background-image: none !important;
+}
+.alt1,
+.alt1Active,
+.alt2,
+.alt2Active,
+.panel,
+.panelsurround,
+.thead,
+.vBulletin_editor,
+.fieldset,
+.ticker,
+#contentshadowwhite {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+td[id="userbarbg"],
+td[id="navbg"],
+td[id="navstart"] {
+    background-color: color-mix(in srgb, var(--darkreader-neutral-text) 10%, var(--darkreader-neutral-background) 90%) !important;
+}
+
+================================
+
+elon.io
+
+CSS
+.hangmanchar {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+elp.northumbria.ac.uk
+
+INVERT
+.selected-answer
+
+================================
+
+emacswiki.org
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+emag.ro
+
+CSS
+.de-box {
+    border: none;
+}
+.avatar-genius {
+    background: var(--brand-onaccent) url(https://s13emagst.akamaized.net/layout/all/images/logo/genius/logo-bullet.svg) no-repeat center !important;
+}
+
+================================
+
+eman-physics.net
+
+INVERT
+.middle_area img
+
+CSS
+.middle_area {
+    border-left-color: transparent !important;
+}
+.middle_area,
+.maintxt,
+.display {
+    background: none !important;
+}
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ember-energy.org
+
+INVERT
+img[src$="/logov4.svg"]
+
+================================
+
+encyclopedia-titanica.org
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+endeavouros.com
+
+INVERT
+.navbar-brand
+
+================================
+
+endoflife.date
+
+CSS
+.bg-green-000,
+.bg-yellow-200,
+.bg-red-000 {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+endomondo.com
+
+INVERT
+.header-shop-logo
+.footer-shop-logo
+.eoFeedWorkout-map-image
+.workoutMap img[src*="maps"]
+
+CSS
+.highcharts-background {
+    fill: rgb(24, 26, 27) !important;
+}
+.highcharts-data-labels text {
+    text-shadow: none !important;
+}
+
+================================
+
+enduhub.com
+
+CSS
+.navbar .nav > li > a {
+    text-shadow: rgb(40, 43, 54) 0px 1px 0px !important;
+}
+.blurme,
+.blurme a {
+    color: inherit;
+    filter: unset;
+}
+
+================================
+
+enea.pl
+
+INVERT
+.menu__logo
+.navbar-brand
+.slider-content > .slider-title
+
+CSS
+.col-lg-12.col-md-12 > div > div > p {
+    color: var(--darkreader-neutral-background) !important;
+}
+.bkg-icon,
+.left-bkg-icon {
+    color: ${white} !important;
+}
+
+================================
+
+enjen.net
+
+CSS
+body {
+    background-image: none !important;
+}
+input.input-medium {
+    background-image: none !important;
+}
+select.input-small {
+    background-image: none !important;
+}
+
+================================
+
+eps.rs
+
+INVERT
+.racun-wrapper
+
+================================
+
+erasmusgeneration.org
+
+CSS
+.form-item a {
+    color: black !important;
+}
+.form-item a:hover {
+    color: white !important;
+}
+
+================================
+
+ernestjones.co.uk
+
+INVERT
+.logo__img
+
+================================
+
+esbuild.github.io
+
+CSS
+.progress {
+    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #181a1b 25%, #181a1b 75%, rgba(255, 255, 255, 0) 100%);
+}
+
+================================
+
+eshop-switch.com
+
+INVERT
+.logo
+
+================================
+
+eshot.gov.tr
+
+CSS
+a.navbar-brand img {
+    filter: hue-rotate(90deg) invert(1) hue-rotate(90deg) saturate(15);
+}
+#heading .left,
+#heading .sub-menu .left-xs,
+#heading .sub-menu .right-xs {
+    background-color: transparent !important;
+    background-image: none !important;
+}
+section#announcements-area .container {
+    background-image: none;
+}
+
+================================
+
+esim.gg
+
+CSS
+.bg-gradient-to-br {
+    background-image: none;
+}
+
+================================
+
+esimdb.com
+
+INVERT
+img[alt="eSIMDB logo"]
+
+================================
+
+esphome.io
+
+INVERT
+img.component-image
+
+================================
+
+estadao.com.br
+
+INVERT
+#puzzleHolder
+.puzzleField
+
+================================
+
+etherrag.blogspot.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+etsy.com
+
+INVERT
+.banner-container
+.secondary-banner-title
+.wt-radio label::before
+.review-star.rating:not(.lit)
+div.rating.nolit:not(:hover) > .ss-star
+
+================================
+
+eu.community.samsung.com
+
+INVERT
+img[alt="search icon"]
+
+================================
+
+eukhost.com
+
+INVERT
+.navbar-brand
+
+================================
+
+everdermlaser.hu
+
+INVERT
+.icon-salient-cart
+.icon-salient-m-user
+
+================================
+
+evernote.com
+
+INVERT
+.global-logo svg
+
+================================
+
+evga.com
+
+INVERT
+.evga-logo-box
+
+CSS
+.product-specs .RadTabStrip .rtsLI .rtsLink {
+    background-image: none !important;
+}
+
+================================
+
+ewybory.eu
+
+INVERT
+.navbar-brand
+
+================================
+
+excel.officeapps.live.com
+*.officeapps.live.com
+
+INVERT
+.ewr-sheettable
+
+CSS
+#ceROOT_ELEMENT-0 > path.MSChart-HighContrast,
+#ceId6_ > path.MSChart-HighContrast {
+    fill: ${rgb(232, 230, 227)} !important;
+}
+.ewa-gridKeyHandler[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+exercism.org
+
+INVERT
+.header-intro .c-icon
+svg.rough-annotation
+
+CSS
+header.c-header-with-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+.theme-light {
+    --darkreader-bg--page-dashboard-background-image: none;
+}
+
+================================
+
+exmo.me
+
+INVERT
+canvas
+
+================================
+
+expedia.com
+
+INVERT
+.uitk-header-brand-logo
+
+================================
+
+experian.com
+
+INVERT
+.logo
+
+================================
+
+experiencia.xpi.com.br
+
+INVERT
+#yield-portal-header a.xpi__header__logo svg path
+#yield-portal-header a.xpi__error__logo svg path
+#chart-profitability > div:nth-child(2) > svg > g > g:nth-child(2) > g:nth-child(1) > g > g > g > g:nth-child(2) > g > g:nth-child(1) > g:nth-child(2) > g:nth-child(2) > g > text > tspan
+
+CSS
+#chart-patrimony g[role='menu'] ~ g tspan {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+explainxkcd.com
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+.mw-ext-score
+.main-footer-menuToggle
+img[src*="Loudspeaker.svg"]
+img[alt="The Signpost"]
+
+CSS
+.diff-addedline .diffchange {
+    background-color: ${lightblue} !important;
+}
+.diff-deletedline .diffchange {
+    background-color: ${#feeec8} !important;
+}
+
+IGNORE INLINE STYLE
+.legend-color
+.infobox > tbody > tr > td[style*="background-color"]
+
+================================
+
+expressjs.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+extra.com.br
+
+CSS
+.product-card__image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+ezgif.com
+
+INVERT
+#logo
+
+================================
+
+ezschoolpay.com
+
+CSS
+.menuSideLabelSubHeader,
+.forgotPassword,
+.rememberMeCell > label,
+.rmText {
+    color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+f-droid.org
+
+INVERT
+.anti-feature-icon
+
+================================
+
+faasafety.gov
+
+CSS
+#navigation .rightBorder,
+#footer {
+    background: ${white} !important;
+}
+body {
+    background-image: none !important;
+}
+
+================================
+
+facebook.com
+
+INVERT
+._2o89
+._2q08
+.sx_af7fe0
+.sx_7ed17e
+.sx_a4a936
+.sx_4d607f
+.sx_aca067
+.sx_77228a
+.sx_51302f
+._2yu5
+._3iiv
+._3pao
+.kv0qyzoi
+.sx_426ea6
+.sx_b77acf
+._2gb3
+._7sjb
+.sx_b9f33b
+.sx_2e7846
+.sx_6d18f4
+.monochrome
+.repliedLast
+.sx_73ef60
+._81u_ .img
+._3ffs li
+#profile_intro_card_bio i
+.uiScrollableAreaWrap .uiList button[type="submit"] i._3-8_
+.editPhoto i._3-8_
+.sx_08856a
+.sx_ac12f7
+.sp_hk4DJV_EEeW
+.sp_V53xxlprDHX_1_5x
+.sp_V53xxlprDHX_2x
+#pagelet_ego_pane button .img._3-8_
+#homepage_panel_promote_footer_pagelet button .img._3-8_
+#event_tabs #reaction_units span img
+.fbPlaceFlyoutWrap img
+._83aj
+._7xv1
+._83ak
+._8g4q
+
+CSS
+.fbNubButton {
+    background-image: none !important;
+}
+.jewelItemNew ._33e {
+    background-color: ${#d0d1d3} !important;
+}
+.sx_cf4e6b {
+    filter: brightness(250%) !important;
+}
+._34k2 {
+    filter: brightness(1000%) !important;
+}
+._3hx- ._4tdt,
+._3hx- ._5wd4,
+._3hx- ._6vu5 ._5w-5,
+._3hx- ._1aa6::after,
+._3hx- ._6vu5 ._31o4,
+._3hx- ._2cnu:only-of-type ._5wdf,
+._3hx- ._5w0o,
+._3hx- ._5z-5,
+._3hx- ._16ys._3e7u,
+._3hx- ._49or .__6j,
+._3hx- ._324d .__6j,
+._llj {
+    border-color: ${#eee} !important;
+}
+._3hx- ._ua1,
+._3hx- ._40qi,
+._3hx- ._5ye6,
+._3hx- ._llj,
+._3hx- ._1a6y,
+._31o4,
+._3_bp,
+._4gd0,
+._49or,
+._40fu {
+    background-color: ${#eee} !important;
+}
+.fbNub._50mz .fbNubFlyoutFooter::after {
+    background-color: ${rgba(0, 0, 0, .15)} !important;
+}
+.fbNub._50mz .fbNubFlyoutInner,
+._4cd8 ._69pt,
+._4mq3 .fbNubFlyout,
+._4mq3 .fbNubButton {
+    box-shadow: 0 0 0 1px ${rgba(0, 0, 0, .15)} !important;
+}
+.__fb-light-mode {
+    --filter-blue-link-icon: invert(73%) sepia(29%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(103.25%) hue-rotate(189deg) brightness(101%) contrast(101%) !important;
+    --filter-disabled-icon: invert(100%) opacity(30%) !important;
+    --filter-negative: invert(25%) sepia(33%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(110%) hue-rotate(345deg) brightness(132%) contrast(96%) !important;
+    --filter-placeholder-icon: invert(59%) sepia(11%) saturate(200%) saturate(135%) hue-rotate(176deg) brightness(96%) contrast(94%) !important;
+    --filter-positive: invert(37%) sepia(61%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(115%) hue-rotate(91deg) brightness(97%) contrast(105%) !important;
+    --filter-primary-icon: invert(100%) !important;
+    --filter-secondary-icon: invert(62%) sepia(98%) saturate(12%) hue-rotate(175deg) brightness(90%) contrast(96%) !important;
+    --filter-warning-icon: invert(77%) sepia(29%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(128%) hue-rotate(359deg) brightness(102%) contrast(107%) !important;
+}
+.__fb-light-mode {
+    --darkreader-border--messenger-card-background: var(--darkreader-bg--messenger-card-background) !important;
+}
+.__fb-dark-mode {
+    --darkreader-border--messenger-card-background: #1c1e20 !important;
+}
+div[role=article] div.k4urcfbm[aria-hidden="true"] {
+    --darkreader-inline-bgcolor: none !important;
+    background-blend-mode: color;
+    background-color: rgba(0, 0, 0, 0.25);
+}
+div[data-pagelet="Stories"] .ha302278 {
+    background-color: rgba(0, 0, 0, 0.4) !important;
+}
+div[aria-label="Change volume"] .ha302278,
+div[aria-label="Change Position"] .ha302278,
+._3paq {
+    background-color: rgba(255, 255, 255, 0.4) !important;
+}
+.r4vyqqch {
+    background-color: var(--fds-white-alpha-50) !important;
+}
+.lyi53s4r {
+    background-color: rgba(88,144,255,.9) !important;
+}
+.tdjehn4e,
+.oo1teu6h {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+}
+.tdjehn4e:hover,
+.ovq5dppa:hover {
+    background-color: rgba(255, 255, 255, 0.2) !important;
+}
+.k19f6yf2 {
+    background-color: var(--press-overlay) !important;
+}
+.cxbav39q {
+    background-color: rbga(0, 0, 0, 0.8) !important;
+}
+.rnr61an3 {
+    background-color: var(--hover-overlay) !important;
+}
+.qbubdy2e {
+    fill: none !important;
+}
+.s1i5eluu {
+    background-color: var(--primary-button-background) !important;
+}
+.q66pz984 {
+    color: var(--accent);
+}
+.esnais5j,
+._8bb_ img,
+._8bb_ i,
+._8bb_ video,
+._8bb_ ._w80,
+._8bb_ ._7umt ._47yj,
+._8bb_ [style*='background-image: url'] {
+    filter: none !important;
+}
+div[role="button"] > i.hu5pjgll:not(.sp_Jc8OKpJq5NW, .sp_T89CCTT7d9Z),
+a[role="link"] > i.hu5pjgll,
+._3w97,
+svg[role="presentation"] {
+    filter: var(--filter-secondary-icon) !important;
+}
+._2yua,
+._3pas {
+    background-color: #888 !important;
+}
+._2yu8 {
+    background-color: rgba(255, 255, 255, .5) !important;
+}
+.leaflet-map-pane img[src*="theme=default"],
+[style*="map"][style*="theme=default"],
+._8bb_ img[src*="/map"],
+._8bb_ [style*="map"],
+img[src*="mapy.cz"],
+._8bb_ img[src*="mapy.cz"],
+img[src*="%2Fmap"],
+._8bb_ img[src*="%2Fmap"],
+img[src*="map.php"],
+._8bb_ img[src*="map.php"],
+img[src*="www.traseo.pl%2Froute"],
+._8bb_ img[src*="www.traseo.pl%2Froute"] {
+    filter: invert(100%) hue-rotate(180deg) !important;
+}
+.j7vl6m33 {
+    fill: var(--always-white) !important;
+}
+::after {
+    border-bottom-color: #1c1e20 !important;
+    border-left-color: #1c1e20 !important;
+    border-right-color: #1c1e20 !important;
+    border-top-color: #1c1e20 !important;
+}
+.x1g6sh6t {
+    fill: none !important;
+}
+div[style*="background-image"] {
+    text-shadow: rgb(40, 43, 54) 0px 0px 3px !important;
+}
+.x1qhmfi1 {
+    background-color: rgba(255,255,255,.1) !important;
+}
+
+IGNORE INLINE STYLE
+[role="button"] svg
+[role="button"] svg line
+div svg[viewBox="0 0 36 36"] mask path
+mask > rect
+mask > circle
+g > rect
+.html-div svg path
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+faceofit.com
+gigxp.com
+soundmaxpro.com
+
+INVERT
+div.menu-icon
+a::before
+circle.progress__value
+div.percent-number
+
+================================
+
+fairhotel.org
+
+INVERT
+.btn-close
+.gm-ui-hover-effect > span
+.navbar-brand > img
+
+================================
+
+fairtradeoriginal.*
+
+INVERT
+.SiteLayout
+.SiteLayout > *
+.Inset-image
+
+================================
+
+fairvote.org
+
+CSS
+.bg-dark-red {
+    background-color: rgb(229 89 80/var(--tw-bg-opacity)) !important;
+}
+.bg-primary,
+.header-navigation > nav#desktop-nav .nav-backdrop,
+.header-navigation > nav#desktop-nav > ul > li > .content-link::after {
+    background-color: rgb(71 24 120/var(--tw-bg-opacity)) !important;
+}
+.header-navigation > nav#desktop-nav .submenu ul.menu-list.third-level > li {
+    border-color: rgb(255 255 255/var(--tw-border-opacity)) !important;
+}
+
+================================
+
+fakt.pl
+
+INVERT
+.header-links
+
+================================
+
+fallout.wiki
+
+INVERT
+.cosmos-actions-talk svg
+img[src*="Hat_arrow.png"]
+
+CSS
+@media screen and (min-width: 850px) {
+    body::after {
+        z-index: 0 !important;
+    }
+}
+.user-anon #cosmos-banner {
+    position: sticky !important;
+}
+.k-player .control-bar {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+famashow.pt
+
+INVERT
+img[alt="Fama Show"]
+.main-footer .siga-sic .nav-title
+.main-footer .siga-sic li a img
+.main-footer .g-brands li
+
+================================
+
+fanatical.com
+
+INVERT
+.trustpilot > .logo-container > a > img
+
+IGNORE INLINE STYLE
+div.drm-container svg g
+
+================================
+
+fandom.com
+*.fandom.com
+
+INVERT
+.mobile-global-navigation__logo
+.wds-global-navigation__logo-fandom
+a[href^="https://auth.fandom.com/auth/redirect?redirect="][data-test="back-button"]
+.mwe-math-element
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+#mixed-content-footer,
+.community-header-wrapper,
+.top-ads-container,
+.bottom-ads-container,
+.global-footer {
+    z-index: 1 !important;
+}
+.fandom-community-header__background.cover {
+    z-index: 0 !important;
+}
+a[href^="https://auth.fandom.com/auth/redirect?redirect="][data-test="back-button"] {
+    color: ${white} !important;
+}
+
+IGNORE INLINE STYLE
+.wds-global-navigation__logo-image g path
+.wds-global-footer__header-logo g path
+.wds-global-footer__link svg g path
+symbol[id^="wds-brand-other"] *
+
+================================
+
+fanfiction.net
+
+CSS
+#content_wrapper_inner,
+#p_footer,
+body,
+.content_wrapper_inner,
+.lc-left,
+.lc,
+.xcontrast_outer,
+.zmenu {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.btn {
+    background-image: none !important;
+}
+#search_keywords,
+select {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+body
+
+================================
+
+fantasy.premierleague.com
+
+INVERT
+.ism-table
+
+================================
+
+fanyi.sogou.com
+
+CSS
+#trans-input {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+farside.ph.utexas.edu
+mathpages.com
+mathprofi.ru
+mathprofi.net
+mathworld.wolfram.com
+reference.wolfram.com
+terrytao.wordpress.com
+wolframalpha.com
+
+INVERT
+img:not([src^="/_next/static/images/"])
+
+================================
+
+fast.com
+
+INVERT
+div.logo
+div.powered-by
+
+IGNORE IMAGE ANALYSIS
+div.logo
+div.powered-by
+
+================================
+
+fastcomments.com
+
+CSS
+.dark .menu-content div > i {
+    filter: invert(0) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.icon.edit-small
+.icon.img-up
+.icon.ul
+.icon.bubble
+
+================================
+
+fastmail.com
+
+INVERT
+.logo svg
+
+================================
+
+fastmail.com/mail
+
+CSS
+.app-listItem.is-focused,
+.app-source.is-selected {
+    background-color: ${lightgray} !important;
+}
+.app-source.is-focused {
+    background-color: ${lightblue} !important;
+    color: ${black} !important;
+}
+.v-MailboxItem-unreadbadge {
+    background-color: ${darkblue} !important;
+}
+.v-Message-body {
+    border-color: transparent !important;
+}
+
+================================
+
+fatmap.com
+
+CSS
+.activity-filter-single-click svg.icon {
+    fill: ${black} !important;
+}
+.stats-container-small svg.ruler-icon {
+    fill: ${#333} !important;
+}
+
+IGNORE INLINE STYLE
+svg.icon
+
+================================
+
+fau.de
+
+INVERT
+.baselogo
+
+CSS
+.accordion-toggle:not(.active) {
+    background-color: ${lightgrey} !important;
+}
+.accordion-toggle.active,
+.accordion-toggle:hover {
+    background-color: #032755 !important;
+}
+
+================================
+
+fax.plus
+
+INVERT
+img[src$="_info.svg"]
+
+================================
+
+fckng-serious.de
+
+INVERT
+.logo
+
+================================
+
+fcmed.pl
+
+INVERT
+.mkd-logo-wrapper
+a[href*="tel"]
+.mkd-sidearea > .textwidget > a > img
+.owl-wrapper
+
+================================
+
+federica.unina.it
+
+INVERT
+img.latex
+
+================================
+
+fedex.com
+
+CSS
+.fx-global-prelog-link.fx-showlogin span {
+    background-image: none !important;
+}
+
+================================
+
+fedica.com
+account.fedica.com
+
+INVERT
+.topleftLogo
+
+================================
+
+fedoraforum.org
+
+INVERT
+.logo-image
+
+================================
+
+feedly.com
+
+CSS
+.entry.u0:hover,
+.entry--selected.u0,
+.entry--selected.u0:hover,
+.entry--selected.u4,
+.entry--selected.u5,
+button.secondary:hover {
+    background-color: ${#ccc} !important;
+}
+
+================================
+
+festivals.mt
+
+CSS
+body :not(iframe) {
+    background-color: ${rgba(255,255,255,0.05)} !important;
+}
+div[data-testid="responsive-container-overflow"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.wixui-mobile-menu__icon .XLAVDo div {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+a[href="http://www.festivals.mt"] svg * {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+feynmanlectures.caltech.edu
+
+INVERT
+.figure > img[src$=".svgz"]
+
+================================
+
+fgo.gamepress.gg
+
+CSS
+.TLW-tier-charname {
+    color: ${black} !important;
+}
+#content-inner {
+    background-image: none !important;
+}
+
+================================
+
+fibermap.it
+
+INVERT
+img[src$="assets/images/bg-cloud.png"]
+
+================================
+
+figma.com
+
+CSS
+:root,
+.blog-body {
+    --darkreader-bg--global-bg-color: var(--darkreader-neutral-background) !important;
+    --darkreader-text--global-color: var(--darkreader-neutral-text) !important;
+    --global-bg-color: var(--darkreader-neutral-background) !important;
+    --global-color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+div[class*="paint_panels--chit"]
+div[class*="modal--modalShadow"] div
+.blog-body
+
+================================
+
+fileformat.info
+
+INVERT
+[src$="logo_wide.png"]
+.thumbnail
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+filetransfer.io
+
+INVERT
+a.logo
+
+================================
+
+filmweb.pl
+
+INVERT
+.ribbonLbl
+.isInit.ribbon[data-state="1"]::after
+.isInit.ribbon[data-state="2"]::after
+.isInit.ribbon[data-state="3"]::after
+.isInit.ribbon[data-state="4"]::after
+.isInit.ribbon[data-state="5"]::after
+.isInit.ribbon[data-state="6"]::after
+.isInit.ribbon[data-state="7"]::after
+.isInit.ribbon[data-state="8"]::after
+.isInit.ribbon[data-state="9"]::after
+.isInit.ribbon[data-state="10"]::after
+
+CSS
+.filmInfo__info {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+filterlists.com
+
+IGNORE INLINE STYLE
+header.ant-layout-header img
+
+================================
+
+final-fantasy.ch
+
+CSS
+nav ul li:first-child span,
+h1 {
+    color: #000 !important;
+}
+input[type="submit" i],
+input[type="file" i] {
+    background-color: ${#c7c7c7} !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+finn.no
+
+INVERT
+finn-footer
+article.ads__unit overflowmenu-active
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+fio.fnar.net
+
+INVERT
+.chartjs-render-monitor
+
+================================
+
+fire.ca.gov
+
+CSS
+.hero-banner__bg::after,
+.page-header__bg::after {
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+.hero-banner__bg::before,
+.page-header__bg::before {
+    border-left-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+firebase.google.com
+
+INVERT
+.devsite-site-logo
+
+CSS
+.c5e-input-container input[type="text"],
+.c5e-input-container input[type="password"],
+.c5e-input-container input[type="url"],
+.c5e-input-container input[type="number"],
+.c5e-input-container input[type="email"],
+.c5e-input-container input[type="search"],
+.c5e-input-container input[type="time"],
+.c5e-input-container input[type="tel"],
+.c5e-input-container md-select,
+.c5e-input-container mat-select,
+.c5e-input-container textarea {
+    color: var(--darkreader-bg--fire-color-grey-primary) !important;
+}
+
+================================
+
+firefox.com
+
+INVERT
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+.sidebar-icon
+
+================================
+
+firefox.net.cn
+
+CSS
+.btn,
+.core_follow,
+.pop_deep .ct dt.reward,
+.pages a,
+.pages strong,
+.design_mode_edit,
+.pop_showmsg {
+    background-image: none;
+}
+
+================================
+
+firms.modaps.eosdis.nasa.gov
+
+IGNORE INLINE STYLE
+.fmmLyrLegendBox
+.fmmTSDLegendIcon
+
+================================
+
+firstcontributions.github.io
+
+CSS
+.App,
+.topnav {
+    background-color: ${CornflowerBlue};
+}
+
+================================
+
+fitgirl-repacks.site
+
+INVERT
+img[src*="https://torrent-stats.info/"]
+.widget_block a[href="https://fitgirl-repacks.site/games-with-my-personal-pink-paw-award/"]
+.swiper-pagination span
+
+CSS
+div.entry-content div:not(.swiper-button-next):not(.swiper-button-prev) {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+
+================================
+
+fiverr.com
+
+IGNORE INLINE STYLE
+.site-logo *
+
+================================
+
+fivethirtyeight.com
+*.fivethirtyeight.com
+
+INVERT
+.logo
+.abclogo
+.site-logo
+#searchform
+.header-espn-link
+
+CSS
+.domain,
+.win-prob,
+.winSentText {
+    stroke: none !important;
+}
+
+================================
+
+flaggenlexikon.de
+
+INVERT
+img[src="https://www.flaggenlexikon.de/pix/flaggenlexikon.gif"]
+
+CSS
+body {
+    background-image: none;
+}
+[background="higru.gif"] {
+    background: var(--darkreader-neutral-background);
+}
+
+================================
+
+flashscore.com.tr
+
+INVERT
+.header__logo
+
+================================
+
+flatuicolors.com
+
+IGNORE INLINE STYLE
+.color
+
+================================
+
+flcu.org
+*.flcu.org
+
+INVERT
+a.brand img
+.logo img
+
+CSS
+a[href="https://flcu.org/resources/solutions/make-a-payment/"] {
+    color: var(--darkreader-neutral-text) !important;
+}
+.nav-menu-popover__background {
+    background-color: var(--darkreader-background-f2f2f2) !important;
+}
+.irisv-button[type="submit"]:not([aria-disabled="true"]) {
+    background-color: rgb(var(--colorBrandedAffordance)) !important;
+    color: white !important;
+}
+.irisv-textfield--filled .irisv-textfield__control {
+    background-color: ${lightgray} !important;
+}
+
+================================
+
+flickr.com
+
+CSS
+.bg-cta-disabled-gray {
+    background-color: ${rgba(48, 52, 54, .7)} !important;
+}
+
+IGNORE INLINE STYLE
+#icon-flickr_logo_dots path
+
+================================
+
+flightconnections.com
+
+INVERT
+img[alt="FlightConnections logo"]
+img[alt="FlightConnections Premium logo"]
+span.menu-icon
+div.slider > div.toggle
+img.contact-img
+
+================================
+
+flightfinder.fi
+
+INVERT
+.logo
+
+================================
+
+flightglobal.com
+
+INVERT
+img#logo
+
+================================
+
+flightutilities.com
+
+CSS
+#main {
+    background-image: none !important;
+}
+#column1 {
+    background-color: rgb(40,40,40) !important;
+}
+#menu li a:hover,
+#menu li a#mainselected,
+#menu li a#mainselected:hover,
+.sidebaritem h1 {
+    color: #5A6370 !important;
+}
+
+================================
+
+flipboard.helpshift.com
+
+INVERT
+img.faq-section-image
+img.js-faq-section-image
+
+CSS
+svg.footer-helpshift-branding-text path {
+    fill: white !important;
+}
+
+IGNORE INLINE STYLE
+svg.footer-helpshift-branding-text path
+
+================================
+
+flow.polar.com
+
+INVERT
+.brand
+.detail-data-panel__icon
+.sleep-chart-yaxis.end
+.supergraph-canvas
+
+CSS
+.highcharts-container svg {
+    fill: ${#3f3f3f} !important;
+}
+.card__item-icon--rounded img {
+    background-blend-mode: color;
+    background-color: rgba(255, 255, 255, 0.15) !important;
+}
+.altitudetitle,
+.altdescmax,
+.altdescmin,
+.zonedesctitle,
+.zonedescmax,
+.zonedesclight,
+.maxhighlightval,
+.maxhighlightname {
+    color: rgb(0, 0, 0) !important;
+}
+.highcharts-background {
+    fill: none !important;
+}
+
+IGNORE INLINE STYLE
+.zonebox
+.zonestartbox
+stop
+
+================================
+
+flowkey.com
+
+INVERT
+body.front #zone-branding-wrapper
+
+CSS
+body.html #page.page #subslogan {
+    color: ${white} !important;
+}
+
+================================
+
+fly.io
+
+CSS
+.bg-custom {
+    background-image: none !important;
+}
+.post :not(a):not(pre):not(.changelog-item) > code {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+flybywiresim.com
+
+CSS
+.opacity-90 {
+    opacity: .4 !important;
+}
+.-z-10 {
+    z-index: 0 !important;
+}
+.from-primary\/30 {
+    --darkreader-bg--tw-gradient-from: #181a1b !important;
+    --darkreader-bg--tw-gradient-to: #181a1b !important;
+}
+
+================================
+
+flyzipline.com
+
+INVERT
+#logo
+
+IGNORE IMAGE ANALYSIS
+#logo
+
+================================
+
+foli.fi
+
+INVERT
+a[title="Etusivu"] svg
+a[title="Home"] svg
+a[title="Huvudsida"] svg
+button svg
+nav g > g:nth-child(1)
+
+================================
+
+follow.it
+
+INVERT
+.header-logo
+.logo
+
+================================
+
+fontawesome.com
+
+CSS
+#icons-header,
+#docs-header,
+#hero > div:not(.container),
+.app-content.docs {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.doc-nav > div {
+    background-color: var(--darkreader-bg--background-norm) !important;
+}
+#search-header {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+fontsinuse.com
+
+INVERT
+.fiu-header__branding
+.fiu-sample-list__item img
+.fiu-gallery-head__text img
+
+================================
+
+fontspring.com
+
+INVERT
+.grid6 .fullwidth
+
+================================
+
+fontsquirrel.com
+
+INVERT
+.fontlistitem
+
+CSS
+#main_content_container {
+    background-image: none !important;
+}
+
+================================
+
+foobar2000.org
+
+INVERT
+img[src="/foobarlogo.svg"]
+
+================================
+
+food4less.com
+
+INVERT
+img[alt="Food4less logo"]
+
+================================
+
+foolcontrol.org
+
+CSS
+html {
+    background-color: transparent !important;
+}
+
+================================
+
+foragerproject.com
+
+INVERT
+.product-icons .icon
+.navbar-brand
+
+================================
+
+forem.com
+
+INVERT
+nav a > img[alt="Home"]
+#cta > section > div > div > img
+
+================================
+
+forms.auth0.com
+
+INVERT
+.react-flow__background
+
+================================
+
+forms.yandex.ru
+
+INVERT
+.header2__service-logo
+.header2__logo-wrap
+
+================================
+
+formula1.com
+
+IGNORE INLINE STYLE
+svg[class*="CountryFlag"].*
+
+================================
+
+forsal.pl
+
+INVERT
+.serviceLogo
+.homePageUrl
+
+CSS
+.mini-tabs {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+forum.canardpc.com
+
+CSS
+.widget-tabs .widget-tabs-nav li,
+.widget-tabs .widget-tabs-nav .ui-tabs-nav,
+.view-mode .widget-tabs .widget-tabs-nav {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+forum.dobreprogramy.pl
+
+INVERT
+#site-logo
+
+================================
+
+forum.donanimhaber.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+forum.eset.com
+forum.ithardware.pl
+forum.kaspersky.com
+forums.getpaint.net
+forums.laptopvideo2go.com
+forums.warframe.com
+nieidealny.pl/forum
+
+INVERT
+.ipsBadge_highlightedGroup
+.ipsBadge_icon
+.ipsBadge_popular
+.ipsComment_authorBadge
+.ipsItemStatus.ipsItemStatus_custom.ipsItemStatus_read
+.ipsReact_button
+img[alt="Forum komputerowe ITHardware"]
+img[alt="paint.net Forum"]
+
+CSS
+.ipsBadge {
+    --darkreader-bg--badge--background: var(--darkreader-neutral-background) !important;
+}
+.ipsReact_reactCount > a,
+.ipsReact_reactCount > span,
+.elFullInbox_menu,
+.ipsHovercard,
+.ipsList_reset,
+.ipsMenu_auto,
+.ipsMenu_footerBar,
+.ipsMenu_headerBar,
+.ipsMenu_innerContent,
+.ipsMenu_item,
+.ipsMenu_sep,
+.ipsMenu_title,
+.ipsPadding,
+.cUserHovercard,
+a[data-mentionid] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+forum.gitlab.com
+
+INVERT
+.chcklst-box
+
+================================
+
+forum.ivao.aero
+
+INVERT
+.buttonlist
+
+CSS
+.cat_bar,
+.cat_bar > *,
+.catbg > * {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+:not(a) > span,
+:not(a) > span > *,
+#footer {
+    background: none !important;
+}
+.buttonlist a:not(.active) {
+    color: var(--darkreader-neutral-background) !important;
+}
+ul.dropmenu li {
+    background: var(--darkreader-neutral-background) !important;
+    border: none !important;
+}
+ul.dropmenu ul {
+    background: var(--darkreader-neutral-background) !important;
+    border: 1px solid var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+#header
+
+================================
+
+forum.kaosx.us
+
+INVERT
+.Header-logo
+
+CSS
+.Dropdown-toggle,
+.item-refresh > Button,
+.DiscussionList-loadMore > Button,
+.LogInButton--github,
+.Button--icon {
+    background: ${#6f7f92} !important;
+    color: ${black} !important;
+}
+
+================================
+
+forum.manjaro.org
+
+CSS
+.below-footer-outlet.custom-footer {
+    background-image: none !important;
+}
+
+================================
+
+forum.miranda-ng.org
+
+CSS
+.firstlevel {
+    color: ${#666666} !important;
+}
+
+================================
+
+forum.osdev.org
+
+INVERT
+#phpbb
+img.avatar
+
+================================
+
+forum.p300.it
+
+CSS
+.ipsReact_reactCount > a {
+    background-color: var(--darkreader-neutral-background);
+    border-color: var(--darkreader-neutral-text);
+}
+.ipsType_normal {
+    border-color: rgb(48,52,54);
+}
+.ipsMenu_headerBar,
+.ipsMenu_footerBar,
+.ipsEmoticons_category,
+.ipsMenu_innerContent,
+ul.ipsMenu,
+.ipsMenu > ul,
+a[data-mentionid],
+.cUserHovercard {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+forum.qt.io
+
+INVERT
+img[alt="Brand Logo"]
+
+================================
+
+forum.videolan.org
+
+CSS
+ul.forums {
+    background-image: none !important;
+}
+
+================================
+
+forums.ankiweb.net
+
+CSS
+#user-content {
+    background: transparent;
+}
+
+================================
+
+forums.comodo.com
+
+INVERT
+.windowbg span.topslice
+.windowbg span.botslice
+.windowbg2 span.topslice
+.windowbg2 span.botslice
+
+CSS
+body {
+    background-image: none !important;
+}
+.buttonlist ul li a span:not(:hover) {
+    color: ${white} !important;
+}
+
+================================
+
+forums.gearsofwar.com
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+forums.mydigitallife.net
+
+IGNORE INLINE STYLE
+#TotpQrCode
+
+================================
+
+forums.opera.com
+
+INVERT
+.forum-logo-wrapper
+
+================================
+
+forums.operationsports.com
+
+INVERT
+i
+.smallfont
+strong
+
+================================
+
+forums.stardock.com
+
+IGNORE IMAGE ANALYSIS
+.body .forum > .post .postcontainer .postinfo .menu .karma_badge
+
+================================
+
+forums.tomshardware.com
+
+INVERT
+img[src="/styles/tomshardware/tomshardware/toms-hardware-logo.png"]
+div.trophyShowcase.trophyShowcase--postbit
+
+================================
+
+forvo.com
+
+INVERT
+img[src$="layout/logo.svg"]
+
+================================
+
+fotor.com
+
+INVERT
+div[style^="background-image: url(\"https://imgv3.fotor.com/images/background/background-image.png\");"]
+div[style^="background-image: url(\"https://imgv3.fotor.com/images/background/background-image.png\");"] > *
+
+================================
+
+fotw.info
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+foundation.rust-lang.org
+
+CSS
+.peoplelist li {
+    background-position: center;
+    background-size: cover;
+}
+
+================================
+
+foundertype.com
+
+CSS
+.btn1 {
+    background-color: transparent !important;
+}
+.getAuthBtn {
+    background-color: var(--darkreader-background-b29c70) !important;
+}
+.downFontBtn {
+    background-color: var(--darkreader-background-464646) !important;
+}
+.header-top,
+.header-top * {
+    background-color: var(--darkreader-background-4d4d4d) !important;
+}
+
+================================
+
+framatube.org
+
+INVERT
+.vjs-load-progress
+.vjs-play-progress
+.vjs-play-progress::before
+
+================================
+
+frame.work
+
+INVERT
+#site-logo
+
+CSS
+.filter-invert {
+    filter: none !important;
+}
+
+================================
+
+fredmeyerjewelers.com
+
+INVERT
+#header1_mainlogo
+.mobileNavIcons img
+.mobileNavIcons input:not(.searchdesktop)
+
+================================
+
+freebsdfoundation.org
+
+CSS
+.content-wrapper {
+    background-image: none !important;
+}
+
+================================
+
+freecodecamp.org
+
+CSS
+.video-quiz-selected-input {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.progress-bar-percent {
+    background-color: ${gray} !important;
+}
+.map-title polygon {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.map-badge circle {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+freecommander.eu
+
+CSS
+#subsilver-nav-topic {
+    background-image: none !important;
+}
+.forumbg,
+.forabg {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+freedom.press
+
+INVERT
+.logo-heading-text
+
+================================
+
+freelancer.com
+
+INVERT
+.LogoImg[src*="freelancer-logo.svg"]
+
+================================
+
+freemaptools.com
+
+INVERT
+img[src="images/freemaptools-logo.jpg"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+freepascal.org/docs-html
+
+INVERT
+img
+
+================================
+
+freeriderhd.com
+
+CSS
+#game-container {
+    background-color: #cdcdcd !important;
+}
+
+================================
+
+freesound.org
+
+CSS
+#search input:not(#search_submit) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+freetp.org
+
+CSS
+html,
+body,
+.wmid,
+.wfoot {
+    background-image: none !important;
+}
+html,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+fresha.com
+
+INVERT
+a[aria-label="Fresha"]
+
+================================
+
+freshprep.ca
+
+INVERT
+img.logo
+
+CSS
+.recipe .product-image {
+    z-index: 0 !important;
+}
+
+================================
+
+friction.graphics
+
+CSS
+#heroVideo {
+    z-index: auto !important;
+}
+
+================================
+
+fritz.box
+
+INVERT
+div.formular input[type="radio"]
+div.formular input[type="checkbox"]
+
+CSS
+div.formular input[type="radio"],
+div.formular input[type="checkbox"] {
+    background-color: transparent !important;
+}
+#navigationMenu {
+    background: linear-gradient(--darkreader-bg--charcoal-gray-20: 30%, rgba(255, 255, 255, 0)) center top,linear-gradient(rgba(255, 255, 255, 0), #1b1e1f 70%) center bottom,linear-gradient(var(--charcoal-gray-30), transparent) center top,linear-gradient(transparent, --darkreader-bg--charcoal-gray-20:) center bottom !important;
+    background-attachment: local,local,scroll,scroll !important;
+    background-repeat: no-repeat !important;
+    background-size: 100% 1.2rem,100% 1.2rem,100% .5rem,100% .5rem !important;
+}
+
+================================
+
+fs.blog
+
+INVERT
+.shared-counts-icon
+
+CSS
+body,
+.header-box {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+fsfe.org
+
+INVERT
+#logo
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+ftp.nluug.nl
+
+INVERT
+img[alt="[NLUUG]"]
+
+================================
+
+fullstackopen.com
+
+CSS
+.gatsby-highlight-code-line {
+    background-color: ${hsla(0,0%,48.2%,.3)} !important;
+}
+
+================================
+
+funpay.ru
+
+INVERT
+.logo-color
+.logo
+
+================================
+
+furrychina.com
+
+INVERT
+.main_logo
+
+================================
+
+fusoya.eludevisibility.org
+
+CSS
+body {
+    background-image: none !important;
+}
+td {
+    background-image: none !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+futar.bkk.hu
+
+INVERT
+.mapboxgl-map
+
+================================
+
+futureplc.com
+
+INVERT
+img[src$="future-logo.svg"]
+
+================================
+
+futurism.com
+
+INVERT
+img.header-logo
+ul.header-socials div.social-icon-wrapper text
+div.footer-logo-wrapper img
+
+================================
+
+fyziklani.*
+online.fyziklani.cz
+physicsbrawl.org
+
+IGNORE IMAGE ANALYSIS
+.flag-icon-bg
+.flag-icon-co
+.flag-icon-fi
+.flag-icon-jp
+.flag-icon-kr
+.flag-icon-lt
+.flag-icon-pl
+.flag-icon-ru
+.flag-icon-sk
+
+================================
+
+fz-juelich.de
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+gadzetomania.pl
+
+CSS
+a svg path[d^="M12.881 14.785v-"] {
+    fill: #fff !important;
+}
+
+================================
+
+gain.tv
+
+CSS
+.body-new-index .hero-img-container {
+    z-index: 0 !important;
+}
+
+================================
+
+gameinformer.com
+
+INVERT
+.site-logo
+
+================================
+
+gameranx.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.mai-toc__listitem,
+.mai-toc__details,
+.mai-toc-default .mai-toc__summary {
+    background-color: ${#f7f7f7} !important;
+}
+
+================================
+
+gamerevolution.com
+
+INVERT
+.wp-block-xwp-curated-content__card-title
+.wp-block-xwp-curated-content__card-excerpt
+.wp-block-xwp-curated-content__card-footer
+.wp-block-xwp-curated-content__title
+.xe-footer-nav__menu
+.xe-footer-social-nav__menu
+.xe-site-footer__bottom-column-2
+#h-featured
+
+================================
+
+gamesindustry.biz
+
+INVERT
+.logo
+
+================================
+
+gamestop.com
+
+INVERT
+.nav-logo
+img[alt*="Icon"]
+img.icon
+a#sub-nav-store-name svg
+
+================================
+
+garmin.com
+*.garmin.com
+
+INVERT
+.gh__logo
+.map-controls.player .pause span
+.recharts-dot
+.highcharts-plot-line-label
+
+CSS
+.recharts-wrapper text {
+    fill: ${rgba(0, 0, 0, 0.75)} !important;
+}
+span[class*="Carousel_carouselHighlightedDot"] {
+    background-color: ${rgba(0, 0, 0, 0.75)} !important;
+}
+span[class*="Gc5ChallengesCard_progressBar"] div[class*="ProgressBar_bar__"],
+span[class*="DayView_progressBar"] div[class*="ProgressBar_bar__"] {
+    background: ${black} !important;
+}
+.find-plan-filters button {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.plan-section-label {
+    color: var(--darkreader-neutral-text) !important;
+}
+.plan-info,
+.plan-specs {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+gasbuddy.com
+
+INVERT
+.pin
+.pin-small
+
+CSS
+.VehicleRecallSearchBar-module__searchBar___3EjPt .VehicleRecallSearchBar-module__dropDown___23Uqi button {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+gat.no
+
+INVERT
+figure.logo > img
+
+CSS
+main.container .every_board > .row:not(.row--takeover) {
+    --front-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+gatsbyjs.com
+
+INVERT
+.ais-InfiniteHits-item
+
+CSS
+.gatsby-highlight,
+.language-text {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+gazeta.pl
+plotek.pl
+sport.pl
+edziecko.pl
+moto.pl
+ukrayina.pl
+
+INVERT
+img[alt^="logo"]
+.vs__actions
+a.item.noSwiper img
+.navigation__logo
+
+CSS
+.top_section_bg,
+.bottom_section_bg {
+    background-color: ${#e5e5e5} !important;
+}
+svg [id="Group_242"],
+svg [id="Path_9914"] {
+    fill: ${black} !important;
+}
+
+================================
+
+gazetaprawna.pl
+
+INVERT
+.bubbleMenuHamburger
+.homePageUrl
+.serviceLogo
+.servicesMenu #menuTrigger span
+
+================================
+
+gazetaswietokrzyska.pl
+
+INVERT
+.logo
+
+CSS
+.elementor-column-wrap.elementor-element-populated {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+geekflare.com
+
+INVERT
+.logo
+
+================================
+
+geeksforgeeks.org
+
+INVERT
+.root[data-dark-mode="false"] .gfg-logo
+
+CSS
+.gsc-input-box {
+    box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 0px 2px !important;
+}
+
+================================
+
+geeksonsite.com
+
+CSS
+#page-content {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+geizhals.*
+skinflint.co.uk
+cenowarka.pl
+
+CSS
+img,
+.mocat-item__image,
+.primary-nav .nav-item-type-cat-image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+generatorbible.com
+
+CSS
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
+}
+
+================================
+
+genius.com
+
+INVERT
+.texmath
+
+================================
+
+genome-euro.ucsc.edu
+
+INVERT
+td.tdData
+.tdLeft
+
+================================
+
+genshin-impact-map.appsample.com
+
+INVERT
+.bg-secondary.px-1.py-0.input-group-text > .icon
+.border-top2.text-center.w-100.sidebar-footer
+.gm-ui-hover-effect
+
+================================
+
+gentoo.org
+
+INVERT
+.site-logo
+
+================================
+
+geogebra.org
+
+INVERT
+.icon-m
+.elemText canvas
+.gwt-Image
+.gwt-StackPanelItem img
+.GeoGebraMenuImage.menuImg
+.menuImg
+.buttonContent.stylebarButton
+.EuclidianPanel > canvas
+.stepTreeElem
+
+================================
+
+gestis.dguv.de
+
+CSS
+.v-application {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+    display: flex;
+}
+#home-content-wrapper {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.65)} !important;
+}
+
+================================
+
+get.google.*
+get.google.*.*
+
+INVERT
+a[href*="about/products"]
+span[aria-label="Settings"][role="menuitem"] path
+span[aria-label="About Album Archive"][role="menuitem"] path
+span[aria-label="Download photo"][role="menuitem"] path
+span[aria-label="Manage in Google Photos"][role="menuitem"] path
+
+================================
+
+getalt.org
+
+INVERT
+.site-title
+
+================================
+
+getbevel.com
+
+CSS
+[class*="color-scheme--bg-"],
+.article__wrapper.container--xs,
+.product-sticky-bar {
+    background: var(--darkreader-neutral-background) !important;
+}
+.color-scheme,
+.collection-toolbar,
+.drawer::part(content) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.header__primary-nav-item,
+.header__nav-icon.icon {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+getfedora.org
+
+INVERT
+img[alt="globe"]
+
+================================
+
+getlektor.com
+
+CSS
+.body-wrapper .container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+pre {
+    background-image: none !important;
+}
+
+================================
+
+getmimo.com
+
+INVERT
+a[title="Home"][href] > svg
+div[class^="FifthSection___StyledDiv8"] > svg
+div[class^="Footer__Row"] > :nth-child(1) svg
+
+CSS
+login-container {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+getpocket.com
+
+CSS
+p a[rel="noopener noreferrer"] {
+    background-image: linear-gradient(to top,transparent,transparent 1px,var(--darkreader-text--color-canvas) 1px,var(--darkreader-text--color-canvas) 2px,transparent 2px) !important;
+    text-shadow: none !important;
+}
+
+================================
+
+getsol.us
+
+INVERT
+img[alt="Logo"]
+
+================================
+
+getsuperpowers.app
+
+CSS
+.bg-gradient-to-r {
+    background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
+}
+
+================================
+
+gg.pl
+
+INVERT
+.chat-btns
+.profile-close i
+.settings-close i
+
+CSS
+.sr-contact-name span {
+    background-image: none !important;
+}
+.search-input {
+    background-color: white !important;
+}
+
+================================
+
+ggmania.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+ghisler.com
+
+INVERT
+img[src$="bit.gif"]
+
+================================
+
+giesswein.com
+*.giesswein.com
+
+INVERT
+.stars__icon
+.R-PlatformLogo
+.accordion-usp img
+.accordion__trigger-icon
+#gie-category-buttons a img
+img.header__logo
+.R-ReviewsioLogo__image
+.newsletter-icon
+.mega-menu__block-image img[src*="alleicons"]
+img.collection-sticky-navigation-item-image
+div.drawer__top > label > svg > path
+.react-product-gallery__item--comparison svg
+.react-product-gallery__item--comparison svg image
+.buddy-modal__close
+img[src*="logo-black"]
+.header__navigation .menu__menu-toggle
+
+CSS
+.banner .image img,
+.plusContent .fullImage img,
+.plusContent .fullImage video {
+    z-index: 0 !important;
+}
+.plusContent .fullImageText,
+.plusContent .textWrapper,
+.GIE121 .collection-header * {
+    color: var(--darkreader-neutral-text) !important;
+    z-index: 1 !important;
+}
+html[data-darkreader-scheme="dark"] .banner .image img,
+html[data-darkreader-scheme="dark"] .plusContent .fullImage img,
+html[data-darkreader-scheme="dark"] .plusContent .fullImage video,
+.GIE121 .collection-header {
+    opacity: 0.5 !important;
+}
+html[data-darkreader-scheme="dark"] .plusContent .fullImageText,
+html[data-darkreader-scheme="dark"] .plusContent .textWrapper,
+html[data-darkreader-scheme="dark"] .GIE121 .collection-header * {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+html[data-darkreader-scheme="dark"] div[class^="sc-Rmtcm"]::before {
+    filter: brightness(0) saturate(100%) invert(1) !important;
+}
+
+IGNORE INLINE STYLE
+.react-product-gallery__item--comparison svg *
+.desktopSVG *
+
+IGNORE IMAGE ANALYSIS
+.GIE121 .collection-header
+
+================================
+
+gigabyte.com
+
+INVERT
+.kf-vision
+.kf-vision > *
+.creator-vision
+.creator-vision > *
+.InnerGIGABYTEContent .scroll_bg_01
+.InnerGIGABYTEContent .scroll_bg_01 > *
+.InnerGIGABYTEContent .eagle_build_strong
+.InnerGIGABYTEContent .eagle_build_strong > *
+
+================================
+
+git-scm.com
+
+INVERT
+img[alt="Git"]
+
+CSS
+body,
+#masthead {
+    background-image: none !important;
+}
+
+================================
+
+github.com
+github.*.*
+
+INVERT
+[src="https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg"]
+[src^="https://github.githubassets.com/images/modules/site/home/community-sponsor-"]
+[src^="https://github.githubassets.com/images/modules/site/home/community-readme-"]
+[src^="https://github.githubassets.com/images/modules/site/home/community-discussions-"]
+[src="https://github.githubassets.com/images/modules/site/home/dependabot-merge.png"]
+[src="https://github.githubassets.com/images/modules/site/home/dependabot-pr.png"]
+[src="https://github.githubassets.com/images/modules/site/home/gh-desktop.png"]
+[src="https://github.githubassets.com/images/modules/site/home/pr-merge.png"]
+[src="https://github.githubassets.com/images/modules/site/home/pr-comment.png"]
+[src="https://github.githubassets.com/images/modules/site/home/pr-description.png"]
+[src="https://github.githubassets.com/images/modules/site/home/pr-screen.png"]
+[src="https://github.githubassets.com/images/modules/site/home/enterprise-city-w-logos.jpg"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/codespaces-icon.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/dependency-rust.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/dependency-3.png"]
+[src^="https://github.githubassets.com/images/modules/site/codespaces/dependencies-"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/commit-3.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/extensions-1.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/extensions-2.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/commit-workflow.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/workflow-view.png"]
+[src="https://github.githubassets.com/images/modules/site/codespaces/code.png"]
+[src="https://github.githubassets.com/images/email/explore/explore-gradient-icon.png"]
+[src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/collections/learn-to-code/learn-to-code.png"]
+.js-viewport-aware-video.color-bg-primary.width-full.d-block.codespaces-hero-video
+.build-in-animate.position-relative.mb-6-fluid.box-shadow-active-mktg.mx-auto.home-mobile-iphone.build-in-slideY.js-build-in > .js-viewport-aware-video.width-full
+.overflow-hidden.position-relative.box-shadow-active-border-mktg.rounded-2-fluid.color-bg-primary.build-in-scale-fade.js-build-in-item
+.build-in-animate.overflow-hidden.box-shadow-active-border-mktg.rounded-2-fluid.position-relative.home-workflow-comp.js-build-in-item
+.mx-lg-auto.col-lg-7.col-12
+#hero-section-brand-heading
+
+CSS
+.blob-code-inner,
+.blob-num,
+.cm-s-github-light .CodeMirror-lines,
+.CodeMirror pre > span,
+.CodeMirror,
+.CodeMirror-dialog input,
+.CodeMirror-hints,
+.CodeMirror-linenumber,
+.CodeMirror-lines,
+.commit .sha,
+.commit .sha-block,
+.commit-desc pre,
+.commit-ref,
+.commit-tease-sha,
+.export-phrase pre,
+.file-info,
+.FormControl-input.FormControl-monospace,
+.FormControl-select.FormControl-monospace,
+.FormControl-textarea.FormControl-monospace,
+.input-monospace,
+.markdown-body .footnotes .data-footnote-backref g-emoji,
+.pr-1 > code > a,
+.react-blob-print-hide,
+.react-code-text,
+.react-code-view-edit .cm-s-github-light .CodeMirror-lines,
+.text-mono *,
+.text-mono,
+.two-factor-recovery-codes,
+[aria-labelledby*="codemirror"] *,
+[class*="blob-code"] *,
+code > a[class="Link--secondary"],
+section[aria-labelledby*="file-name-id"] > div > div *,
+span.commit-ref > a > *,
+span.commit-ref > a {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
+}
+.markdown-body code,
+.markdown-title code {
+    background-color: ${rgba(27, 31, 35, 0.1)} !important;
+}
+.markdown-body pre code {
+    background-color: transparent !important;
+}
+.refined-github .dashboard .js-all-activity-header + div {
+    background-color: ${#e4e5e9} !important;
+    border-color: ${#bbc1c9} !important;
+}
+.refined-github .dashboard-rollup-items .body {
+    border-top-color: ${#bbc1c9} !important;
+}
+.refined-github .reaction-summary-item a {
+    box-shadow: 0 0 0 2px ${white} !important;
+}
+.refined-github button.reaction-summary-item {
+    border-bottom: rgb(77, 172, 253) !important;
+    border-top-color: rgb(52, 59, 68) !important;
+}
+.js-site-search-form {
+    background-color: #ffffff1a !important;
+    border-radius: 2pt !important;
+}
+.blob-num:not(.cc-coverage-covered-border):not(.cc-coverage-missed-border) {
+    border-right: 0 !important;
+}
+.cc-issue-description {
+    color: #24292e !important;
+}
+.cc-readup-background {
+    background-color: rgb(28, 30, 31) !important;
+}
+.cc-readup-content {
+    border-left: 1px solid grey !important;
+    color: rgb(216, 214, 208) !important;
+}
+.cc-readup-content blockquote {
+    border-left: 3px solid dimgrey !important;
+}
+.cc-pr__link-text {
+    color: darkgrey !important;
+}
+.cc-pr__tooltip {
+    background-color: rgb(28, 30, 31) !important;
+    color: darkgrey !important;
+}
+.octotree-sidebar,
+.cc-pr__logo,
+.cc-octicon,
+#network canvas,
+img.network-tree {
+    filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
+}
+#commit-activity-detail > svg {
+    fill: ${black} !important;
+}
+.ContributionCalendar-day,
+.ContributionCalendar-day[data-level="0"] {
+    fill: var(--color-calendar-graph-day-bg) !important;
+}
+.ContributionCalendar-day[data-level="1"] {
+    fill: var(--color-calendar-graph-day-L1-bg) !important;
+}
+.ContributionCalendar-day[data-level="2"] {
+    fill: var(--color-calendar-graph-day-L2-bg) !important;
+}
+.ContributionCalendar-day[data-level="3"] {
+    fill: var(--color-calendar-graph-day-L3-bg) !important;
+}
+.ContributionCalendar-day[data-level="4"] {
+    fill: var(--color-calendar-graph-day-L4-bg) !important;
+}
+.day,
+.day[data-Count="0"] {
+    fill: var(--color-calendar-graph-day-bg) !important;
+}
+.day[data-Count="1"] {
+    fill: var(--color-calendar-graph-day-L1-bg) !important;
+}
+.day[data-Count="2"] {
+    fill: var(--color-calendar-graph-day-L2-bg) !important;
+}
+.day[data-Count="3"] {
+    fill: var(--color-calendar-graph-day-L3-bg) !important;
+}
+.day[data-Count="4"] {
+    fill: var(--color-calendar-graph-day-L4-bg) !important;
+}
+:root {
+    --color-calendar-graph-day-bg: ${#ebedf0} !important;
+    --color-calendar-graph-day-L1-bg: ${#9be9a8} !important;
+    --color-calendar-graph-day-L2-bg: ${#40c463} !important;
+    --color-calendar-graph-day-L3-bg: ${#30a14e} !important;
+    --color-calendar-graph-day-L4-bg: ${#216e39} !important;
+    --color-previewable-comment-form-bg: var(--darkreader-neutral-background) !important;
+}
+.Box-row--yellow {
+    background-color: ${#fffbdd} !important;
+}
+.merge-status-list {
+    border-color: ${#c0c5c7} !important;
+}
+.user-has-reacted {
+    background-color: rgba(17, 88, 199, 0.2) !important;
+}
+.hx_IssueLabel,
+span[class*="TokenBase"] {
+    background: rgba(var(--label-r),var(--label-g),var(--label-b),var(--background-alpha)) !important;
+    border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%),var(--border-alpha)) !important;
+    color: hsl(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%)) !important;
+}
+.header-search-input {
+    border: 0 !important;
+}
+.HeaderMenu-link--sign-in {
+    border: 0 !important;
+}
+.timeline-comment--caret.current-user::after {
+    --color-current-user-tip-bg: var(--darkreader-bg--color-box-bg-info) !important;
+}
+.timeline-comment--caret.current-user::before {
+    background-color: var(--darkreader-border--color-box-border-info) !important;
+}
+@media screen and (min-width: 1012px) {
+    markdown-toolbar.border-lg-top-0 {
+        border-top: 1px solid var(--darkreader-border--color-border-primary) !important;
+    }
+}
+@media screen and (max-width: 767px) {
+    div.tabnav--responsive button.tabnav-tab {
+        --color-border-primary: var(--darkreader-border--color-border-primary) !important;
+    }
+}
+.TimelineItem-badge[style^="background-color: var(--color-timeline-merged-bg)"] {
+    background-color: var(--color-timeline-merged-bg) !important;
+}
+.ContributionCalendar-label {
+    --color-text-primary: var(--darkreader-neutral-text) !important;
+}
+article div[style^="background: linear-gradient"] {
+    background: linear-gradient(to top, var(--darkreader-bg--color-bg-primary), transparent) !important;
+}
+.ͼ5 .cm-content,
+.ͼ5 .cm-panel.cm-search > button {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+a[href^="https://apps.apple.com/app/"] g
+a[href^="https://apps.apple.com/app/"] path
+tracked-issues-progress svg *
+div#user-repositories-list .tooltipped svg *
+div#org-repositories .tooltipped svg *
+
+IGNORE IMAGE ANALYSIS
+[data-color-mode="auto"][data-dark-theme*="dark"] .pagination-loader-container
+
+================================
+
+githubstatus.com
+*.githubstatus.com
+
+CSS
+.illo-desktop-header {
+    z-index: 0 !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.status-red .icon-indicator::before
+
+================================
+
+gitlab.com
+gitlab.host
+gitlab.*.*
+gitlab.*.*.*
+code.videolan.org
+framagit.org
+git.fairkom.net
+repo1.dso.mil
+
+INVERT
+.js-contrib-calendar
+
+CSS
+:root {
+    --svg-status-bg: #181a1b;
+}
+.avatar,
+.avatar-container {
+    border: none !important;
+}
+table.code .line_content *:not(pre),
+.job-log *:not(pre) {
+    font-family: "Menlo", "DejaVu Sans Mono", "Liberation Mono", "Consolas", "Ubuntu Mono", "Courier New", "andale mono", "lucida console", monospace !important;
+}
+.gl-drawer-close-button,
+.js-reply-button,
+.dropdown.more-actions > button,
+.js-note-edit,
+.btn-default-tertiary,
+.btn-confirm-tertiary {
+    mix-blend-mode: unset !important;
+}
+.board-inner {
+    --darkreader-border--gray-100: ${#d1cdc7} !important;
+    --gray-10: ${#e1e3e4} !important;
+}
+.mr-tree-list:not(.tree-list-blobs) .tree-list-parent::before {
+    background-color: transparent !important;
+}
+#one-time-password-authenticator-otp > div > div {
+    background-color: white !important;
+}
+#one-time-password-authenticator-otp svg rect {
+    fill: black !important;
+}
+
+================================
+
+giveawayoftheday.com
+
+INVERT
+.header_lang .curr_lang::before
+.header_logo
+.header_nav_trig
+.header_search
+.header_search .button
+
+IGNORE IMAGE ANALYSIS
+.countdown-amount .diggit
+
+================================
+
+giveaways.cavebot.xyz
+
+CSS
+.respon1.p-r-50.p-l-50.p-b-22.p-t-42.bor1.cd100.flex-sa-m.flex-w {
+    border: none !important;
+}
+.overlay1::after {
+    background: unset !important;
+}
+.overlay1::before {
+    background-color: unset !impotant;
+    background-image: unset !impotant;
+    opacity: 0.8 !important;
+}
+.overlay1::before {
+    background-color: unset !important;
+    background-image: unset !important;
+}
+
+================================
+
+gizmodo.com
+
+INVERT
+[aria-label="Gizmodo logo"]
+
+================================
+
+giznewsdaily.com
+
+INVERT
+.wp-block-site-logo
+
+================================
+
+gladgame.ru
+
+INVERT
+tr:not(:hover) img
+
+CSS
+tr:hover td {
+    color: var(--darkreader-text-0040ff) !important;
+}
+
+================================
+
+glassdoor.*
+glassdoor.*.*
+
+CSS
+div[class^=rating-star_RatingStarContainer]:has(svg[class^=rating-star_RatingStarOutline]) path {
+    fill: none !important;
+}
+
+================================
+
+glasswire.com
+
+INVERT
+.download-n-marks div img
+.menu
+
+CSS
+.head-menu .menu a {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+glitchprod.com
+
+INVERT
+ul[aria-label="Social Bar"]
+
+CSS
+div[data-testid="container-bg"] {
+    background-color: var(--container-corvid-background-color,rgba(var(--bg,var(--color_11,color_11)),var(--alpha-bg,1))) !important;
+}
+
+================================
+
+global.gotomeeting.com/join/*
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+globalping.io
+
+INVERT
+.gm-style img[role="presentation"]:not([src*="v="])
+.gp-about_in-numbers_list_block_item_value
+img[src*="radio.svg"]
+img[src*="help-icon.svg"]
+img[src*="file-text.svg"]
+img[src*="settings-icon.svg"]
+
+CSS
+.gp-probe-filters_field select {
+    border-color: ${#333739} !important;
+}
+.gp-probe-filters_field button {
+    background-color: ${#fff} !important;
+}
+
+================================
+
+gloswielkopolski.pl
+
+INVERT
+.componentsNavigationNavbar__brand
+
+================================
+
+gls-pakete.de
+
+CSS
+.tracking--status .status-box::before,
+.tracking--status .status-box::after {
+    z-index: 0 !important;
+}
+.tracking--status .status-box.status--complete.status--lastcomplete .status-box--tooltip,
+.tracking--status .status-box.status--current .status-box--tooltip {
+    bottom: 0 !important;
+    margin-bottom: 0px !important;
+    margin-top: -10px !important;
+    position: absolute !important;
+    transform: none !important;
+}
+
+================================
+
+gnc.com
+
+IGNORE INLINE STYLE
+a[id^="powered_by_pixlee"]
+
+================================
+
+gnu.org
+
+INVERT
+#gnu-banner img
+#search-icon
+
+================================
+
+godaddy.com
+
+INVERT
+.logo-mark
+
+================================
+
+godbolt.org
+
+CSS
+div.view-lines * {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
+}
+
+================================
+
+godfathers.com
+
+INVERT
+.header .top-bar .top-bar-wrapper .page-header-branding img
+
+================================
+
+godoc.org
+
+CSS
+.banner {
+    background-color: ${rgb(225, 190, 130)} !important;
+}
+
+================================
+
+godzinyotwarcia24.pl
+
+INVERT
+.mbdtr
+.mpktr
+form[action="/szukaj"]
+div[id="suchfeldlabels"]
+
+================================
+
+gog-games.com/game
+
+INVERT
+img[src*="hoster_logos"]
+div.close
+
+CSS
+#game-details > .container::before {
+    background-image: none !important;
+}
+
+================================
+
+gog.com
+
+INVERT
+i.icn.icn--close
+svg.icon-wrapper-icon
+svg.big-spot__add-to-cart-icon
+svg.ic-svg:not(.button__icon):not(.productcard-slider__nav-icon)
+.productcard-thumbnails-slider-pagination
+.carousel-pagination__page
+.big-spot__carousel-pages-container
+.big-spots__arrow-icon
+.discover-games-more__icon
+
+CSS
+.product-tile__info:hover {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+a.product-tile__content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.galaxy-tooltip__layer {
+    background: ${#d9d9d9} !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.big-spot__content,
+.big-spot__text,
+.big-spot__action {
+    backdrop-filter: brightness(50%) !important;
+}
+.big-spot__title,
+.big-spot__super-title,
+.big-spot__action {
+    filter: brightness(130%) !important;
+}
+.wishlist-button,
+.review__read-more,
+.review-new__add-button,
+.review-new__guideline-button {
+    background-image: none !important;
+}
+.productcard-thumbnails-slider__play-btn {
+    border-color: rgb(220, 218, 215) !important;
+}
+.productcard-thumbnails-slider__play-btn::before {
+    border-left-color: rgb(220, 218, 215) !important;
+}
+.list--summary.shelf-skin--wood .product-row-wrapper::after {
+    background-image: url(/bundles/gogwebsiteaccount/img/shelf/wood.png);
+}
+
+IGNORE IMAGE ANALYSIS
+.menu-anonymous__shelf
+
+================================
+
+gokulv.netlify.app
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+golang.org
+
+INVERT
+.Footer-gopher
+.gopher
+
+CSS
+#file-editor .CodeMirror,
+#file-editor .CodeMirror-lines,
+#file-editor .CodeMirror-gutters,
+#wrap {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+goodreads.com
+
+INVERT
+.responsiveSiteFooter__socialLinkWrapper
+
+================================
+
+google.*
+google.*.*
+
+INVERT
+.gb_hc
+.gb_ec
+.gb_x.gb_Vb
+.gb_x.gb_Ub
+.gb_0b
+#dictionary-modules img[src*="png"]
+a.gb_b > div
+a[href*="about/products"][title]
+.JOmIqc
+.hLcKi
+#EcMbV
+#wrap a[href="/mobile/"]
+.vk-sf-b
+.vk-t-btn
+.ChZgtd div::before
+.ChZgtd div::after
+.yPHXsc div
+.mn-dwn-arw
+img.act-icon-dark-gray
+.YsGUOb
+.tays_show_more_answer_button_hide
+.tays_show_more_answer_button_show
+#tays_add_more_answers_button_hide
+#tays_add_more_answers_button
+img[src^="https://www.google.com/maps"]
+[data-attrid="formula-image"]
+[data-attrid^="variable"] img
+[src^="/chrome/static/images/thank-you/"]
+[src^="/chrome/static/images/reversible/"]
+[src="/chrome/static/images/gpay/slate.png"]
+[src^="/chrome/static/images/productivity/"]
+[src^="/chrome/static/images/features/phone"]
+[src^="/chrome/static/images/features/big_phone"]
+[src^="/chrome/static/images/be-more-productive/"]
+[src^="/chrome/static/images/search-bar/chrome-ui"]
+[src="/chrome/static/images/go-mobile/qr-code.png"]
+[src^="/chrome/static/images/download-browser/pixel"]
+[src^="/chrome/static/images/browser-by-google/pixel"]
+[src^="/chrome/static/images/sync-incognito/chrome-ui"]
+[src^="/chrome/static/images/download-browser/big_pixel"]
+[src="/chrome/static/images/homepage/homepage_tools.png"]
+[src="/chrome/static/images/homepage/homepage_privacy.png"]
+[src="/chrome/static/images/google-translate/screen-english.png"]
+#shield-ok-fill-shield
+
+CSS
+.X6JNf,
+.appbar,
+.sfbg {
+    background: var(--darkreader-neutral-background) !important;
+}
+.RNNXgb,
+.aajZCb {
+    box-shadow: 0 0 2px 0 ${rgba(0,0,0,0.16)}, 0 0 0 1px ${rgba(0,0,0,0.08)} !important;
+}
+.Gor6zc {
+    background-color: white !important;
+}
+img[id^="platop"] {
+    background-color: white !important;
+}
+.chr-full-bleed-hero {
+    background-image: none !important;
+}
+html,
+body,
+img,
+[role="img"],
+video,
+iframe,
+#gb,
+a[href^="https://shopping.google.com"][href*="/lists"] > span {
+    filter: none !important;
+}
+.REySof {
+    color: rgba(255,255,255,0.1) !important;
+}
+.Xkjimd {
+    background-color: ${rgb(229, 237, 255)} !important;
+}
+:root,
+.YzCcne,
+.YzCcne *,
+[data-mcp="18"],
+[data-mcp="18"] * {
+    --m3c10: ${#545d7e} !important;
+    --m3c11: ${#0a0a0a} !important;
+    --m3c9: ${#0a0a0a} !important;
+    --xhUGwc: var(--darkreader-neutral-background) !important;
+}
+:root,
+.YzCcne *,
+.rG9tvd {
+    --m3c6: ${#e5edff} !important;
+}
+
+IGNORE INLINE STYLE
+.kdPwrb
+.rnt3Ze
+.NYcQFd
+.lnXdpd path
+#logo path
+#shield-ok-fill-shield
+
+================================
+
+google.*/chrome
+
+INVERT
+[src$="slate.png"]
+[src$="articles.png"]
+[src$="phone_desktop.png"]
+[src$="homepage_tools.png"]
+[src$="chrome-ui-sync.png"]
+[src$="password-check.png"]
+[src$="big_pixel_phone.png"]
+[src=$"homepage_privacy.png"]
+[src$="big_phone_desktop.png"]
+[src$="chrome-ui_desktop.png"]
+[src$="pixel_slate_port_desktop.png"]
+[src^="/chrome/static/images/productivity/"]
+[src^="/chrome/static/images/be-more-productive/"]
+[src^="/chrome/static/images/download-browser/pixel"]
+[src^="/chrome/static/images/google-translate/screen-"]
+
+================================
+
+google.*/maps
+google.*.*/maps
+
+INVERT
+#app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .widget-scene-canvas
+#app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .canvas-container > canvas
+#app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .full-screen > img
+#app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) [role="application"] > canvas
+div[jstrack="1"]:not(.app-imagery-mode):not(.app-globe-mode):not(.Nkjr6c):not(.K1N2o) [role="application"] > canvas
+div[jstrack="1"]:not(.app-imagery-mode):not(.app-globe-mode):not(.Nkjr6c):not(.K1N2o) [role="application"] .mAWRAc
+.widget-settings-button-icon
+.searchbox-button
+.searchbox-searchbutton
+.searchbox-hamburger::before
+.maps-sprite-settings-chevron-left
+a.ita-kd-icon-button > span
+li.ita-kd-menuitem > span.ita-kd-menuitem-inputtool-icon
+li.ita-kd-menuitem > span.ita-kd-checkbox
+div.maps-sprite-common-chevron-left
+span.maps-sprite-common-chevron-right
+span.section-destination-via-line-icon
+div.section-directions-trip-travel-mode-icon
+button.searchbox-hamburger.white-foreground
+label.kd-radio-label::before
+label.kd-checkbox-label::before
+label.kd-checkbox-label::after
+button.section-directions-details-action-button
+div.section-loading-spinner
+a.gb_b > div
+a.gb_xc
+.gm-style img[role="presentation"]:not([src*="v="])
+.i4ewOd-xl07Ob
+.i4ewOd-LQLjdd li::before
+.un1lmc-j4gsHd
+.maps-sprite-settings-languages
+a[href*="about/products"]
+.google-logo
+.watermark
+.section-review-action-menu
+.section-review-interaction-button
+.section-directions-trip-travel-mode-icon
+.renderable-component-icon
+.cards-rating-star
+.maps-sprite-common-chevron-right
+[role="region"] button[jsaction^="pane.list-item.add"] [class*="icon-background"] [class*="icon"][src*="black"]
+.top-activity-icon
+.activity-icon
+img[src$="menu_black_24dp.png"]
+#assistive-chips .e2moi img
+button[guidedhelpid="searchbutton"]
+a[href^="//myaccount.google.com/yourdata/maps"] > div
+img[src^="//www.google.com/images/branding/lockups/"][alt="Google Maps"]
+div[role="checkbox"] > div
+div[aria-label="Toggle star"][role="checkbox"]
+#legendPanel > div > div > div > div > div > div > div > div > div[jsaction^="keydown"][jsshadow=""][role="checkbox"][style=""]
+#legendPanel > div > div > div > div > div > div > div > div > div > div > div > div[jsaction^="keydown"][jsshadow=""][role="checkbox"]
+#map-canvas > div > #watermark
+body.vsc-initialized > #app > #map-container > #map > .map-outer.map-extent
+body.vsc-initialized > #app > #map-container > #map > div > div > div > button[jsaction="map.toggle-map-control"] > img
+body.vsc-initialized > #app > #map-container > #map > div > div > div > div > div > button[jsaction="map.zoom-out"] > img
+body.vsc-initialized > #app > #map-container > #map > div > div > div > div > div > button[jsaction="map.zoom-in"] > img
+#app-container > #modal-dialog > div > div > div > div > button[jsaction="modal.close"]
+#map-canvas div[data-tooltip]
+div[style="top: 0px;"] > div > div > div > :first-child
+div[style="top: 0px;"] > div > :last-child > div > :nth-child(2)
+div[style="top: 0px;"] > div:first-child:not([style^="background"]) > :last-child
+
+CSS
+#app-container > #modal-dialog > div > div > div > div > button[jsaction="modal.close"] {
+    background-color: $var(--darkreader-neutral-background) !important;
+}
+span.google-symbols > * {
+    font-family: "Google Symbols" !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.widget-settings-map
+.widget-settings-satellite
+.widget-settings-terrain
+.widget-settings-globe
+.widget-settings-traffic
+.widget-settings-transit
+.widget-settings-bike
+.widget-settings-street-view
+.widget-settings-covid-info-icon
+.widget-settings-location-sharing
+.widget-settings-your-places
+.widget-settings-rate-review
+.widget-settings-timeline
+.widget-settings-link
+.widget-settings-print
+
+================================
+
+googleprojectzero.blogspot.com
+
+CSS
+.c5 a img {
+    background-color: white !important;
+}
+
+================================
+
+goplay.anontpp.com
+
+INVERT
+img[src*="download.svg"]
+img[src*="cast.png"]
+img[src*="bookmark.png"]
+.jw-slider-container
+.jw-time-tip::after
+
+================================
+
+goproblems.com
+
+INVERT
+.navbar-brand
+
+IGNORE INLINE STYLE
+<div class="player-container">
+
+================================
+
+gorod.gov.spb.ru
+
+INVERT
+.header__logo
+.reason__icon
+.map-with-address
+.problem-details__map
+.problem-map-page__map
+.evtmap canvas
+
+================================
+
+gorod.mos.ru
+
+INVERT
+.scene__logo
+div[id^="map"] > div > div > div
+div[style^="text-align: center; margin"] > div > div:first-of-type
+
+CSS
+#footer {
+    background: ${#CCECE8} !important;
+}
+
+================================
+
+gosuslugi.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="places-pane"] span
+
+================================
+
+gotquestions.org
+
+CSS
+.gradient-to-b {
+    --color-end: var(--darkreader-neutral-background) !important;
+    --color-start: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+gov.pl/web/bip
+
+INVERT
+.banner-promo
+.banner-promo__text
+
+================================
+
+gowork.pl
+
+INVERT
+.city__img .city__text
+
+================================
+
+gp.se
+
+CSS
+header nav {
+    border-top: unset !important;
+}
+header nav::after {
+    background: linear-gradient( 90deg, hsl(0deg 0% 100% / 4%) 0, hsl(0deg 0% 30.39% / 40%) 25%, var(--darkreader-bg--white) ) !important;
+}
+article.teaser-article {
+    --teaser-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+gpnbonus.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+gprivate.com
+gogoprivate.com
+
+INVERT
+[style*="color: rgb(0, 39, 142) !important;"]
+
+CSS
+[style*="color: rgb(0, 39, 142) !important;"] {
+    background-color: white !important;
+}
+
+================================
+
+gptzero.me
+
+CSS
+.bg-home-mobile-background {
+    background-image: none !important;
+}
+img[alt="background image"] {
+    display: none !important;
+}
+
+================================
+
+grammarly.com
+
+INVERT
+img[alt="Grammarly logo"]
+
+IGNORE INLINE STYLE
+div[data-qa="heroSectionAnimationContainer"] path
+
+================================
+
+gramota.ru
+
+INVERT
+img[src*="logo-gramota"]
+.caret
+td > strong
+
+================================
+
+gravatar.com
+
+INVERT
+a.g-home
+.g-user-menu > svg
+body#page > div > div > nav > ul > li > a > svg.g-logo.g-logo--name-gravatar
+
+CSS
+a[class="g-sign-in"] > svg > path {
+    fill: white !important;
+}
+body {
+    background-image: none !important;
+}
+
+================================
+
+grc.com
+
+INVERT
+img[src*="gif"]
+
+================================
+
+greatergood.com
+
+INVERT
+.ctg-logo
+.logo-ggc-color
+#site-logo
+
+================================
+
+grocy.info
+
+INVERT
+.navbar-brand
+.carousel-control-prev-icon
+.carousel-control-next-icon
+
+================================
+
+grovedb.org
+
+INVERT
+.title-background *
+
+CSS
+.main-banner {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.banner-background
+
+================================
+
+grubhub.com
+
+CSS
+.s-checkbox-filler {
+    color: rgb(24, 26, 27) !important;
+}
+label,
+h5,
+h6,
+header,
+.h5 {
+    color: ${black};
+}
+
+================================
+
+gsmchoice.com
+mgsm.pl
+
+INVERT
+.promo-sticky__item--large
+.promo-sticky__item--small
+.social-fixed--infoline
+img[alt="GSMchoice.com"]
+img[alt="mGSM.pl"]
+img[src*="card_ico"]
+img[src*="short"]
+
+================================
+
+gu.spb.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+CSS
+.bg {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+guancha.cn
+
+CSS
+.dahui {
+    background-image: none !important;
+}
+
+================================
+
+gucci.com
+
+INVERT
+#inner-header-wrapper #logo
+
+CSS
+:root {
+    --_g-logo-fill-color: white !important;
+}
+
+IGNORE INLINE STYLE
+#inner-header-wrapper #logo svg path
+
+================================
+
+guideautoweb.com
+
+CSS
+body {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+guiott.com
+
+CSS
+.Section1 > div {
+    background-image: none !important;
+}
+
+================================
+
+guitarcenter.pl
+
+INVERT
+tr > td > img
+p.standard_price
+p.promo_price
+
+================================
+
+guitarworld.com
+
+INVERT
+.site-logo
+
+================================
+
+gumroad.com
+
+INVERT
+.mega-gum-logo
+
+================================
+
+gurushots.com
+
+CSS
+.c-challenges-speed-item__countdown > .round-progress-wrapper,
+.challengesItemSuggested__timer .round-progress-wrapper {
+    background-color: transparent !important;
+}
+.modal-vote__exposure-meter__arrow,
+.modal-vote__exposure-meter__arrow::after {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+gutrad.com
+
+CSS
+.g_parallex_bnr li .g_no_slider {
+    color: black !important;
+}
+
+================================
+
+habitica.com
+
+INVERT
+.logo path:nth-child(2)
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+habr.com
+
+INVERT
+img[src*="//tex.s2cms.ru/"]
+img[data-tex]
+img.formula
+
+CSS
+html {
+    text-shadow: none !important;
+}
+.main-navbar .icon-svg {
+    fill: ${#929ca5} !important;
+}
+
+================================
+
+hacdias.com
+
+CSS
+:root {
+    --background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+hackerone.com
+
+INVERT
+.app__logo
+
+================================
+
+hackerrank.com
+
+INVERT
+.badge-icon
+.CodeMirror-cursors
+.CodeMirror-selected
+
+CSS
+.monaco-editor .cursor {
+    background-color: ${black} !important;
+}
+
+================================
+
+half-life-calculator.com
+
+INVERT
+canvas#chart
+
+================================
+
+hampage.hu
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+handshake.org
+
+INVERT
+[src*="logo-dark.svg"]
+[src*="blocks.svg"]
+
+CSS
+ul.notes li::before {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+handwiki.org
+
+CSS
+#mw-content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+haokan.baidu.com
+
+INVERT
+.header-logo-icon
+
+================================
+
+hapo.org
+
+INVERT
+.section__overlap[style*="/new-site/background-swoosh.png"]
+
+================================
+
+hazi.ro
+
+CSS
+:root {
+    --app-nav-top-bg: var(--darkreader-neutral-background);
+    --dropdown-bg: var(--darkreader-neutral-background);
+    --input-bg: var(--darkreader-neutral-background);
+    --input-disabled-bg: var(--darkreader-neutral-background);
+    --site-section-bg: ${#ddd};
+    --ui-block-bg: var(--darkreader-neutral-background);
+}
+.main-footer-extended.main-footer-extended-gray {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+hbo.com
+
+INVERT
+img[alt="HBO Logo"]
+
+================================
+
+hbr.org
+
+INVERT
+.hamburger-icon
+.top-header--logo
+.search-icon
+.footer-logo
+
+================================
+
+hbweb.hu
+
+CSS
+[background] {
+    background-image: unset;
+}
+
+================================
+
+hdgo.cc
+vio.to
+
+INVERT
+.hdplayer .big_play_button div
+.hdplayer .hdgo_controls div.hdgo_pause_control div
+.hdplayer .hdgo_controls div.hdgo_play_control div
+
+================================
+
+hdlbits.01xz.net
+
+CSS
+img.image,
+.image > img {
+    background-color: white !important;
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+headphones.com
+
+INVERT
+.header__heading-logo
+
+CSS
+#MainContent,
+.header__menu-container,
+details > ul,
+.search__input {
+    background-color: rgb(30, 33, 34) !important;
+}
+.search__input::placeholder {
+    color: rgb(30, 33, 34) !important;
+}
+
+================================
+
+heise.de
+
+INVERT
+.heise-online-logo
+
+================================
+
+helix.ru
+
+INVERT
+.Site-Header-Logo
+
+================================
+
+help.ea.com
+
+CSS
+.app,
+.app > div {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+help.nextdns.io
+
+INVERT
+.logo-desktop
+.logo-mobile
+
+================================
+
+help.ubuntu.com
+
+CSS
+body,
+#second-nav li:first-child {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.65)} !important;
+}
+
+================================
+
+helzberg.com
+
+INVERT
+.logo
+.footer.content
+.footer.content > div
+.footer__column--logo
+
+IGNORE INLINE STYLE
+a[id^="powered_by_pixleee"]
+
+================================
+
+heraldscotland.com
+
+INVERT
+.brand
+
+================================
+
+heritage.org/index
+
+INVERT
+.bar
+
+CSS
+.content-container {
+    background-image: none !important;
+}
+
+================================
+
+hex-rays.com
+
+INVERT
+#logo
+.footer-logo
+
+================================
+
+hexos.com
+
+CSS
+.fe-block {
+    text-shadow: ${white} 1px 1px 0px !important;
+}
+
+================================
+
+hh.ru
+
+CSS
+html {
+    text-shadow: none !important;
+}
+
+================================
+
+hificompass.com
+
+CSS
+.field-slideshow-slide img {
+    background-color: cornsilk !important;
+}
+
+================================
+
+high-minded.cx
+
+CSS
+i[aria-hidden="true"] {
+    font: normal normal normal 18px/1 "Material Design Icons" !important;
+}
+
+================================
+
+hindustantimes.com
+
+INVERT
+.menu.noti-dot
+.searchHolder .search
+img[src$="logo-big-cm.png"]
+img[src$="logo-ht.png"]
+img[src$="htlogo.png"]
+
+================================
+
+hionnature.com
+
+INVERT
+img.header__heading-logo
+div.footer-block-image > img
+
+CSS
+.gradient {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+history.state.gov
+
+CSS
+body {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+hktdc.com
+
+INVERT
+.header-logo
+
+================================
+
+hm.com
+
+INVERT
+[class^="TurnToReviewsButton-module--ratingStars"]
+
+CSS
+.review-answers .review-answer .average-score {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+.swatch
+
+================================
+
+hmong.*
+wikihmong.com
+
+INVERT
+span.mwe-math-element
+
+================================
+
+homebrewery.naturalcrit.com
+
+CSS
+.CodeMirror-scroll {
+    background-color: #444;
+}
+span[role="presentation"] {
+    color: white;
+}
+span[role="presentation"] > .cm-header {
+    color: rgb(50, 150, 250);
+}
+span[role="presentation"] > .cm-variable-2 {
+    color: rgb(50, 150, 250);
+}
+.phb blockquote {
+    background-color: #e0e5c1 !important;
+}
+.phb h3,
+.phb h2,
+.phb h1 {
+    color: #58180D;
+}
+.phb p {
+    color: black;
+}
+.cm-link,
+.cm-attribute {
+    color: rgb(90, 140, 255) !important;
+}
+.cm-url,
+.cm-string {
+    color: rgb(200, 50, 50) !important;
+}
+.cm-quote,
+.cm-tag {
+    color: rgb(50, 200, 50) !important;
+}
+
+================================
+
+homecrux.com
+
+INVERT
+span.hamburger-icon
+a.logo-link
+
+================================
+
+homedepot.com
+
+CSS
+span[role="progressbar"] > .sui-bg-inverse {
+    background-color: ${#f70} !important;
+}
+
+================================
+
+hoogle.haskell.org
+
+INVERT
+#logo img
+
+================================
+
+hooktail.sub.jp
+hooktail.org
+
+INVERT
+#box img
+.box img
+
+CSS
+#box,
+.box {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+h2 {
+    background-image: none;
+}
+a {
+    color: rgb(157, 149, 237);
+}
+
+================================
+
+hootsuite.com
+
+INVERT
+img[src$="hootsuite_white_form3.png"]
+
+================================
+
+host-c.com
+
+INVERT
+.logo
+
+================================
+
+hotcrp.com
+
+CSS
+select,
+button,
+.btn,
+button.btn-t:hover {
+    color: silver;
+}
+
+================================
+
+howbuy.com
+
+INVERT
+.bottomStar
+.cpBottomWord
+.logo
+.navList dt
+.phCon
+.title
+#valuationChar
+
+================================
+
+howstuffworks.com
+
+INVERT
+a[data-track-gtm="Logo"]
+
+================================
+
+hp.com
+*.hp.com
+
+INVERT
+#g-nav .c-logo
+.w-100
+img[src*="CCLS_SSL_Icon.svg"]
+.lia-img-powered-by-khoros
+a[aria-label="Options"]
+.myprofile-img
+.solutions-img
+.mykudo-img
+.ikudo-img
+.osDetectionWindows img
+.hpsaImg
+
+CSS
+.pdp-bg {
+    background-image: none !important;
+}
+
+================================
+
+hpanel.hostinger.com
+
+CSS
+.hp-table {
+    background-color: var(--darkreader-bg--neutral--0, var(--darkreader-background-ffffff, #1f2122)) !important;
+}
+.hp-table-header[data-v-92941e81] {
+    border-bottom: 1px solid var(--darkreader-border--neutral--200) !important;
+}
+.header__logo img {
+    filter: brightness(5);
+}
+input {
+    background: none;
+}
+
+================================
+
+hs.fi
+
+CSS
+article,
+article > article {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+hstechdocs.helpsystems.com
+
+CSS
+.body-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+ul.sidenav li a,
+ul.sidenav ul > li > a {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+htmlcolorcodes.com
+
+IGNORE INLINE STYLE
+.js-palette-color
+.js-swatch
+.js-color
+
+================================
+
+httpwg.org
+
+CSS
+svg.diagram text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+huawei.com
+
+INVERT
+.logo
+
+================================
+
+huba.news
+
+INVERT
+img[alt="Huba"]
+img[alt="INTERIA.PL"]
+.most-interesting-topics-header::before
+
+================================
+
+hubs.mozilla.com
+
+INVERT
+svg.hmc-logo
+
+================================
+
+hugoboss.com
+
+INVERT
+.dy_reco-product__image svg.dy_reco-product__logo
+.dch-footer
+.dch-footer img
+
+CSS
+.dch-head-teaser__text-container h1,
+.dch-textbox-item,
+.dch-footer {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+================================
+
+huji.ac.il/dataj/controller/
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+hvdic.thivien.net
+
+INVERT
+img.hvres-variant-img.lazy
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+hyperphysics.phy-astr.gsu.edu
+
+INVERT
+tbody td > img
+tbody center > img
+tbody center > a > img
+
+================================
+
+hyperskill.org
+
+INVERT
+.html-preview
+
+CSS
+.monaco-editor .margin,
+.monaco-editor-background {
+    background-color: #181A1B !important;
+}
+.monaco-editor .cursor {
+    background-color: ${#000000} !important;
+}
+.step-text[data-v-341d1caa] pre {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+hyperx.com
+
+CSS
+.product-card__thumbnail-container,
+.knockout-image {
+    mix-blend-mode: unset !important;
+}
+
+================================
+
+hypixel.net
+
+INVERT
+.p-nav-inner
+.message-avatar::after
+
+CSS
+.p-navEl-link,
+.p-header-playNow .p-header-playNow-button,
+.p-navgroup-link--search {
+    color: ${rgb(214, 210, 205)} !important;
+}
+
+================================
+
+i-item.jd.com
+
+CSS
+.itemInfo-wrap .summary-price-wrap .summary-top .summary-promotion {
+    background-image: none !important;
+}
+
+================================
+
+iadisportal.org
+
+CSS
+#iadis-container #iadis-container2,
+#iadis-containerwrap2 {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+ic.unicamp.br
+
+INVERT
+.logo-unicamp
+.logo-top
+
+================================
+
+ica.coop
+
+INVERT
+.main-header__logo
+
+================================
+
+icloud.com
+
+INVERT
+.rm-list-body
+.note-list-item-attachment
+.sc-iujRgT.jxLrRl
+.icloud-text.image
+.img.app-icon-icloud
+#cloudos-loading-spinner
+.editor-container
+.light > svg
+
+CSS
+.cw-pane-container,
+.reminders {
+    background-image: none !important;
+}
+.homepage-viewport .homepage-gradient-background {
+    filter: grayscale(0.8) !important;
+}
+.content > .title {
+    color: var(--darkreader-neutral-background) !important;
+}
+.content > .description {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+icofont.com
+
+INVERT
+.logo
+
+================================
+
+iconfinder.com
+
+INVERT
+.logo
+
+================================
+
+iconify.design
+
+IGNORE INLINE STYLE
+svg.iconify *
+svg#footer-icon-name *
+svg#icon-nav-prev *
+svg#icon-nav-next *
+.si-svg-wrapper svg *
+.block-container .icons svg *
+
+================================
+
+icons8.com
+
+CSS
+.main-page .gradient {
+    background-image: none !important;
+}
+
+================================
+
+icrc.org
+
+CSS
+.logo,
+.logo img {
+    background-color: #fff !important;
+}
+
+================================
+
+id.fedoraproject.org
+
+INVERT
+img[alt="logo"]
+
+================================
+
+id.unity.com
+
+CSS
+.qr-code {
+    border: calc(150px * 1/45) solid #f5f8f9;
+}
+
+================================
+
+idealo.*
+idealo.*.*
+
+CSS
+.mix-blend-multiply:not(#\#):not(#\#):not(#\#):not(#\#),
+img[class*="productImage"] {
+    mix-blend-mode: unset !important;
+}
+div[class*="trending-categories_trendingCategoryFrame"] {
+    background-color: white !important;
+}
+
+================================
+
+identity.kde.org
+
+CSS
+body,
+.navbar-inner,
+.navbar {
+    background-image: none !important;
+}
+
+================================
+
+ieee.org
+
+INVERT
+.logo-left
+
+================================
+
+iett.istanbul
+
+CSS
+#routedesc p:nth-child(2) {
+    font-size: 0;
+}
+#routedesc p:nth-child(2)::after {
+    content: "Kırmızı renkli seferler ÖHO ve OAŞ; beyaz renkli seferler İETT’ye aittir.";
+    font-size: 20px;
+}
+
+================================
+
+ifixit.com
+
+INVERT
+a[aria-label="home page"] > svg > path:first-child
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+iflscience.com
+
+INVERT
+.header-primary div a svg
+.footer-branding a svg
+.footer-subscribeBox div span a svg
+
+================================
+
+ifood.com.br
+
+CSS
+.responsive-header__logo svg {
+    --darkreader-inline-fill: rgb(212, 45, 58) !important;
+}
+
+================================
+
+igraal.com
+*.igraal.com
+
+INVERT
+.vouchers-main__top
+.vouchers-main__top .title
+.vouchers-main__top .subtitle
+
+CSS
+body,
+body .main-content {
+    background: var(--darkreader-bg--grey-100) !important;
+}
+
+================================
+
+igurublog.wordpress.com
+
+CSS
+body,
+.entry,
+#content,
+#container {
+    background-image: none !important;
+}
+
+================================
+
+ikea.*
+
+INVERT
+.menu-btn
+
+CSS
+.range-revamp-ratings-bar__star--empty path,
+.range-revamp-ratings-bar__star--half path:first-child {
+    fill: ${rgb(246, 245, 244)} !important;
+}
+.hnf-svg-icon {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.card,
+.card-header,
+.card-footer {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.gpr__color-dot
+
+================================
+
+iliad.it
+
+IGNORE IMAGE ANALYSIS
+.background
+
+================================
+
+illinois.edu
+*.illinois.edu
+
+CSS
+ilw-header,
+input[type="search"][aria-labelledby],
+ilw-header [slot="search"][role="search"] > button[id],
+ilw-header-menu-section ul {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ilovepdf.com
+
+INVERT
+.brand__logo
+.ico--down
+.ico--desk
+.ico--hamburger
+
+================================
+
+imadr.me
+
+CSS
+body {
+    background: transparent !important;
+}
+.canvas {
+    background: rgba(128, 128, 128, 0.25) !important;
+}
+
+================================
+
+image-net.org
+
+INVERT
+img[src="/static_files/index_files/logo.jpg"]
+
+================================
+
+imdb.com
+
+INVERT
+.a-icon
+.jw-slider-volume
+
+CSS
+#wrapper {
+    background: ${#e3e2dd} !important;
+}
+.ipc-page-section--base {
+    --ipc-pageSection-base-bg: var(--darkreader-neutral-background) !important;
+}
+:root: {
+    --darkreader-bg--ipt-baseAlt-shade1-bg: var(--darkreader-neutral-background) !important;
+}
+.imdb-header__nav-drawer div,
+.ipc-menu--on-baseAlt,
+.imdb-header__search-menu,
+.ipc-promptable-base__panel {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ipc-promptable-base__content {
+    background-color: #171a1b !important;
+}
+div[class^="SubNav__SubNavContainer"],
+div[class^="Media__ButtonContainer"] > a,
+div[class*="WatchlistButton__ButtonParent"] > button,
+a[class*="EmptyState__FYWStateButton"],
+a[class*="EmptyState__FromYourWatchlistRibbon"] > svg,
+.ipc-poster-card,
+.ipc-poster-card__actions > .ipc-button {
+    background: rgba( var(--ipt-on-baseAlt-rgb,255,255,255),var(--ipt-baseAlt-hover-opacity,0.08) ) !important;
+}
+div[class^="SubNav__ShareButtonWrapper"]::before,
+div[class^="Root__Separator"] {
+    background: rgba(var(--ipt-base-rgb,255,255,255),0.2);
+}
+.ipc-title__text::before,
+.ipc-tabs__indicator {
+    background: #f5c518 !important;
+}
+.ipc-signpost--accent1 {
+    background: var(--darkreader-bg--mdc-theme-ipt-accent1-color, #bb9508) !important;
+}
+hgroup[class*="ipc-title--category-title"] > .ipc-title__text,
+.ipc-title-prompt__title {
+    color: #f5c518 !important;
+}
+.boxOfficeTitle:nth-of-type(2n) {
+    background: linear-gradient( to right,rgba(var(--ipt-on-baseAlt-rgb),0),rgba(var(--ipt-on-baseAlt-rgb),0.06) ) !important;
+}
+div[class^="VideoInfostyles__VideoDescriptionOverlay"] {
+    background: linear-gradient(transparent 50%,var(--ipt-baseAlt-bg)) !important;
+}
+main {
+    background: var(--ipc-pageSection-baseAlt-bg) !important;
+}
+.ipc-watchlist-ribbon__bg-ribbon {
+    fill: rgba(var(--ipt-baseAlt-shade1-rgb), 0.75) !important;
+}
+.ipc-watchlist-ribbon--inWatchlist .ipc-watchlist-ribbon__bg-ribbon {
+    fill: #BB9508 !important;
+}
+.ipc-switch__slider::before,
+.ipc-switch__slider::after {
+    background: #5799ef !important;
+}
+.aux-content-widget-2 {
+    background: none !important;
+}
+.ipc-tabs--display-chip .ipc-tab--active,
+.ipc-tabs--display-chip .ipc-tab--active:hover {
+    background: ${rgb(245,197,24)} !important;
+}
+.ipc-split-button {
+    border: solid 2px currentcolor !important;
+}
+section[cel_widget_id="StaticFeature_Photos"] button {
+    background: none;
+}
+
+================================
+
+immobilienscout24.de
+
+INVERT
+img[alt^="ImmobilienScout24"]
+.topnavigation__sso-login__plus-logo
+.button-primary
+.main-search__content--rent--from-0
+.result-list-entry__new-flag
+.product-teaser__image
+.no-of-results-highlighter
+
+CSS
+.result-list__listing {
+    background-color: transparent !important;
+}
+
+================================
+
+imwithgeekarchive.weebly.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+in.gr
+*.in.gr
+
+CSS
+.inner-main-article a,
+.hover-underline,
+.hover-underline h3,
+a.author,
+span.team-name,
+span.team-result,
+.shopflix-items a.shopflix-link-title {
+    color: var(--darkreader-neutral-text) !important;
+}
+.article_above_footer ::after {
+    filter: invert(0.5) !important;
+}
+
+================================
+
+inaturalist.org
+
+INVERT
+.logolink
+
+================================
+
+inc.com
+
+INVERT
+svg[class*="logo"]
+
+================================
+
+ind.ie
+
+INVERT
+.three-rs .three-rs-list p
+
+================================
+
+independent.co.uk
+
+INVERT
+.logo-text
+#MegaMenuButton
+.search-toggle
+.jw-slider-horizontal
+.jw-slider-volume
+
+IGNORE INLINE STYLE
+.logo-svg-cls-2
+
+================================
+
+index-education.net
+*.index-education.net
+
+INVERT
+.widget .content-container::after
+.conteneurAbs>canvas
+
+CSS
+body:not(.ThemeAccessible) .ThemeCat-edt {
+    --darkreader-text--theme-claire-scalePlus80: ${#e8e6e3} !important;
+}
+body:not(.ThemeAccessible) .ThemeCat-resultat {
+    --darkreader-text--theme-claire-scalePlus80: ${#cdc8c2} !important;
+}
+body:not(.ThemeAccessible) .ThemeProduitEDT,
+body:not(.ThemeAccessible) .ThemeCat-viescolaire {
+    --darkreader-text--theme-claire-scalePlus80: ${#ccc7c1} !important;
+}
+body:not(.ThemeAccessible) .ThemeCat-pedagogie {
+    --darkreader-text--theme-claire-scalePlus80: ${#cecac3} !important;
+}
+body:not(.ThemeAccessible) .ThemeCat-communication {
+    --darkreader-text--theme-claire-scalePlus80: ${#cecac4} !important;
+}
+.ObjetBandeauPied .knowledge-container .ibp-pill {
+    border-color: ${#a49d91} !important;
+}
+.ObjetBandeauPied hr {
+    background-color: ${#2f323470} !important;
+}
+:root,
+:root body.dark-mode .disable-dark-mode {
+    --theme-neutre-claire: ${#c6caca} !important;
+    --theme-neutre-moyen2: ${#b4b4b4} !important;
+}
+html[data-darkreader-scheme="dark"] .ibe_gauche>* {
+    filter: invert(94%) hue-rotate(180deg) contrast(90%) !important;
+}
+.ie-chips.tag-style {
+    background: linear-gradient(90deg, var(--darkreader-bg--theme-neutre-claire) 0, var(--darkreader-bg--theme-neutre-claire) calc(100% - 0.8rem), transparent calc(100% - 0.8rem), transparent 100%) !important;
+}
+
+================================
+
+inet.se
+
+INVERT
+.h1yh8nho
+a.item-button span[class*="icon"]
+
+CSS
+:root {
+    --svg-icon-default-color: #e8e6e3 !important;
+}
+
+================================
+
+infinity-academies.com
+
+INVERT
+img.bb-logo
+img[src*="profile-avatar-buddyboss-50.png"]
+
+================================
+
+infinitysearch.co
+
+INVERT
+img[src$="github.ico"]
+img[src$="unsplash.png"]
+img[src$="boardreader.ico"]
+#logo_img_home[src$="logo_text_black.png"]
+
+================================
+
+info.wyborcza.biz
+
+INVERT
+.imgw
+
+================================
+
+infoq.com
+
+CSS
+.bg-cover {
+    background-blend-mode: multiply;
+}
+
+================================
+
+inforlex.pl
+
+INVERT
+div[class="content -dark"]
+div[class="loginLogo"]
+img[src*="infor-lex_2020.jpg"]
+a[class="client-logo-entry"]
+
+================================
+
+informa.com
+
+INVERT
+.header-logo
+
+================================
+
+informatech.com
+
+INVERT
+.log-img
+
+================================
+
+inibuilds.com
+
+INVERT
+.header__heading-logo
+.icon
+img[alt="add icon"]
+img[alt="plus"]
+.footer-block__image-wrapper
+.list-social__link
+
+IGNORE IMAGE ANALYSIS
+.flagged .flags-AUD
+.flagged .flags-EUR
+
+================================
+
+inoreader.com
+
+CSS
+.article_expanded {
+    background-color: rgb(31, 35, 38) !important;
+}
+
+================================
+
+inquirer.com
+
+CSS
+footer a > svg,
+header button[aria-label="Search"] > svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+header button[aria-label="Full navigation"] > div.bg-black {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+insideclimatenews.org
+
+INVERT
+.site-logo
+
+================================
+
+insomniac.com
+
+INVERT
+.global-navbar__logo
+.social:not(.social--bordered-white):not(.social--white)
+.icon-menu span
+
+IGNORE IMAGE ANALYSIS
+.social__twitch
+
+================================
+
+inspirehep.net
+
+CSS
+svg text {
+    fill: ${black} !important;
+}
+
+================================
+
+instacart.com
+
+CSS
+html[data-darkreader-scheme="dark"] button:not(:hover) {
+    color: gray;
+}
+.e-im51v0 {
+    background-color: ${rgb(255, 255, 255)};
+}
+
+================================
+
+instagram.com
+
+INVERT
+.s4Iyt
+.coreSpriteActivityHeart
+.coreSpriteAppStoreButton
+.coreSpriteCall
+.coreSpriteCheck
+.coreSpriteCi
+.coreSpriteClose
+.coreSpriteDesktopNavDirect
+.coreSpriteDesktopProfileSaveActive
+.coreSpriteDesktopProfileTaggedActive
+.coreSpriteDirectHeart
+.coreSpriteDownload
+.coreSpriteDropdownArrowGrey9
+.coreSpriteGallery
+.coreSpriteGooglePlayButton
+.coreSpriteKeyhole
+.coreSpriteLockSmall
+.coreSpriteLoggedOutWordmark
+.coreSpriteMobileNavDirect
+.coreSpriteMobileNavTypeLogo
+.coreSpriteNavBack
+.coreSpriteNotificationLeftChevron
+.coreSpriteNullProfile
+.coreSpriteOptionsEllipsis
+.coreSpritePagingChevron
+.coreSpriteProfileCamera
+.coreSpriteReload
+.coreSpriteSaveNull
+.coreSpriteSpinstaStory
+.coreSpriteStoryCreation
+.coreSpriteTaggedNull
+.coreSpriteVideoNux
+.coreSpriteWindowsStoreButton
+.coreSpriteWordmark
+.glyphsSpriteAdd__outline__24__grey_9
+.glyphsSpriteAdd_friend__outline__96
+.glyphsSpriteApp_instagram__outline__24__grey_9
+.glyphsSpriteApp_messenger__outline__24__grey_9
+.glyphsSpriteApp_twitter__outline__24__grey_9
+.glyphsSpriteApp_whatsapp__outline__24__grey_9
+.glyphsSpriteCall__outline__24__grey_9
+.glyphsSpriteCamera__outline__24__grey_9
+.glyphsSpriteChevron_down__outline__24__grey_9
+.glyphsSpriteChevron_left__outline__24__grey_9
+.glyphsSpriteChevron_up__outline__24__grey_9
+.glyphsSpriteCircle_add__outline__24__grey_9
+.glyphsSpriteComment__outline__24__grey_9
+.glyphsSpriteContact_import
+.glyphsSpriteContact_import_sm
+.glyphsSpriteDirect__outline__24__grey_9
+.glyphsSpriteDirect__outline__96
+.glyphsSpriteDownload_2FAC
+.glyphsSpriteError__outline__24__grey_9
+.glyphsSpriteError__outline__96
+.glyphsSpriteFacebook__outline__24__grey_9
+.glyphsSpriteFb_brand_center_grey
+.glyphsSpriteForward__outline__24__grey_9
+.glyphsSpriteFriend_Follow
+.glyphsSpriteGlyph_chevron_right
+.glyphsSpriteHashtag__outline__24__grey_9
+.glyphsSpriteHeart__filled__16__grey_9
+.glyphsSpriteHeart__filled__24__grey_9
+.glyphsSpriteHeart__outline__24__grey_9
+.glyphsSpriteHome__filled__24__grey_9
+.glyphsSpriteHome__outline__24__grey_9
+.glyphsSpriteInfo__filled__16__grey_9
+.glyphsSpriteLink__outline__24__grey_9
+.glyphsSpriteLocation__outline__24__grey_9
+.glyphsSpriteLock__outline__24__grey_9
+.glyphsSpriteLock__outline__96
+.glyphsSpriteMail__outline__24__grey_9
+.glyphsSpriteMenu__outline__24__grey_9
+.glyphsSpriteMore_horizontal__outline__24__grey_9
+.glyphsSpriteNew_post__outline__24__grey_9
+.glyphsSpritePaging_chevron
+.glyphsSpritePlay__filled__16__grey_9
+.glyphsSpriteSave__filled__24__grey_9
+.glyphsSpriteSave__outline__24__grey_9
+.glyphsSpriteSearch__filled__24__grey_9
+.glyphsSpriteSearch__outline__24__grey_9
+.glyphsSpriteSettings__outline__24__grey_9
+.glyphsSpriteShare__outline__24__grey_9
+.glyphsSpriteShopping__outline__16__grey_9
+.glyphsSpriteStar_filled_24
+.glyphsSpriteStar_half_filled_24
+.glyphsSpriteStory__outline__24__grey_9
+.glyphsSpriteUser__filled__24__grey_9
+.glyphsSpriteUser__outline__24__grey_9
+.glyphsSpriteUser_follow__filled__24__grey_9
+.glyphsSpriteUser_follow__outline__24__grey_9
+.glyphsSpriteUsers__outline__24__grey_9
+.glyphsSpriteVideo_chat__outline__24__grey_9
+.glyphsSpriteWhatsapp__outline__24__grey_9
+.glyphsSpriteX__outline__24__grey_9
+span.LikeSprite.embedSpriteHeartOpen
+span.hideText.embedSpriteComment
+span.hideText.embedSpriteShare
+span.hideText.embedSpriteSaveOpen
+span.Sprite.embedSpriteGlyph.hideText
+.-Nmqg
+svg[aria-label*="Facebook"]
+a[role="link"][href="/"] i[role="img"]
+
+CSS
+div > a[tabindex],
+div > span > a[tabindex] {
+    border-color: transparent !important;
+}
+._ac3p {
+    background-color: rgb(180, 180, 180) !important;
+}
+._ac3o {
+    background-color: rgb(68, 68, 68) !important;
+}
+
+================================
+
+instantpot.com
+
+CSS
+:root {
+    --darkreader-bg--bg-color: var(--darkreader-neutral-background) !important;
+}
+input,
+select {
+    background-color: ${#ddd} !important;
+}
+
+================================
+
+instructables.com
+
+INVERT
+.site-logo
+
+================================
+
+instructure.com
+
+INVERT
+.equation_image
+.Page-container
+
+================================
+
+integration.wikimedia.org
+
+CSS
+:root {
+    --darkreader-text--text-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+interaktywnie.com
+
+INVERT
+img[alt="Interaktywnie.com"]
+img[src*="companym/"]
+
+================================
+
+interia.pl
+
+INVERT
+.logo
+.search-submit
+
+CSS
+.calendar-date,
+.calendar-body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+internationalrightsadvocates.org
+
+INVERT
+.header-title
+
+CSS
+.container .section-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.container .section-background .background-fx-canvas > canvas {
+    display: none !important;
+}
+.page-section h3,
+.sqsrte-text-color--lightAccent {
+    color: var(--darkreader-neutral-text) !important;
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+================================
+
+internetexchangemap.com
+
+INVERT
+div[aria-label="Map"] > div:first-child
+div.fade
+
+================================
+
+interpride.org
+
+INVERT
+.header__logo
+.search-open
+.top-line::after
+.logo-items picture
+.footer__logo
+
+================================
+
+inu-manga.com
+
+CSS
+.bs .bsx .limit .type.Manhwa,
+.listupd .utao.styletwo .uta .imgu .type.Manhwa {
+    background-image: url("/wp-content/themes/mangareader/assets/images/manhwa.png") !important;
+}
+.bs .bsx .limit .type.Manga,
+.listupd .utao.styletwo .uta .imgu .type.Manga {
+    background-image: url("/wp-content/themes/mangareader/assets/images/manga.png") !important;
+}
+
+================================
+
+investing.com
+
+INVERT
+img[src="https://a-invdn-com.investing.com/Broker_Button_New/Fab120/ICMARKET2022.png"]
+
+CSS
+div[class*="border-color"]:has(svg) {
+    background: white !important;
+}
+
+IGNORE INLINE STYLE
+.w-full svg *
+
+================================
+
+investopedia.com
+
+INVERT
+.widget-ticker-container
+.mntl-dotdash-universal-nav__logo
+
+================================
+
+invisioncommunity.com
+
+INVERT
+img[src*="customer_logos.png"]
+img[src*="logo_dark.png"]
+img[src*="footer"]
+.cDownloadsCategoryCount
+
+CSS
+.ipsBadge {
+    --darkreader-bg--badge--background: var(--darkreader-neutral-background) !important;
+}
+.ipsReact_reactCount > a,
+.ipsReact_reactCount > span,
+.elFullInbox_menu,
+.ipsMenu_auto,
+.ipsMenu_footerBar,
+.ipsMenu_headerBar,
+.ipsMenu_innerContent,
+.ipsMenu_item,
+.ipsMenu_sep,
+.ipsMenu_title,
+.ipsPadding {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+inwestomat.eu
+
+CSS
+main {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+iopscience.iop.org
+
+INVERT
+.article-text img[alt^="$"]
+
+================================
+
+ip-api.com
+
+INVERT
+img[alt="logo"]
+
+================================
+
+ipinfo.io
+
+INVERT
+.navbar-brand
+
+================================
+
+ipko.pl
+
+INVERT
+a[href="#"]:has(span)
+
+CSS
+._1IGN3 {
+    background-size: 75px 56px !important;
+}
+._3cnGx::before {
+    background-size: 112px 80px !important;
+}
+._3o8il {
+    background-size: 48px 48px !important;
+}
+._2A4oT::before {
+    background-size: 36px 38px !important;
+}
+.a41fa18d {
+    background-size: 100% !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.a41fa18d
+
+================================
+
+iplocation.net
+
+INVERT
+img[src="/assets/images/logo.png"]
+
+================================
+
+ipma.pt
+
+INVERT
+img[alt="Instituto Portugues do Mar e Atmosfera - Homepage"]
+img[alt="Ministério da Agricultura e Mar"]
+
+================================
+
+iqiyi.com
+
+INVERT
+.qy-micro-bg
+
+================================
+
+irishtimes.com
+
+INVERT
+.masthead-block-logo img
+
+================================
+
+is.muni.cz
+
+INVERT
+.isElInput_label_latex
+.se-tex-img
+
+================================
+
+isbgpsafeyet.com
+
+CSS
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    color: rgb(255, 255, 255) !important;
+}
+.Hero,
+.Footer {
+    background: None !important;
+}
+.Button-is-primary {
+    background: var(--primary-background-color);
+}
+
+================================
+
+ising.pl
+
+CSS
+body.grey-gui-bg #content,
+div.grey-gui-bg,
+.small-navy-heading,
+.small-blue-heading,
+.small-purple-heading,
+.small-navy2-heading {
+    background-image: none !important;
+}
+
+================================
+
+isis.tu-berlin.de
+
+INVERT
+img.icon
+img.activityicon
+
+================================
+
+isitdownrightnow.com
+
+CSS
+.ts1,
+.ts2,
+.ts3,
+.ts4,
+.ts5,
+.ts6,
+.ts7,
+.ts8,
+.ts9,
+.ts10,
+.ts11,
+.ts12,
+.ts13,
+.ts14,
+.ts15,
+.ts16,
+.ts17,
+.ts18,
+.ts19,
+.ts20,
+.ts21,
+.ts22,
+.ts23,
+.ts24,
+.ts25,
+.ts26,
+.ts27,
+.ts28,
+.ts29,
+.ts30,
+.ts31,
+.ts32,
+.ts33,
+.ts34,
+.ts35,
+.ts36,
+.ts37,
+.ts38 {
+    background-image: none !important;
+}
+
+================================
+
+istanbulfm.com.tr
+
+CSS
+#jarallax-container-0 {
+    z-index: 0 !important;
+}
+
+================================
+
+italy-vms.ru
+
+INVERT
+#main_logo
+
+================================
+
+itbiznes.pl
+
+INVERT
+.custom-logo
+
+================================
+
+itch.io
+
+INVERT
+.header_widget .mobile_nav_btn
+img[src="https://static.itch.io/images/logo-black-new.svg"]
+
+CSS
+.index_page .app_banner .outline_button,
+.youtube_game_promo_banner_widget .game_information .cta_button {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+item.jd.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+itemfix.com
+
+INVERT
+.logo-outer
+.footer-logo
+a[href="ll"]
+
+================================
+
+ithardware.pl
+
+INVERT
+.navbar-brand
+a[href*="uzywki.expert"]
+a[href*="rankingi"]
+a[href*="feed"]
+
+================================
+
+iu-fernstudium.de
+
+INVERT
+.cp-logo
+.cp-contact-bubble__svg-open
+svg[class$="transform"]
+
+================================
+
+iubenda.com
+
+INVERT
+img[alt="Iubenda logo"]
+
+================================
+
+iupts.org
+
+CSS
+body,
+.loginbg {
+    background-image: none !important;
+}
+
+================================
+
+iwm.org.uk
+
+CSS
+.branch-showcase-teaser__media,
+.hero__media {
+    z-index: 0 !important;
+}
+.branch-showcase-teaser .branch-showcase-teaser__location div,
+.branch-showcase-teaser h3 {
+    color: white !important;
+    position: relative !important;
+    z-index: 1 !important;
+}
+html[data-darkreader-scheme="dark"] .main-menu__secondary-navigation__search-open::after {
+    filter: none !important;
+}
+
+================================
+
+ixbt.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+iyingdi.com
+
+CSS
+.header-area {
+    background-image: linear-gradient(
+        180deg,
+        transparent,
+        color-mix(in srgb, var(--darkreader-neutral-background) 30%, transparent) 25%,
+        color-mix(in srgb, var(--darkreader-neutral-background) 60%, transparent) 44%,
+        color-mix(in srgb, var(--darkreader-neutral-background) 90%, transparent) 69%,
+        var(--darkreader-neutral-background)
+    ) !important;
+}
+.header-area .post-title,
+.header-area .post-detail-info {
+    color: var(--darkreader-neutral-text) !important;
+}
+.post-main-content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.author-info-bar {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.author-info-bar .user-name,
+.author-info-bar .fans-and-follows .count {
+    color: rgb(200, 196, 189) !important;
+}
+
+================================
+
+jacobin.com
+
+INVERT
+.hm-sd-b-ty
+.hm-sd-b-ty > *
+.po-cn .po-cn__intro
+.po-cn .po-cn__intro > *
+.po-cn .po-cn__rule
+.po-hr-cn
+.po-hr-cn > *
+.pq::after
+.pq::before
+.si-hr-nv__icon--menu
+
+IGNORE IMAGE ANALYSIS
+.hm-sd-b-ty
+
+================================
+
+jailbreak.fce365.info
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+jakdojade.pl
+
+INVERT
+#main-map
+
+================================
+
+jamendo.com
+
+INVERT
+.player-volume_range_track
+.player-volume_range_fill
+
+================================
+
+janeway.exotica.org.uk
+
+CSS
+html {
+    background: var(--darkreader-neutral-background) !important;
+}
+body,
+div.area,
+div.area *,
+table.list * {
+    background-image: none !important;
+}
+
+================================
+
+japscan.lol
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+jared.com
+kay.com
+banter.com
+peoplesjewellers.com
+zales.com
+
+INVERT
+.company-logo
+
+================================
+
+java.com
+
+INVERT
+html #jvc0v2.bg1 .jvc0w1
+html #jvc0v2.bg3 .jvc0w1
+html #jvc0v2.bg5 .jvc0w1
+
+================================
+
+jbl.com
+
+CSS
+.product-tile .product-image .thumb-link img {
+    mix-blend-mode: normal !important;
+}
+.search-refinement,
+i[class^="icon"].hidden-xs {
+    color: var(--darkreader-neutral-text) !important;
+}
+.product-tile .product-image {
+    background-color: white !important;
+}
+.product-tile .product-swatches .swatch-list li.selected img,
+.product-tile .product-swatches .swatch-list li.selected:hover img {
+    border-color: white !important;
+}
+
+================================
+
+jegy.mav.hu
+
+INVERT
+.service-icon-container
+.standard-icon-size
+
+CSS
+.text-content .box {
+    color: black !important;
+}
+div[style='background-image: url("https://jegy.mav.hu//PlaceReservationIcons/Graphic/Cars/wagon_base-empty.svg");'] span {
+    color: black !important;
+}
+
+IGNORE INLINE STYLE
+g[id*="ules"] path
+#seat-info-container svg path
+span
+
+================================
+
+jenkins.*.local
+jenkins.*.com
+*.jenkins.*.local
+*.jenkins.*.com
+jenkins.io
+
+IGNORE INLINE STYLE
+.logo-jenkins *
+
+================================
+
+jetbrains.com
+
+CSS
+span,
+#content :is(p, a, span[role], h1, h2, h3),
+[class*="_rs-text"],
+[data-test="main-submenu-column-title"] {
+    color: var(--darkreader-neutral-text) !important;
+}
+[type="button"] {
+    background-color: var(--_rs-button-background) !important;
+}
+
+IGNORE INLINE STYLE
+linearGradient[id*="svg"] > stop
+radialGradient[id*="svg"] > stop
+svg[class*="logo"]
+#__SVG_SPRITE_NODE__ > symbol > path
+#__SVG_SPRITE_NODE__ > symbol > g
+
+================================
+
+jewishcurrents.org
+
+INVERT
+img[alt="Jewish Currents"]
+
+================================
+
+jiqizhixin.com
+
+INVERT
+.header__logo
+
+================================
+
+jira.*.com
+
+INVERT
+.aui-dropdown2-trigger::after
+
+================================
+
+jira.*.services
+
+CSS
+.hstbad {
+    z-index: 1 !important;
+}
+
+================================
+
+jisho.org
+
+INVERT
+h1.logo
+.stage
+
+================================
+
+jlcpcb.com
+*.jlcpcb.com
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+jobs.github.com
+
+CSS
+#page {
+    background-image: none !important;
+}
+
+================================
+
+joc.com
+
+INVERT
+header img
+
+CSS
+div[data-cy="welcome-section"] div {
+    mix-blend-mode: normal !important;
+}
+.chartdiv {
+    filter: brightness(0.5) !important;
+}
+
+IGNORE INLINE STYLE
+.chartdiv *
+
+IGNORE IMAGE ANALYSIS
+.chartdiv *
+
+================================
+
+joemonster.org
+
+INVERT
+#commentHeader
+.art-details span
+.item-vote-down
+.logo
+.moderb
+.mtv-item-not-working
+.vote-down
+.vote-up
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+johnhorgan.org
+
+CSS
+.column-sidebar-02 h4,
+.column-sidebar-02 div,
+.column-sidebar-02 a {
+    color: ${white} !important;
+}
+
+================================
+
+johnlewis.com
+
+INVERT
+a[href="/"] img
+
+CSS
+.qrcode-logo {
+    background-color: #FFFFFF !important;
+}
+div[class^="overlay-foreground"] div[data-test="copy-title"] h2,
+div[class^="overlay-foreground"] div[data-test="copy"] p,
+div[class^="overlay-foreground"] a[data-testid="tertiary-button"] {
+    color: black !important;
+}
+
+IGNORE INLINE STYLE
+.qrcode-logo svg path
+
+================================
+
+joinhoney.com
+*.joinhoney.com
+
+INVERT
+img[src$="paypal-honey-logo-bl.svg"]
+img[src$="star-honey-rating.svg"]
+
+CSS
+#lp-pom-block-11 {
+    background-color: black;
+}
+
+================================
+
+joinpickleheads.com
+*.joinpickleheads.com
+
+CSS
+.bg-\[\#E5E7EB\] {
+    background-color: gray !important;
+}
+.bg-\[\#111827\] {
+    background-color: darkblue !important;
+}
+span.inline-block.rounded-full.bg-white {
+    background-color: rgb(255 255 255/var(--tw-bg-opacity)) !important;
+}
+
+================================
+
+jojowiki.com
+
+CSS
+.mw-body {
+    background-image: none !important;
+}
+
+================================
+
+joplinapp.org
+
+CSS
+#in-the-press-section {
+    background-image: none !important;
+}
+
+================================
+
+journal.tinkoff.ru
+
+INVERT
+._17-LK > span
+._3aEco
+._1Dhxk
+.uVy35.V6dif::before
+._38Vkx.FrrKu::after
+._3LO60._4GqdT::after
+.PwECA
+.best-authors__arrow.best-authors__arrow--active
+.best-authors__arrow
+label[class^="hamburgerMenu"]
+
+================================
+
+journals.aps.org
+
+INVERT
+a.logo-link
+
+CSS
+.headline,
+.teaser p,
+h1,
+p.description-text,
+.content-container .title,
+.content-container .title-description,
+.description-container {
+    color: var(--darkreader-neutral-text) !important;
+}
+.card,
+.article-fulltext-figure-heading {
+    background-color: ${rgb(249,249,249)} !important;
+}
+summary,
+.export-article-citation,
+.physh-concept {
+    background-color: ${rgb(225, 225, 225)} !important;
+    color: ${rgb(0, 83, 139)} !important;
+}
+summary:hover,
+.export-article-citation:hover,
+.physh-concept:hover {
+    background-color: rgb(0, 64, 105) !important;
+    color: white !important;
+}
+figcaption p {
+    color: ${rgb(107, 107, 108)} !important;
+}
+
+================================
+
+jpl.nasa.gov
+
+CSS
+.brand_area {
+    background-image: url("https://www.jpl.nasa.gov/assets/images/logo_nasa_trio_white@2x.png") !important;
+}
+
+================================
+
+jpmorgan.com
+
+INVERT
+.first-logo
+
+================================
+
+jpost.com
+
+INVERT
+img[alt*="The Jerusalem Post"]
+img[class*="header"]
+.btn-digital-library-header > img
+
+================================
+
+jsdelivr.com
+
+INVERT
+.navbar-brand > img
+
+================================
+
+jsr.io
+
+CSS
+.pl-smi {
+    color: ${black} !important;
+}
+.pl-s {
+    color: ${#313688} !important;
+}
+.pl-c1 {
+    color: ${#2f84d0} !important;
+}
+.pl-en {
+    color: ${#009759} !important;
+}
+.ddoc :not(.highlight) > code {
+    background-color: ${#ccd4da} !important;
+}
+.ddoc a > code {
+    color: ${#205faa} !important;
+}
+#usageSelector > summary {
+    background-color: ${white} !important;
+}
+.markdown_summary p code {
+    color: white !important;
+    opacity: 0.50 !important;
+}
+html[data-darkreader-scheme="dimmed"] .markdown_summary p code {
+    filter: invert(100%) hue-rotate(180deg) !important;
+}
+
+================================
+
+jsware.net
+
+INVERT
+img[src="since.gif"]
+
+CSS
+h5.H5Dex,
+td.Dex {
+    background: unset !important;
+}
+
+================================
+
+juejin.cn
+
+INVERT
+.equation
+
+================================
+
+jumia.*
+jumia.*.*
+zando.co.za
+
+INVERT
+svg.ic[role="img"]:not([aria-label="Zando logo"])
+.logo > a > img
+.inbox > a:not(:nth-of-type(1)) > svg
+img[src*="jumia-group-logo.png"]
+img[src*="jumia_logo_small_checkout.png"]
+img[src*="/Jumia-Pay"]
+li.logo:nth-child(1) > .-i-jumia-logo
+.-ecosystem > a.-category.-inlineblock.-vatop:not([href*="mall"]) > img
+img[src*="empty-cart.png"]
+.-header > img:nth-child(1)
+.-gy5 > .-fs0 > .vent-link[title*="Rewards"]
+.-gy5 > .-fs0 > .vent-link[title*="Pay"]
+.-gy5 > .-fs0 > .vent-link[title*="Primo"]
+.-gy5 > .-fs0 > .vent-link[title*="Food"]
+.-gy5 > .-fs0 > .vent-link[title*="Party"]
+.-gy5 > .-fs0 > .vent-link[title*="Now"]
+.col4 > .s-menu > a:not(:nth-child(1)):not(:nth-child(3)):not(:nth-child(7)) > svg
+div.-fw-w:nth-child(1) > a.-fs0 > img
+article.-df > svg > use
+svg.ic.xprss
+div.-df.-d-co.-c-bet > h3.-fw > svg.ic
+a.fk-cb.-me-start.-fsh0 > svg.ic.-h-24
+
+================================
+
+justhost.ru
+
+INVERT
+.header__logo
+
+================================
+
+justjoin.it
+
+CSS
+.css-oi8ccm {
+    height: 98px !important;
+}
+
+================================
+
+justtherecipe.com
+
+INVERT
+flt-glass-pane
+
+================================
+
+juwai.com
+
+INVERT
+.c-header__logo
+.c-responsive-navigation__logo
+
+================================
+
+jvc.net
+
+INVERT
+img[src="img/logo.jpg"]
+
+================================
+
+k-report.net
+
+CSS
+.dfzlu1 div,
+#diskuse_zahlavi a,
+.dfprofil,
+#diskuse_zahlavi td {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+kaggle.com
+kaggleusercontent.com
+
+CSS
+div.output_png img {
+    background-color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+div.output_png img
+
+================================
+
+kahoot.it
+
+INVERT
+main[data-functional-selector="correct-answer"] > div > div > div > svg > g > path
+main[data-functional-selector="incorrect-answer"] > div > div > div > svg > g > path
+main[data-functional-selector="time-up-answer"] > div > div > div > svg > g > path
+div[data-functional-selector="kahoot-settings__language-picker"] > div > div > div > div > img
+.sc-iqxcLP.klWCeb
+g#Background
+g#Greyscale
+span[data-functional-selector="kahoot-logo"] > svg > g > path
+
+IGNORE INLINE STYLE
+[data-functional-selector^="answer"]
+[data-functional-selector="intro-animation-animation_pre-question-animation"] *
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+kaldata.com
+
+IGNORE IMAGE ANALYSIS
+.tdi_112 .tdb-featured-image-bg
+
+================================
+
+kali.org
+
+CSS
+#kali-platforms .card > div {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#banner-logo
+
+================================
+
+kamigame.jp
+
+CSS
+article,
+.article {
+    background-image: none !important;
+}
+
+================================
+
+kaos-community-packages.github.io
+
+INVERT
+.Header-brand
+
+================================
+
+kaosx.us
+
+INVERT
+.Header-brand img
+
+================================
+
+kapitanbomba.pl
+
+INVERT
+.custom-logo
+
+================================
+
+kartotekaonline.pl
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+kasmedia.com
+
+CSS
+.flex {
+    z-index: 1 !important;
+}
+.z-10 {
+    z-index: 0 !important;
+}
+
+================================
+
+katahiromz.web.fc2.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+kaytrip.com
+
+INVERT
+.date
+.jd_ss
+.liuchengt
+.nApp
+.nTel
+.n_app
+.tt_t
+.wmap
+
+CSS
+#imageField {
+    background-color: transparent !important;
+}
+.jd_xl {
+    filter: none !important;
+}
+
+================================
+
+kbb.com
+
+IGNORE INLINE STYLE
+svg[class*="LogoText"] g
+
+================================
+
+keep.google.com
+
+INVERT
+.gb_hc
+
+================================
+
+keepa.com
+
+INVERT
+div#loadingIcon
+div.pLText
+
+CSS
+#tabHeadIFrame > li.active,
+#tabHead > li.active,
+.tabItemI:not(.tabExtern):not(.active):hover,
+.tabItem:not(#tabAmazon):not(.tabDeals):not(.active):hover {
+    background-image: none !important;
+}
+div#flotTipDate {
+    background: var(--darkreader-background-f0f0f0, #282b2d) !important;
+}
+
+================================
+
+keepass.info
+
+INVERT
+img[src="help/images/trans.png"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+keepassxc.org
+
+CSS
+.btn-primary {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+kelkoo.it
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+kenh14.vn
+
+CSS
+.kbwcb-left,
+.kbwcb-left::before {
+    background-image: none !important;
+}
+
+================================
+
+kenmore.com
+
+INVERT
+.navbar-brand
+
+================================
+
+kenwood.com
+
+INVERT
+.logo01
+
+================================
+
+kernel.org
+
+INVERT
+img[src*="understand"]
+
+================================
+
+keychron.*
+
+INVERT
+img[src*="keychron-logo-transparent"]
+img[src*="keychron_600_V1.png"]
+.btn--secondary
+
+CSS
+body,
+.header,
+.product-info,
+.footer {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+keyserver.pgp.com
+
+INVERT
+a.button-text
+#ImPGPComHelp
+#ImPGPComHome
+[src="images/crystal_button_left.gif"]
+[src="images/crystal_button_left-dark.gif"]
+[src="images/crystal_button_right.gif"]
+[src="images/crystal_button_right-dark.gif"]
+[src="images/global_dir_logo_web.gif"]
+[background="images/crystal_button_fill.gif"]
+[background="images/crystal_button_fill-dark.gif"]
+
+CSS
+.card-top,
+.card-top-left-corner,
+.card-top-right-corner,
+.divide-fill,
+.header-bar-left,
+.header-bar-right,
+.title-left,
+.title-right {
+    background-image: none !important;
+}
+
+================================
+
+kfccoupons.co.nz
+
+CSS
+.img-container {
+    z-index: 0 !important;
+}
+.img-container > img {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+khirevich.com
+
+INVERT
+.fig > img
+
+================================
+
+khronos.org
+
+INVERT
+.navbar-brand
+
+================================
+
+kiedyprzyjedzie.pl
+
+INVERT
+.cluster-marker div
+.leaflet-pane > .leaflet-layer
+
+CSS
+.cluster-marker div span {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+killedbygoogle.com
+
+INVERT
+img[src*="e.svg"]
+img[src*="-logo"]
+
+================================
+
+kingston.com
+
+INVERT
+.s-kt-navigation .nav-logo img
+
+================================
+
+kinhmatanna.com
+
+INVERT
+img[src$="/logo-anna.svg"]
+img[src$="/anna-text.svg"]
+i.eicon
+.elementor-button-icon > svg
+.elementor-button-icon > svg > g
+
+CSS
+.elementor-button-icon::before {
+    z-index: 1 !important;
+}
+.elementor-icon svg {
+    fill: #f0f0f0 !important;
+}
+a[href="/danh-muc-san-pham/gong-kinh/"] {
+    background-color: black !important;
+    border-color: black !important;
+    color: white !important;
+}
+a[href="/danh-muc-san-pham/gong-kinh/"]:hover {
+    filter: invert(100%) contrast(90%) !important;
+}
+.product:not(div[data-elementor-type="product-archive"]) {
+    background-color: #121212 !important;
+}
+.ast-container > div > section:nth-child(4) > div > div:nth-child(2) > div > div:nth-child(4) {
+    z-index: 0 !important;
+}
+
+================================
+
+kinoart.ru
+
+INVERT
+main > div > svg
+header > a > svg
+footer > div > svg
+header > div > a > svg
+
+================================
+
+kinopoisk.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+CSS
+input[name="kp_query"]::placeholder {
+    background-image: linear-gradient(45deg, var(--darkreader-neutral-text) 70%, transparent 100%) !important;
+}
+input[name="kp_query"] {
+    background-color: ${lightgray};
+}
+input[name="kp_query"]:focus {
+    background-color: ${rgb(195, 195, 195)};
+}
+
+================================
+
+kinsta.com
+
+INVERT
+.wp-block-kinsta-hero-title
+.wp-block-kinsta-hero-title > *
+
+================================
+
+kinzhal.media
+
+INVERT
+img[src$="logo.svg"]
+img[src$="search.svg"]
+img[src$="close.svg"]
+.footer-soc
+.footer__18
+.kinzhal-icon
+
+================================
+
+kioxia.com
+
+INVERT
+.header__logo
+
+================================
+
+kipling-usa.com
+
+IGNORE INLINE STYLE
+[id^=powered_by_pixlee]
+
+================================
+
+kirishiavtoservis.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="default-cluster"] > ymaps
+
+================================
+
+kivra.se
+
+CSS
+.FullSizeHero-module--background-image--8c4a3 {
+    opacity: 0.75;
+    z-index: 0;
+}
+
+================================
+
+klarna.com
+*.klarna.com
+
+CSS
+input {
+    -webkit-text-fill-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+kleinanzeigen.de
+
+CSS
+.Modal--Content,
+.UserBadgesModal--Dialog {
+    background-color: var(--darkreader-bg--kds-sema-color-surface) !important;
+}
+
+================================
+
+klibs.io
+
+CSS
+.rs-text_hardness_hard:not(a),
+.rs-text_hardness_average:not(a),
+.rs-h1:not(a) {
+    color: var(--darkreader-neutral-text) !important;
+}
+label[data-test="menu-item"] span:not([data-test="checkbox"]) {
+    color: white !important;
+}
+
+================================
+
+klubjagiellonski.pl
+
+INVERT
+.logo
+.site_hamb svg
+
+================================
+
+knaben.eu
+knaben.org
+
+INVERT
+a[href="https://matrix.to/#/#general:knaben.org"]
+
+CSS
+.text-darker,
+.text-bright,
+.text-white {
+    color: var(--darkreader-text-netural) !important;
+}
+
+================================
+
+knife.media
+
+INVERT
+svg[class$="logo-image"]
+.explorer__header-close
+
+================================
+
+knowablemagazine.org
+
+INVERT
+img[alt="Knowable Magazine | Annual Reviews"]
+img[alt="Knowable Magazine"]
+img[alt="Annual Reviews"]
+
+CSS
+div.category-header h1 {
+    text-shadow: ${rgb(225, 212, 201)} 2px 2px 2px !important;
+}
+
+================================
+
+knowyourmeme.com
+
+INVERT
+.enlargeNavigation > #enlargeNav-prev
+.enlargeNavigation > #enlargeNav-next
+
+================================
+
+ko-fi.com
+
+INVERT
+img[alt="Ko-fi Logo"]
+.ui-mobile-nav-toggle
+
+================================
+
+kohls.com
+
+INVERT
+.top-global-header #logo
+
+================================
+
+koji.fedoraproject.org
+koji.rpmfusion.org
+
+CSS
+* {
+    border: none !important;
+    margin: auto !important;
+    padding: 5px !important;
+}
+body {
+    background-blend-mode: multiply !important;
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text);
+}
+.footer {
+    position: relative !important;
+}
+table.data-list td {
+    vertical-align: top !important;
+}
+tr.list-header,
+.taskclosed,
+.taskclosed:visited,
+.taskclosed:hover,
+.taskfailed,
+.taskfailed:visited,
+.taskfailed:hover,
+.taskfree,
+.taskfree:visited,
+.taskfree:hover,
+.taskopen,
+.taskopen:visited,
+.taskopen:hover,
+td.tree,
+.tree span.root,
+.tree span.treeLabel {
+    background-color: transparent !important;
+}
+tr.list-header th {
+    background-color: var(--darkreader-background-dddddd);
+}
+tr.row-odd {
+    background-color: var(--darkreader-background-ffffff);
+}
+tr.row-even {
+    background-color: var(--darkreader-background-eeeeee);
+}
+span#loginInfo,
+#headerSearch input[type="submit"] {
+    background-color: transparent !important;
+}
+
+================================
+
+komorkomat.pl
+
+INVERT
+.navbar-brand > img
+.owl-wrapper
+.result-item-logo
+
+================================
+
+komputerswiat.pl
+
+INVERT
+.serviceLogoImg
+.serviceIcon
+.secondaryLogoImg
+
+================================
+
+konicaminolta.us
+
+INVERT
+#km_Header .logo img
+
+================================
+
+konkret24.tvn24.pl
+
+INVERT
+.header-left-corner__logo
+.menu-button__bars
+.report-toggle-button__icon
+.search-panel-toggle-button__icon
+
+================================
+
+konto.onet.pl
+
+INVERT
+img[alt="Business Insider"]
+img[alt="Onet Konto"]
+img[alt="Onet Poczta"]
+img[alt="Menu aplikacji"]
+img[alt="Powiadomienia"]
+
+IGNORE INLINE STYLE
+div[class="sc-50572c49-8 kbIkEh"]
+
+================================
+
+kopalniawiedzy.pl
+
+INVERT
+img[alt="Patronite"]
+
+================================
+
+korso24.pl
+korsosanockie.pl
+
+INVERT
+img.weather-box__img
+.nav-top__logo-wrapper
+.nav-top__footer-burger > div > span
+a.footer__logo
+
+================================
+
+kort.foroyakort.fo
+
+INVERT
+.header-section > a:first-child
+.container-section > .icon-node
+
+================================
+
+kraken.com
+
+CSS
+header > nav > ul > li > a::after,
+span[data-testid^="asset-pair"][data-testid$="-low"] + div > :last-child {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+krew.info
+
+INVERT
+a[class*="kropla"]
+
+================================
+
+krita.org
+
+CSS
+.container {
+    background: none !important;
+}
+
+================================
+
+krytykapolityczna.pl
+
+INVERT
+img[src*="logo"]
+
+================================
+
+ksiegowawsieci.pl
+
+INVERT
+.logo
+
+================================
+
+kubuntu.org
+
+INVERT
+.logo
+
+================================
+
+kulinarnyblog.pl
+
+INVERT
+.logo-img
+
+================================
+
+kwyk.fr
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+kyivindependent.com
+
+INVERT
+.custom-logo-link
+.donate__patreon::before
+
+================================
+
+l10n.kde.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+labcorp.com
+
+INVERT
+.logo
+
+================================
+
+labfolder.com
+
+CSS
+:root {
+    --secondary-color: ${#002b56} !important;
+}
+
+================================
+
+laczynasnapiecie.pl
+
+INVERT
+.navbar-brand
+.tim-power
+.row-partners-logo a
+
+================================
+
+ladybird.org
+
+INVERT
+.text-black img
+.gi__image
+
+CSS
+.text-\[\#000\] {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+.bg-gradient-to-r {
+    background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
+}
+.gi__image {
+    background-image: url(../../../assets/img/get-involved.webp) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.bg-\[url\(\'\.\.\/\.\.\/\.\.\/assets\/img\/hero\.webp\'\)\]
+
+================================
+
+lafibre.info
+
+CSS
+.frame,
+#header {
+    background-image: none !important;
+}
+
+================================
+
+lajtmobile.pl
+
+CSS
+body > * {
+    --background: var(--darkreader-neutral-background) !important;
+}
+.ls-bg-wrap > img,
+.generatorTemplate > .columnsBlockGeneratorBlock.mobileHide {
+    filter: brightness(50%) sepia(40%) !important;
+}
+.columnsBlockGeneratorBlock .offertBlock:not(.highlightOffert),
+.generatorTemplate > .columnsBlockGeneratorBlock.mobileHide,
+.summaryModule,
+.formModule,
+input[type="text"] {
+    background: var(--darkreader-neutral-background) !important;
+}
+.generatorTemplate > .columnsBlockGeneratorBlock.mobileHide > * {
+    background: ${#FEF} !important;
+}
+
+================================
+
+lambda-the-ultimate.org
+
+CSS
+a {
+    color: #3391ff !important;
+}
+
+================================
+
+lambdalabs.com
+
+INVERT
+.lambda-logo
+
+================================
+
+lambdatest.com
+
+INVERT
+.tools_logo a img
+
+================================
+
+landscan.ornl.gov
+
+INVERT
+img[src*="tile.openstreetmap.org"]
+img[src*="landscan.ornl.gov/tiles"]
+
+CSS
+.global-key-values .square1 {
+    background-color: ${${#15150d}};
+}
+.global-key-values .square2 {
+    background-color: ${${#1f1f0d}};
+}
+.global-key-values .square3 {
+    background-color: ${${#2e2e0d}};
+}
+.global-key-values .square4 {
+    background-color: ${${#9b4e0d}};
+}
+.global-key-values .square5 {
+    background-color: ${${#f2690e}};
+}
+.global-key-values .square6 {
+    background-color: ${${#f29191}};
+}
+.global-key-values .square7 {
+    background-color: ${${#f2a4a4}};
+}
+.global-key-values .square8 {
+    background-color: ${${#f2c6c6}};
+}
+.hd-us-key-values .square1 {
+    background-color: ${${#15150d}};
+}
+.hd-us-key-values .square2 {
+    background-color: ${${#1f1f0d}};
+}
+.hd-us-key-values .square3 {
+    background-color: ${${#2e2e0d}};
+}
+.hd-us-key-values .square4 {
+    background-color: ${${#9b4e0d}};
+}
+.hd-us-key-values .square5 {
+    background-color: ${${#f27c38}};
+}
+.hd-us-key-values .square6 {
+    background-color: ${${#f29a9a}};
+}
+.hd-us-key-values .square7 {
+    background-color: ${${#f2c6c6}};
+}
+
+================================
+
+languagetool.org
+
+INVERT
+#checktext_ifr
+
+================================
+
+laptopmag.com
+
+INVERT
+div#publisherDetails.logo
+.qc-cmp-publisher-logo
+
+================================
+
+laravel.com
+
+CSS
+.bg-gray-100,
+aside > div {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+last.fm
+
+INVERT
+.resource-external-link--homepage::before
+.share-option
+.report-headline-share
+.avatar-status-dot
+.toggle-button::before
+.js-playlink::before
+.js-playlink-station::before
+.header-new-playlink::before
+.header-new-more-button::before
+.dropdown-menu-clickable-item::before
+.play-this-track-playlink--itunes::before
+.resource-external-link--apple-music::before
+
+CSS
+.user-dashboard-loved-tracks .user-dashboard-big-datapoint-value a {
+    color: ${#666666} !important;
+}
+.user-dashboard-catalogue-item-total a {
+    color: ${#666666} !important;
+}
+.highcharts-text-outline {
+    stroke: none !important;
+}
+.user-dashboard-scalable-content span {
+    color: ${#666666} !important;
+}
+.linkfire-button {
+    --darkreader-border--play-arrow-color: var(--gray-50) !important;
+}
+.promo-v3 .listening-report-promo-date::after {
+    filter: invert(0.5) !important;
+}
+.js-playlink::before,
+.header-new-playlink::before {
+    background-color: hsla(0,0%,100%,.85) !important;
+}
+.js-playlink-station::before {
+    background-color: hsla(0,0%,100%,.85) !important;
+    background-image: url("/static/images/icons/play_dark_32.2d17859fb8d8.png") !important;
+}
+.artist-header-featured-items-item-playlink::before,
+.image-overlay-playlink-link::before,
+.recs-feed-playlink::before {
+    background-image: url("/static/images/icons/play_dark_24.44cbb56c2236.png") !important;
+}
+.chartlist-play-button::before,
+.stationlink::before,
+.header-new-playlink::before {
+    background-image: url("/static/images/icons/play_dark_16.e469e7d1482a.png") !important;
+}
+.highcharts-background {
+    fill: transparent !important;
+}
+.adaptive-skin-container,
+.container.page-content,
+.container.content-top-lower,
+.shout-user a,
+textarea.js-shout-input,
+.content-top-inner-wrap,
+textarea#id_tags {
+    background-color: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text);
+}
+.navlist-hidden-list-wrap * {
+    background-color: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text) !important;
+}
+.chartlist-row:hover,
+.section-with-separator::after,
+.navlist-hidden-list-wrap a:hover {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+}
+.chartlist-row--now-scrobbling,
+.subscribe-cta {
+    background-color: ${#fff9e5} !important;
+}
+.chartlist-count-bar-slug {
+    background-color: ${rgb(255, 192, 192)} !important;
+}
+.alert-success {
+    background-color: ${#e5f4ef} !important;
+}
+.shout--deleted {
+    background: ${#f9f9f9} !important;
+}
+.two-column-layout .container {
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+.page-loading-logo-container *
+.highcharts-series-group *
+.highcharts-legend *:not(text)
+
+IGNORE IMAGE ANALYSIS
+.masthead-logo-loading
+.masthead-logo
+.tag-label--average-daily-scrobbles::before
+.report-headline-border
+.header .header-background::before
+.chartlist-play-button::before
+.stationlink-list .stationlink::before
+.featured-item-art .image-overlay-playlink-link::before
+.header-new-playlink::before
+.header-new-love-button::before
+.header-new-bookmark-button::before
+.header-new-more-button::before
+.more-item--obsession::before
+.more-item--artist-link::before
+.buylink.buylink--amazon::before
+.buylink.buylink--itunes::before
+.buylink.buylink--ebay::before
+.play-this-track-playlink--itunes::before
+
+================================
+
+lastpass.com
+
+INVERT
+.lp-header__logo--link
+
+================================
+
+latimes.com
+
+INVERT
+.page-logo
+.page-header-logo
+
+================================
+
+launchpad.net
+
+INVERT
+.edit-controls
+#launchpad-logo-and-name
+
+CSS
+.footer .lp-arcana {
+    background-image: none !important;
+}
+
+================================
+
+laurelroad.key.com
+
+INVERT
+img[src="images/logo-lrd.svg"]
+.hds-header-logo__img
+
+CSS
+.kds-layout__grid {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+lazka.github.io/pgi-docs
+
+INVERT
+svg text
+
+================================
+
+leafblowerguide.com
+
+CSS
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
+}
+
+================================
+
+leagueoflegends.com
+
+INVERT
+[data-testid="featurednews"] div[class^="style__ItemWrapper"] div[class^="style__Container"] canvas
+.bxrpQD
+
+CSS
+article > div > canvas[class^="style__Canvas"] {
+    display: none !important;
+}
+div[class^="style__NavContent"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+lear.com
+
+INVERT
+.logo
+
+================================
+
+learn.comptia.org
+
+INVERT
+.logo-item
+
+================================
+
+learn.inside.dtu.dk
+
+INVERT
+.pdfViewer
+svg
+d2l-icon
+d2l-button-icon
+
+CSS
+a {
+    color: var(--darkreader-neutral-text) !important;
+}
+:html {
+    --d2l-color-celestine-plus-2: var(--darkreader-neutral-background) !important;
+}
+:host {
+    --d2l-dropdown-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-input-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-list-item-content-text-color: var(--darkreader-neutral-text) !important;
+    --d2l-menu-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-menu-background-color-hover: var(--darkreader-neutral-background) !important;
+    --d2l-tabs-background-color: var(--darkreader-neutral-background) !important;
+}
+.d2l-navigation-s-personal-menu-text,
+.d2l-menu-item-text,
+.d2l-body-small,
+.d2l-heading,
+d2l-htmleditor-menu-item,
+d2l-empty-state-simple,
+button {
+    color: var(--darkreader-neutral-text) !important;
+}
+.d2l-card-link-container,
+.d2l-card-footer,
+.d2l-floating-buttons-container,
+.d2l-htmleditor-container,
+.d2l-dialog-outer,
+d2l-card,
+d2l-list-item-generic-layout {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+learn.simplywall.st
+
+INVERT
+.logo-image-copy
+.program-card-header-copy > .program-name-block > img
+
+================================
+
+learn.uwaterloo.ca
+
+INVERT
+.d2l-labs-navigation-link-image-container
+#viewerContainer
+
+CSS
+.d2l-box.d2l-box-h.d2l-twopanelselector-side.d2l-twopanelselector-side-sep.d2l-repsonsive-collapse-layout.d2l-twopanelselector-padding {
+    background: var(--darkreader-background-ffffff, #181a1b);
+}
+* {
+    --d2l-count-badge-background-color: #242728;
+    --d2l-menu-background-color: var(--darkreader-background-ffffff, #181a1b);
+    --d2l-menu-background-color-hover: #002d41;
+    --d2l-menu-foreground-color-hover: #004489;
+    --d2l-popover-background-color: var(--darkreader-background-ffffff, #181a1b);
+}
+.d2l-page-header d2l-breadcrumbs::after {
+    display: none;
+}
+
+================================
+
+learn2.open.ac.uk
+
+CSS
+.oucontent-quote p {
+    color: ${grey} !important;
+}
+
+================================
+
+learningstylequiz.com
+*.learningstylequiz.com
+
+CSS
+:root {
+    --wt-text-on-background-color: var(--darkreader-text--wt-text-on-background-color) !important;
+}
+
+================================
+
+learnopengl.com
+
+CSS
+#hover {
+    background-image: none !important;
+    opacity: 1 !important;
+}
+
+================================
+
+learnroadrunner.com
+
+INVERT
+img[src*="YouAreHere"]
+img[src="/assets/advanced/termination-flow.svg"]
+img[src="/assets/img/max-vel-latex-half.319e0372.png"]
+.u-wrap
+
+================================
+
+leetcode.com
+leetcode-cn.com
+
+INVERT
+img[alt="logo"]
+.cursor
+.CodeMirror-cursor
+.user-story-chapter-base .companies-showcase-base .logo
+
+CSS
+div[class^="data-structure-viewer"] g[class^="node"] > circle {
+    fill: var(--darkreader-neutral-background) !important;
+}
+[class^=question-picker-detail] {
+    background: none !important;
+}
+.monaco-editor,
+.monaco-editor-background,
+.monaco-editor .margin {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div#solution img {
+    background-color: ${black};
+}
+
+================================
+
+legacy.com
+
+CSS
+.Directory {
+    background-image: none !important;
+}
+
+================================
+
+leginfo.legislature.ca.gov
+
+CSS
+@media screen and (min-width: 768px) {
+    #tab_panel,
+    #system,
+    #quick_search,
+    #bill_version,
+    #breadcrumbs {
+        display: block !important;
+    }
+}
+
+================================
+
+lemonde.fr
+
+INVERT
+.logo__lemonde
+
+================================
+
+lenovo.com
+
+INVERT
+.m-megaMenu
+
+CSS
+.m-mastheadUtilityLinks {
+    background: none !important;
+}
+
+================================
+
+leroymerlin.*
+
+CSS
+.kl-tile__group {
+    filter: invert(0%) !important;
+}
+.kl-tile .kl-blade--figure {
+    z-index: 0 !important;
+}
+
+================================
+
+lesbonscomptes.com
+
+CSS
+.important {
+    background-color: rgb(92, 92, 61) !important;
+}
+
+================================
+
+letters.gov.spb.ru
+
+INVERT
+.leaflet-map-pane
+
+================================
+
+letyshops.com
+
+INVERT
+.header-logo-image
+
+================================
+
+lever.co
+
+INVERT
+a.main-header-logo
+div.site-branding
+
+================================
+
+lexar.com
+
+INVERT
+.page_header_wrapper a.logo img
+
+================================
+
+lg.com
+
+INVERT
+.logo
+img[src*="/features/"]
+
+================================
+
+liberte.pl
+sklep.liberte.pl
+
+INVERT
+img[src*="liberte_logo.svg"]
+img[src*="libertesklep.svg"]
+.hamburger
+
+================================
+
+librarything.com
+
+CSS
+section {
+    background: linear-gradient(180deg, ${#f7f5f366} 0, var(--darkreader-neutral-background) var(--grad-width)) !important;
+}
+
+================================
+
+libravatar.org
+
+INVERT
+footer::before
+.hero::before
+
+================================
+
+libreoffice.org
+
+CSS
+a > .green {
+    color: #00A500 !important;
+}
+
+================================
+
+libretexts.org
+
+CSS
+.mt-content-container img:hover {
+    background-blend-mode: normal;
+    background-color: rgba(255, 255, 255, 0.75) !important;
+}
+
+================================
+
+librewolf-community.gitlab.io
+
+INVERT
+[src="/images/search.svg"]
+[src="/images/no-looking.png"]
+
+================================
+
+librewolf.com
+
+CSS
+.docs-container .max-w-screen-md .screenshot + .inner {
+    background-image: linear-gradient( 180deg, rgba(255, 255, 255, 0) 0%, rgba(26, 24, 26, var(--darkreader-bg--tw-bg-opacity)) 50% ) !important;
+}
+
+================================
+
+librivox.org
+
+INVERT
+.logo
+
+CSS
+.main-content-home,
+.homepage-main-wrap,
+.homepage-main-block p span {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: transparent !important;
+}
+.box_1 {
+    background-color: ${#eaefdf} !important;
+}
+.box_2 {
+    background-color: ${#e0eef1} !important;
+}
+.post-wrap,
+.page-wrap {
+    background-color: ${#f8f8f5} !important;
+}
+.statistics-wrap {
+    background-color: unset !important;
+}
+
+================================
+
+licensing.biz
+
+INVERT
+.logo
+
+================================
+
+lichess.org
+
+CSS
+.time {
+    z-index: 0 !important;
+}
+
+IGNORE INLINE STYLE
+cg-container > svg > line
+
+IGNORE IMAGE ANALYSIS
+.is2d .bishop.black
+.is2d .king.black
+.is2d .knight.black
+.is2d .pawn.black
+.is2d .queen.black
+.is2d .rook.black
+.brown .is2d cg-board
+
+================================
+
+life360.com
+
+INVERT
+.site-header .header-brand img
+
+================================
+
+lifelock.com
+
+INVERT
+.c-topnav__logo-link
+
+================================
+
+lightning.force.com
+*.lightning.force.com
+
+INVERT
+.chart
+.legend
+
+CSS
+.slds-brand-band,
+.slds-brand-band::after,
+.slds-brand-band_cover,
+.slds-brand-band_medium,
+.slds-page-header,
+.slds-utility-bar,
+.slds-tabs_card,
+.slds-card-wrapper,
+.slds-grid,
+.slds-clearfix {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.slds-card {
+    background-color: ${rgb(201, 201, 201)} !important;
+}
+.slds-button_neutral,
+.slds-button--neutral {
+    color: ${rgb(1, 118, 211)} !important;
+}
+
+================================
+
+lightningmaps.org
+
+INVERT
+.bo_map_realtime
+.live_ctrl > img
+.tiles_radar
+
+================================
+
+lingvoforum.net
+
+INVERT
+div#header
+div#header img.avatar
+span.topslice
+span.botslice
+
+CSS
+body {
+    background-image: none !important;
+}
+div#header {
+    color: black !important;
+}
+div#header a:link,
+div#header a:visited {
+    color: black !important;
+}
+
+================================
+
+link.springer.com
+
+INVERT
+.c-header__brand
+img[src$="logo_high_res.png"]
+
+================================
+
+linkedin.com
+
+INVERT
+div.artdeco-carousel__item-container img.align-items-center
+svg[role="progressbar"]
+
+CSS
+:root {
+    --color-text-low-emphasis: ${rgba(0,0,0,0.6)};
+}
+.js-job-card-company-logo {
+    background-blend-mode: color;
+    background-color: rgba(255, 255, 255, 0.20);
+}
+.global-footer-compact__linkedin-logo,
+li-icon[type="linkedin-logo"],
+.bug-text-color {
+    fill: ${black} !important;
+}
+.pds-ge-entry-card__card {
+    background: linear-gradient(to bottom, var(--color-action, var(--blue-70, #0073b1)), var(--color-action, var(--blue-70, #0073b1)) 4px, var(--darkreader-neutral-background, #fff) 4px, var(--darkreader-neutral-background, #fff)) !important;
+}
+.vjs-load-progress {
+    background-color: hsla(0,0%,100%,.3) !important;
+}
+.vjs-play-progress,
+.vjs-play-progress::before,
+.vjs-volume-level::before,
+.vjs-volume-level {
+    background-color: #fff !important;
+}
+.vjs-volume-bar {
+    background-color: hsla(0,0%,100%,.4) !important;
+}
+img[class*="ghost-"],
+div[class*="ghost-"] {
+    background-size: 100% 100% !important;
+}
+.artdeco-pill {
+    background-color: ${#ccc} !important;
+}
+img {
+    background-color: transparent !important;
+}
+img[src*="logo"] {
+    filter: brightness(75%);
+}
+.card-layout {
+    background-color: var(---darkreader-neutral-background);
+}
+.member-analytics-addon-insight-v2 {
+    background: var(--darkreader-bg--voyager-color-background-brand-accent-1-tint) !important;
+}
+.comments-highlighted-animation {
+    animation: transitionHighlightedBackground 1s backwards !important;
+}
+.highcharts-background {
+    fill: transparent !important;
+}
+
+================================
+
+linode.com
+
+INVERT
+.c-identity__image
+
+CSS
+.o-form__input {
+    background-color: rgb(41, 44, 46) !important;
+    border-color: rgb(232, 230, 227) !important;
+    color: rgb(232, 230, 227) !important;
+}
+.o-form__input:hover {
+    background: transparent !important;
+}
+.o-form__icon::before {
+    color: rgb(232, 230, 227) !important;
+}
+.o-form__input::placeholder {
+    color: rgb(232, 230, 227) !important;
+}
+.o-button,
+o-button--secondary {
+    background-color: rgb(41, 44, 46) !important;
+    border-color: rgb(232, 230, 227) !important;
+    color: rgb(232, 230, 227) !important;
+}
+.o-button:hover {
+    background: transparent !important;
+}
+
+================================
+
+linotype.com
+
+INVERT
+#logo
+
+================================
+
+linustechtips.com
+
+INVERT
+.ipsMenu
+
+CSS
+:root {
+    --darkreader-bg--badge--background: ${white} linear-gradient(rgba(0,0,0,0.9), rgba(0,0,0,0.9)) !important;
+}
+.ipsHovercard {
+    background-color: ${#fff} !important;
+}
+
+================================
+
+linux-hardware.org
+
+CSS
+#ezcGraphChart > path:first-of-type {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+linuxcollections.com
+
+INVERT
+html
+body
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+linuxfoundation.org
+
+INVERT
+.logo img
+
+================================
+
+linuxgrandma.blogspot.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+linuxhowtos.org
+
+CSS
+#background {
+    visibility: hidden !important;
+}
+#mc {
+    background-blend-mode: difference !important;
+    background-color: ${#555} !important;
+}
+#leftcontent {
+    background-image: none !important;
+}
+.shadr,
+.shadb,
+.shadt {
+    visibility: hidden !important;
+}
+
+================================
+
+linuxuprising.com
+
+INVERT
+.logo
+
+================================
+
+liqpay.ua
+
+INVERT
+div.qrcode > canvas
+
+================================
+
+liquor.com
+
+INVERT
+svg.icon.icon-logo
+
+================================
+
+lirc.org
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+lists.gnu.org
+
+CSS
+a:visited {
+    color: ${purple} !important;
+}
+
+================================
+
+literia.pl
+
+INVERT
+.icon-svg-pinterest
+.icons-icon-facebook
+.sec-logo
+.slick-arrow
+a::after
+a#logo
+span.as-label::before
+img[alt="ringier axel springer"]
+
+================================
+
+live.myvrspot.com
+
+INVERT
+.img-logo
+
+CSS
+.wrap {
+    background: var(--darkreader-neutral-background);
+}
+
+================================
+
+liveagent.com
+
+INVERT
+.Header__logo
+
+================================
+
+livemint.com
+
+INVERT
+div.icoMenu
+a.icoSearch.iconSprite
+a.icoBell.iconSprite
+a.icoBookmark2.iconSprite
+a.icoBookmark3.iconSprite
+a.icoTwit.iconSprite
+div.icoShare.iconSprite
+
+================================
+
+livetv.sx
+
+CSS
+table[background="//cdn.livetv869.me/img/vc.gif"],
+td[background^="//cdn.livetv869.me/img/v"],
+td[background="//cdn.livetv869.me/img/h2_bg.gif"],
+td[background="//cdn.livetv869.me/img/l_bg.gif"] {
+    background-image: none !important;
+}
+a.menu {
+    color: black !important;
+}
+
+================================
+
+liveuamap.com
+
+INVERT
+.comment-link::after
+.leaflet-pane > .leaflet-layer
+.logo
+.top-bright > label::after
+
+CSS
+.head-news {
+    background-image: none !important;
+}
+
+================================
+
+lk.teboil.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+lkml.org
+
+INVERT
+img[src*="corner"]
+
+CSS
+body {
+    background-image: none !important;
+}
+td.c {
+    color: ${white} !important;
+}
+pre[itemprop="articleBody"] a {
+    color: ${lightblue};
+}
+
+================================
+
+llvm.org
+*.llvm.org
+
+CSS
+header,
+.www_sectiontitle,
+.www_sidebar {
+    background: none !important;
+}
+
+================================
+
+loepenshop.com
+bonjourfoto.nl
+
+CSS
+body {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+div.art-Header-jpeg
+
+================================
+
+login-widget.privatbank.ua
+
+CSS
+div[class*="qrContainer"] > div > div {
+    background-color: white !important;
+}
+
+================================
+
+login.assetpanda.com
+
+CSS
+tr,
+.main-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+login.docker.com
+
+INVERT
+span[data-provider^="github"]
+
+CSS
+body {
+    --page-background-color: var(--darkreader-neutral-background) !important;
+}
+:root {
+    --font-default-color: var(--darkreader-neutral-text) !important;
+    --input-background-color: var(--darkreader-neutral-background) !important;
+    --input-text-color: var(--darkreader-neutral-text) !important;
+    --secondary-button-text-color: var(--darkreader-neutral-text) !important;
+    --title-font-color: var(--darkreader-neutral-text) !important;
+    --widget-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+login.flightaware.com
+
+INVERT
+img[alt="FlightAware Logo"]
+
+CSS
+.items-center > button,
+.items-center > a {
+    background-color: gray;
+}
+.items-center > button:hover,
+.items-center > a:hover {
+    background-color: lightgray;
+}
+.bg-white {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+login.live.com
+
+INVERT
+div[id$="Proofs"] .tile-img
+div.promoted-fed-cred-content > div > div > div > div > img
+div#credentialList.form-group > div > div > div > div > div > img
+div.pagination-view.has-identity-banner.animate.slide-in-next > div > div > div > img
+span.help-button > img
+button.backButton > img
+img[data-testid="backgroundLogo"]
+#outer img
+
+CSS
+[data-testid="backgroundImage"] {
+    background-image: none !important;
+}
+
+================================
+
+login.microsoftonline.com
+
+INVERT
+div#backgroundImage
+
+================================
+
+login.yahoo.com
+
+INVERT
+.social-login
+label[for=persistent]::before
+#password-toggle-button
+
+IGNORE IMAGE ANALYSIS
+.social-login
+
+================================
+
+logitech.com
+
+INVERT
+.locale-selector-bg
+
+================================
+
+logowanie.edukacja.olsztyn.eu
+
+INVERT
+img[alt="Nagłówek strony"]
+img#logo
+img[src="/Resources/wylogowano-plansza.jpg"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+lol.fandom.com
+
+CSS
+.bracket-line:not(.l-down)::after,
+.bracket-line::before,
+.bracket-spacer.horizontal::before {
+    border-width: 0 0 2px 0 !important;
+}
+.bracket-line.z-down::after {
+    border-width: 0 0 2px 2px !important;
+}
+.bracket-line.z-down::before {
+    border-width: 2px 2px 0 0 !important;
+}
+.bracket-line.z-up::before {
+    border-width: 0 2px 2px 0 !important;
+}
+.bracket-line.z-up::after {
+    border-width: 2px 0 0 2px !important;
+}
+
+================================
+
+louis.*
+louis-moto.*
+
+CSS
+.product-image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+lovekrakow.pl
+
+INVERT
+.brand
+
+================================
+
+lowendtalk.com
+
+INVERT
+.MeMenu > :last-child
+.SpBookmarks
+
+================================
+
+lowes.com
+
+CSS
+img {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+lrt.lt
+
+INVERT
+img[src*="/images/logo/logo-"]
+
+================================
+
+lsa.umich.edu
+
+IGNORE IMAGE ANALYSIS
+.header-wrap
+.giving-wrap
+
+================================
+
+lunapic.com
+
+INVERT
+.toolbar-button
+.square-toolbar-button
+
+IGNORE INLINE STYLE
+.color-well-color
+
+================================
+
+luogu.com.cn
+
+IGNORE INLINE STYLE
+.fa-group
+.fa-secondary
+.fa-primary
+.lfe-caption tag status-name
+.data-v-386007e1
+
+================================
+
+lux.camera
+
+CSS
+.u-content-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+lyx.org
+
+CSS
+body,
+#wrapper {
+    background-image: none !important;
+}
+#col-right {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+m.dianping.com
+
+INVERT
+.flash-screen
+.header-download-img
+
+================================
+
+m.genk.vn
+
+CSS
+.news .li {
+    background-image: none !important;
+}
+
+================================
+
+m.motonet.fi
+
+CSS
+form#haku input[type="text"],
+#select_my_motonet {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+m.slashdot.org
+
+CSS
+.slashbar,
+.story-prop,
+#discussion,
+#filler {
+    background-image: none !important;
+}
+
+================================
+
+mabi.tmpinc.io/numbers/
+
+INVERT
+button
+img.lock
+div.line
+
+CSS
+.bit.blue,
+.bit.red,
+.bit.green {
+    border-bottom: 3px solid var(--bit-color) !important;
+}
+.bit.gray {
+    background-color: ${lightgray} !important;
+}
+label:first-of-type {
+    border-left: 1px solid var(--darkreader-neutral-text) !important;
+}
+label {
+    border-bottom: 1px solid var(--darkreader-neutral-text) !important;
+    border-right: 1px solid var(--darkreader-neutral-text) !important;
+    border-top: 1px solid var(--darkreader-neutral-text) !important;
+}
+.demo {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+:root {
+    --darkreader-border--bit-color: var(--darkreader-neutral-text);
+}
+
+================================
+
+machinelearningmastery.com
+
+INVERT
+img.size-full.wp-image-7676
+
+================================
+
+macrumors.com
+
+CSS
+body,
+.js-content,
+.widget--3ewetJyi {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.textRow--3IWlPgCD {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+madshi.net
+
+CSS
+body,
+tr,
+td {
+    background-image: none !important;
+}
+
+================================
+
+mafreebox.freebox.fr
+
+CSS
+* {
+    filter: none !important;
+}
+.desktop-icon-outer {
+    color: #fff !important;
+}
+body {
+    background-image: linear-gradient(rgb(14 14 14 / 50%), rgb(40 40 40 / 50%)), url(../resources/images/fbx/bg_freeboxos.svg);
+}
+.setting-list-app .setting-app .setting-app-img,
+.file-icon-inode_directory,
+.x-tree-icon {
+    opacity: 1 !important;
+}
+.freeboxos-southbar .btn-start .x-btn-button {
+    background-color: #fff !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.freeboxos-southbar .btn-start .x-btn-button
+body
+
+================================
+
+magazine-hd.com
+
+INVERT
+div#header-logo-image img.custom-logo
+
+================================
+
+magazine.skyeng.ru
+
+INVERT
+.header__logo__img
+
+================================
+
+magazynbieganie.pl
+
+INVERT
+.logo-box
+
+================================
+
+magic.freizeitspieler.de
+
+INVERT
+img[src="pics/MtG-Freizeitspieler.gif"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+magister.net
+
+INVERT
+.bottom > img
+
+CSS
+.splash-container {
+    z-index: 0 !important;
+}
+.cijfers-k-grid.k-grid .grade.empty {
+    background-color: ${#cfcfcf} !important;
+    background-image: none !important;
+}
+
+================================
+
+magit.vc
+docs.magit.vc
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+mail.eni.it/owa
+
+IGNORE IMAGE ANALYSIS
+.image-font-png
+.image-font_size-png
+.image-bold-png
+.image-italic-png
+.image-underline-png
+.image-backcolor-png
+.image-forecolor-png
+.image-insertunorderedlist-png
+.image-insertorderedlist-png
+.image-outdent-png
+.image-indent-png
+.image-justifyleft-png
+.image-justifycenter-png
+.image-justifyright-png
+.image-createlink-png
+.image-unlink-png
+.image-superscript-png
+.image-subscript-png
+.image-strikethrough-png
+.image-alttext-png
+.image-blockdirltr-png
+.image-blockdirrtl-png
+.image-undo-png
+.image-redo-png
+.image-removeformat-png
+.image-table_icon-png
+.image-insertpicture-png
+.image-emoji-png
+.image-format-png
+.image-c_word-png
+.image-c_powerpoint-png
+.image-c_excel-png
+
+================================
+
+mail.google.com
+
+INVERT
+.asor_t0
+.asor_i1 > img
+.asor_i4
+.d-Na-Jo.d-Na-N-ax3
+.RK-QJ-Jk
+.RK-Mo.RK-Qq-LF
+#ita-st-id-cs
+.d-Na-N-M7-JX.d-Na-J3
+.ita-icon-0
+.ita-icon-1
+img[src$="profile_mask2.png"]
+.rY>.sa
+.buh
+.asor
+.mixmax-flyout__wrapper
+div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
+form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
+img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"]
+div[style$="gm_add_black_24dp.png)"]
+.WR .z0>.L3::before
+.WR.anZ .z0>.L3::before
+
+CSS
+@media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {
+    .buk {
+        background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_default_v1_2x.png) !important;
+    }
+    .bui {
+        background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_comfortable_v1_2x.png) !important;
+    }
+    .buj {
+        background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_2x.png) !important;
+    }
+}
+.buk {
+    background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_default_v1_1x.png) !important;
+}
+.bui {
+    background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_comfortable_v1_1x.png) !important;
+}
+.buj {
+    background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_1x.png) !important;
+}
+div[class*="bym"][role="navigation"],
+.afC,
+.agJ {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.agJ:hover,
+.ag5 {
+    background-color: ${#E8E6E5} !important;
+}
+.agJ.bjE {
+    background-color: ${#E3E1E0} !important;
+}
+.ain .TO,
+.TO.ol {
+    background-color: rgba(255,255,255,0.05) !important;
+}
+.agh,
+.afV,
+.afA,
+.bbV {
+    background-color: transparent !important;
+}
+.aRg,
+.aRj {
+    color: ${white} !important;
+}
+.gb_3e {
+    color: ${white} !important;
+}
+table {
+    color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+.at
+.au
+.av
+.qj
+.hU.hM
+.hV.hM
+.ajZ-Jt
+.aH5
+.JA-Kn-Jr-Kw-Jt
+
+IGNORE IMAGE ANALYSIS
+.WR .z0 > .L3::before
+.WR.anZ .z0>.L3::before
+.d-Na-J3
+.aBS .d-Na-JX-I .d-Na-J3
+
+================================
+
+mail.jwpub.org/owa
+
+IGNORE IMAGE ANALYSIS
+.image-font-png
+.image-font_size-png
+.image-bold-png
+.image-italic-png
+.image-underline-png
+.image-backcolor-png
+.image-forecolor-png
+.image-insertunorderedlist-png
+.image-insertorderedlist-png
+.image-outdent-png
+.image-indent-png
+.image-justifyleft-png
+.image-justifycenter-png
+.image-justifyright-png
+.image-createlink-png
+.image-unlink-png
+.image-superscript-png
+.image-subscript-png
+.image-strikethrough-png
+.image-alttext-png
+.image-blockdirltr-png
+.image-blockdirrtl-png
+.image-undo-png
+.image-redo-png
+.image-removeformat-png
+.image-table_icon-png
+.image-insertpicture-png
+.image-emoji-png
+.image-format-png
+
+================================
+
+mail.qq.com
+
+INVERT
+.header_logo
+.imglogo
+.listbg
+.navbar
+.topline
+.topbg
+.todaybar_ad_bg
+.navbottom
+.search_subject .smartsearch
+#searchIcon
+
+CSS
+.fdbody,
+.tipstitle {
+    background-color: ${#9bbb59} !important;
+}
+.fdbody {
+    border-left-color: var(--darkreader-neutral-background) !important;
+}
+.readmailinfo,
+.settingtable,
+.tabtitle td.selected,
+.biginfo,
+.tipstitle,
+.colorsure {
+    background-color: ${#ebf4d8} !important;
+}
+.toolbgline,
+.tabtitle td,
+.readmailinfo,
+.settingtd,
+.addr_line,
+.filtertd1,
+.bartools {
+    border-bottom-color: ${#87a34d} !important;
+}
+.toolbg,
+.toolbg1,
+.tabtitle,
+.addrsort {
+    background-color: ${#bed393};
+}
+.attbg {
+    background-color: ${#dceac0} !important;
+}
+body[module="qmReadMail"] {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-color) !important;
+}
+.selbar_bt {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+    border-top-color: var(--darkreader-neutral-background) !important;
+}
+table.O2 td {
+    border-bottom-color: ${#c1c8d2} !important;
+}
+body[accesskey],
+.cpright {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.B,
+.nomail,
+.colortitle {
+    background-color: ${#a9b3b6} !important;
+}
+.settingTitle .selected {
+    color: ${#ebf4d8} !important;
+}
+
+================================
+
+mail.snopes.com
+
+CSS
+:root {
+    --wt-text-on-background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+mail.tutanota.com
+
+CSS
+div.mb > div > svg > path {
+    fill: black !important;
+}
+
+================================
+
+mailbox.org
+
+CSS
+body.bg-blog {
+    background-image: none !important;
+}
+.common .mod_article > .inside {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.io-ox-sidepopup
+
+================================
+
+make.com
+*.make.com
+
+CSS
+.switch.active::after {
+    color: var(--darkreader-bg--white) !important;
+}
+.switch:not(.active)::before {
+    color: var(--darkreader-bg--white) !important;
+}
+.switch:not(.active)::after {
+    color: var(--darkreader-text--white) !important;
+}
+
+================================
+
+maketext.io
+
+CSS
+#landing {
+    background-image: none !important;
+}
+
+================================
+
+makeuseof.com
+
+IGNORE IMAGE ANALYSIS
+.header-logo
+
+================================
+
+maltapost.com
+
+CSS
+.multi-steps > li.is-active::before {
+    background-color: gray !important;
+}
+
+================================
+
+manage.buyvm.net
+
+INVERT
+.legend-container
+
+================================
+
+manim.community
+
+INVERT
+svg.manim-banner
+
+================================
+
+manjaro.org
+
+INVERT
+img[alt="manjaro logo"]
+
+CSS
+.bg-teal-accent-400,
+.bg-teal-accent-400 path {
+    background-color: ${rgb(29,233,182)} !important;
+    fill: ${rgb(29,233,182)} !important;
+}
+
+IGNORE INLINE STYLE
+.bg-teal-accent-400 path
+
+================================
+
+manualslib.com
+
+IGNORE IMAGE ANALYSIS
+div.pdf
+
+================================
+
+manytoon.com
+
+CSS
+.profile-manga,
+.c-breadcrumb-wrapper {
+    background-image: none !important;
+}
+
+================================
+
+map.qq.com
+
+INVERT
+#FullScreen
+#Logo
+#Map
+.MenuPanelCheckbox
+.MenuPanelContent
+.nextStep
+.prevStep
+.textInput
+.titleText
+.traffic_next
+.traffic_rightbg_b2
+.traffic_rightbg_m
+.traffic_rightbg_m3
+.traffic_rightbg_t2
+
+================================
+
+mapa-turystyczna.pl
+
+INVERT
+.ts-map svg
+
+================================
+
+maps.metager.de
+
+INVERT
+.map canvas
+
+================================
+
+mapy.cz
+*.mapy.cz
+
+INVERT
+img[src*="mapserver.mapy.cz"]:not([src*="bing"])
+.icon polygon
+
+CSS
+.marker span.text {
+    color: black !important;
+}
+
+================================
+
+marginalrevolution.com
+
+INVERT
+.logo-mobile
+.logo-desktop
+img[src$="mru-logo-450.png"]
+
+CSS
+nav {
+    background-color: #288d73 !important;
+}
+
+================================
+
+mariadb.org
+
+INVERT
+.featured-header-image
+
+================================
+
+marinij.com
+
+INVERT
+.custom-logo.logo > a > img
+
+================================
+
+market.yandex.*
+
+INVERT
+ymaps[class$="main-engine-container"] > canvas
+ymaps[class$="marker"] > div > div > div
+
+CSS
+a[data-zone-name="offerLink"]:has(img) {
+    background-color: #fff !important;
+}
+[data-baobab-name="picture"],
+[data-zone-name="picture"] > div > div,
+[data-zone-name="picture"] img {
+    mix-blend-mode: unset !important;
+}
+[data-zone-name="offer"] > div > div:nth-child(1) > div:nth-child(1) {
+    background-color: white;
+}
+[data-zone-name="cartButton"] button {
+    background-color: rgb(136, 109, 0) !important;
+}
+
+IGNORE INLINE STYLE
+[data-zone-name="offer"] > div > div:nth-child(1) > div:nth-child(1)
+
+================================
+
+marketmarketmarket.com
+marketstudios.com
+
+INVERT
+img.header__heading-logo
+button.is-active
+
+CSS
+:root {
+    --gradient-background: rgb(24, 26, 27) !important;
+}
+sticky-header.header-wrapper {
+    background-color: rgb(24, 26, 27) !important;
+}
+::placeholder {
+    color: transparent !important;
+}
+
+================================
+
+marketplace.visualstudio.com
+
+CSS
+.ux-updated-date {
+    color: ${rgb(55, 255, 0)} !important;
+}
+.ms-Grid-row {
+    color: ${rgba(0, 0, 0, .8)} !important;
+}
+
+================================
+
+markfreeman.ca
+
+INVERT
+.elementor-widget-container > img
+
+================================
+
+markmcgranaghan.com
+
+CSS
+body {
+    background-color: transparent !important;
+}
+
+================================
+
+marktplaats.nl
+
+INVERT
+.mp-Header-logo
+.mp-svg-messages
+.mp-svg-notification
+.mp-svg-profile
+.svg-icon-block
+
+================================
+
+marquette.edu
+
+CSS
+.h1 {
+    -webkit-text-fill-color: unset !important;
+    background-color: unset !important;
+    background-image: unset !important;
+    color: var(--darkreader-text--primary_blue, var(--darkreader-text-000000)) !important;
+}
+
+================================
+
+mastarti.com
+streamguard.cc
+
+INVERT
+.fp-play-icon div
+.fp-pause-icon .fp-pause-block div
+.fp-volumebar em.fp-color
+.fp-fullscreen-line
+.fp-fullscreen-dot
+
+================================
+
+math.semestr.ru
+
+INVERT
+.img-online
+
+================================
+
+math.tamu.edu
+
+INVERT
+div[align="center"] > p + p > img
+
+================================
+
+mathsathome.com
+
+INVERT
+article p img
+
+================================
+
+mathsisfun.com
+
+CSS
+#searchFld {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: black !important;
+}
+#searchBtn {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: black !important;
+}
+#content h1 {
+    color: var(--darkreader-neutral-text) !important;
+}
+#hdr {
+    opacity: 0.2;
+}
+#menuWide li {
+    background-color: rgb(64, 99, 255) !important;
+    color: white !important;
+}
+#menuWide li:hover {
+    background-color: rgb(18, 35, 112) !important;
+}
+
+================================
+
+mathsolver.microsoft.com
+
+INVERT
+img.light
+
+CSS
+.page-header {
+    background: ${#e4e6e7} !important;
+}
+.page-layout-container {
+    background: ${#d1e1e1} !important;
+}
+.t1 {
+    color: ${#4f4941} !important;
+}
+
+================================
+
+matomo.org
+
+INVERT
+img[alt*="WordPress"]
+img[src*="Mailfence"]
+img[src*="sampling"]
+img[src*="logo"]
+img.mega-menu-logo
+
+CSS
+select,
+.elementor-text-editor,
+.elementor-text-editor *,
+.elementor-blockquote *,
+.elementor-testimonial *,
+.elementor-price-table * {
+    color: var(--darkreader-neutral-text) !important;
+}
+.elementor-card-shadow-yes .elementor-post__card:hover {
+    box-shadow: rgb(76 75 75 / 42%) 0px 0px 30px 0px;
+}
+.elementor-card-shadow-yes .elementor-post__card {
+    box-shadow: rgb(0 0 0 / 23%) 0px 0px 10px 0px;
+}
+
+================================
+
+matrix.org
+
+INVERT
+.mxnavbar__logo
+.mxnavsection__icon
+.mxgrid__item__bg__img
+.mxblock__explore__item__img
+a[aria-label="matrix live  permalink"] > svg
+a > svg
+
+================================
+
+matrix.to
+
+INVERT
+div.footer > p > img
+
+================================
+
+matsci.org
+
+INVERT
+.d-header #site-logo
+
+CSS
+.category-logo.aspect-image img {
+    background-color: white !important;
+}
+
+================================
+
+mattermost.com
+
+INVERT
+.site-header__col--logo
+
+================================
+
+matters.news
+
+INVERT
+.splash-screen .icon
+.logo .icon
+
+CSS
+section[class$="container"][style^="background-image"] {
+    background-image: none !important;
+}
+
+================================
+
+maxar.com
+
+INVERT
+#siteSearch--desktop img:first-child
+
+CSS
+.BigHeroSingleComponent .background {
+    z-index: 0 !important;
+}
+
+================================
+
+mayoclinic.org
+
+INVERT
+.mc-logo
+.logo > a > img[alt="Mayo Clinic"]
+img[src="/-/media/images/mayologo.png"]
+img[src="/styles/img/gbs/logo-mayoclinic-mobile.png"]
+
+CSS
+ul#nav.nav > li.no-image > a,
+ul#nav.nav > li.current > a {
+    background-image: url("/UniversalNav/Styles/img/sprite-globalnavarrows.png") !important;
+}
+
+================================
+
+mbank.superksiegowa.pl
+
+INVERT
+.nav-item img
+
+================================
+
+mcbsys.com
+
+INVERT
+.site-branding
+.icon-image
+
+================================
+
+mcdonalds.com
+
+INVERT
+.cmp-global-header__logo
+
+================================
+
+mechanicalkeyboards.com
+
+INVERT
+.brands__items img
+img.header__heading-logo
+
+CSS
+::placeholder {
+    opacity: 0 !important;
+}
+.predictive-search__result-group,
+.header__mega-menu,
+.header__menu-item {
+    background: var(--darkreader-neutral-background) !important;
+}
+.cards-grid__heading,
+.cards-grid__subheading {
+    color: black !important;
+}
+.collapsible-content__digit,
+.collapsible-content__icon {
+    background-color: ${lightgray} !important;
+}
+.collapsible-content__item {
+    border-bottom: .2rem solid ${lightgray} !important;
+}
+.collapsible-content__item:first-child {
+    border-top: .2rem solid ${lightgray} !important;
+}
+
+================================
+
+mediabiasfactcheck.com
+
+INVERT
+span.slicknav_icon
+
+================================
+
+mediaexpert.pl
+
+INVERT
+.euronics-logo
+.sg-kategory-box-txt
+.sg-new-btn-white
+.sg_kat_txt
+img[src*="kafelki_do_bran"]
+svg > path[d^="M244.122 17.1023C244.122"]
+
+CSS
+.product-image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+mediaite.com
+
+INVERT
+.c-menu-btn__line
+
+================================
+
+medianauka.pl
+
+INVERT
+img[src*="wzory"]
+
+================================
+
+mediawiki.org
+*.mediawiki.org
+wikibooks.org
+*.wikibooks.org
+wikidata.org
+*.wikidata.org
+wikiless.org
+*.wikiless.org
+wikimedia.org
+*.wikimedia.org
+wikimediafoundation.org
+*.wikimediafoundation.org
+wikinews.org
+*.wikinews.org
+wikipedia.org
+*.wikipedia.org
+wikiquote.org
+*.wikiquote.org
+wikisource.org
+*.wikisource.org
+wikiversity.org
+*.wikiversity.org
+wikivoyage.org
+*.wikivoyage.org
+wikiwand.com
+*.wikiwand.com
+wiktionary.org
+*.wiktionary.org
+
+INVERT
+#main_menu > li:not(.lang_btn) > img.logo_img ~ i
+#p-logo-text
+.article_btn .drop_down li a > i
+.bookend
+.cdx-text-input__icon.cdx-text-input__start-icon
+.central-featured-logo-text
+.central-textlogo__image
+.feedback_btn .drop_down li a > i
+.licensetpl td[style^="width"]
+.locmap .pl
+.locmap .pr
+.logo-container
+.logo:not(td)
+.main-footer-menuToggle
+.mf-icon-close-gray
+.mf-icon-expand
+.mf-icon-expand-invert
+.minerva-footer-logo img
+.music-symbol img
+.mw-ext-score
+.mw-hiero-outer.mw-hiero-table
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.mw-logo-tagline
+.mw-logo-wordmark
+.mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
+.mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
+.mw-ui-icon-wikimedia-expand
+.mw-wiki-logo
+.mwe-math-fallback-image-display
+.mwe-math-fallback-image-inline
+.nav-logo
+.svg-Wikimedia-logo_black
+.title_icon
+.toc-title-icon
+.tool.tool-button[src$="background-image:"]
+.wd-mp-headerimage
+.zh-glyph img
+body > .oo-ui-windowManager .vega .marks
+div.post-content.footer-content > h2 > img
+header .branding-box > a > span > img
+img.graphite-graph
+img.immediate:not(.ntmb)
+img.logo_img
+img[alt="Video Camera Icon.svg"]
+img[alt="audio speaker icon"]
+img[alt="logo Wikisource"]
+img[src*="Wiktionary-logo"]
+img[src="images/black.png"]
+img[src*="Wikipedia-logo-textonly.svg"]
+img[src*="Unbalanced_scales.svg"]
+img[src*="ignature"][src*=".svg"]
+img[src*="ignature"][src*=".png"]
+img[src*="Emblem_of_Iran.svg"]
+img[src*="Share_alt_square_font_awesome.svg"]
+img[src*="Justice_scale_silhouette%2C_medium.svg"]
+img[src*="Twemoji_1f464.svg"]
+img[src*="Mp3.svg"]
+img[src*="Globe_eye_icon.png"]
+img[src*="Octicons-globe.svg"]
+img[src*="Stylized_eye.svg"]
+img[src*="AMD_Radeon_logo_2019.png"]
+img[src*="AMD_Radeon_RX_6000_series_wordmark.png"]
+img[src*="AMD_Radeon_RX_7000_Series_Logo.png"]
+img[src*="Creative_Assembly_logo.png"]
+img[src*="poweredby_mediawiki.svg"]
+img[src*="Greek_lc"][src*=".svg"]
+img[src*="Greek_uc"][src*=".svg"]
+img[src*="uc_lc"][src*=".svg"]
+img[src*="Greek_letter"][src*="sans.svg"]
+img[src*="Psi2.svg"]
+li.menu-tooltip:not(.lang_btn)
+#vector-main-menu-dropdown .vector-icon
+#vector-page-tools-dropdown-label::after
+.vector-user-links-main .vector-icon
+#vector-user-links-dropdown .vector-icon
+#vector-user-links-dropdown .vector-icon::after
+#vector-user-links-dropdown-label::after
+.vector-menu-content .vector-icon
+td.icon
+.minerva-icon
+.mw-mmv-icon
+.cdx-button__icon
+.leaflet-top
+.leaflet-bottom
+.mw-kartographer-fullScreen
+.mw-kartographer-attribution
+img[src*="GNUTLS-logo.svg"]
+img[src*="Zelda_2017.svg"]
+img[src*="Gnomelogo.svg"]
+img[src*="Plasma_coloured_logo.svg"]
+img[src*="Coreboot_full.svg"]
+img[src*="Libreboot_logo.svg"]
+img[src*="Meson_%28software%29_logo_2019.svg"]
+img[src*="Freebsd_logo.svg"]
+img[src*="DragonFly_BSD_Logo.svg"]
+img[src*="Fallout_logo.svg"]
+img[src*="PlayStation_4_logo_and_wordmark.svg"]
+img[src*="PlayStation_logo_and_wordmark.svg"]
+img[src*="Xbox_logo_%282019%29.svg"]
+#p-twinkle-dropdown-label::after
+#p-lang-btn-label::after
+img[src*="Systemd-logo.svg"]
+img[src*="PulseAudio-logo.png"]
+img[src*="Pipewire_logo.svg"]
+img[src*="Metal_Gear_franchise_logo.svg"]
+img[src*="Persona_PSP_logo.svg"]
+.popups-icon--settings
+img[src*="Parteiadler_Nationalsozialistische_Deutsche_Arbeiterpartei"]
+img[src*="Totenkopf.svg"]:not(img[src*="KG54_Totenkopf.svg"])
+img[src*="Wolfsangel"]
+img[src*="Nazi_Odal_rune.svg"]
+img[src*="Schutzstaffel_SS.svg"]
+img[src*="Algiz.svg"]
+img[src*="Celtic-style_crossed_circle.svg"]
+img[src*="Sun_Cross_Swastika.svg"]
+img[src*="Black_Sun"]
+.mw-mmv-restriction-nazi
+img[src*="Victoria%E2%80%99s_Secret_%28logo%2C_2021%29.svg"]
+img[src*="VS_%26_Co_%28logo%29.svg"]
+img[src*="Industry5.svg"]
+img[src*="Hame%C3%A7on.svg"]
+img[src*="Reichsadler_Deutsches_Reich"]
+.skin-invert-image img
+.skin-invert img
+img[src*="Airport_Immigration.svg"]
+img[src*="Croix_de_Feu.svg"]
+img[src*="Sig_runes.svg"]
+img[src*="Runic_letter_"]:not(.skin-invert-image img)
+img[src*="Tiwaz_rune.svg"]
+img[src*="Heilszeichen.svg"]
+img[src*="Armanenrunor_i_cirkel_med_siffror_vector.svg"]
+img[src*="White_Pride_World_Wide_-_Stormfront_hate_symbol.svg"]
+img[src*="Earth_symbol"]
+img[src*="Broken_crossed_circle.svg"]
+img[src*="Southern_Cult_Solar_Cross.svg"]
+img[src*="Sun_cross.svg"]
+img[src*="Maru_juji.svg"]
+img[src*="Thule-Gesellschaft.svg"]
+img[src*="BlackSun.svg"]
+img[src*="Sampad.svg"]
+.mw-mmv-restriction-insignia
+img[src*="Yocto_Project_logo.svg"]
+img[src*="The_Pirate_Bay_logo.svg"]
+img[src*="President_of_India_Logo.png"]
+img[src*="mediawiki_compact.svg"]
+img[src*="Peace"][src*=".svg"]
+img[src*="peace"][src*=".svg"]
+img[src*="Pacyfa"][src*=".svg"]
+img[src*="U%2B262E.svg"]
+img[src*="Emojione_BW_262E.svg"]
+span.mw-no-invert:not(table.infobox span):not(figure span.legend-color):not(.mw-mmv-post-image span.legend-color)
+#vector-user-links-dropdown-label-sticky-header
+.vector-sticky-header-icons
+.vector-sticky-header-icon-start
+.mw-ui-icon-wikimedia-language
+.mw-interlanguage-selector::after
+.mw-ui-icon-wikimedia-listBullet
+
+CSS
+:root {
+    --background-color-interactive: ${#eaecf0} !important;
+    --border-color-subtle: ${#a2a9b1} !important;
+    --darkreader-border--border-color-base: ${#a2a9b1} !important;
+    --wikt-palette-cyan: ${#eaffff} !important;
+    --wikt-palette-lightyellow: ${#ffffe0} !important;
+}
+.mwe-popups-discreet > img,
+div .thumbimage[src$=".png"],
+div .thumbimage img[src$=".png"],
+.image-carousel .image-loaded {
+    background-color: white;
+}
+.mw-mmv-image .svg,
+.fullImageLink [src*=".svg"],
+a[href$=".svg"]:hover > img,
+a[href*=".gif"]:hover > img {
+    background-blend-mode: color;
+    background-color: rgba(255, 255, 255, 0.75) !important;
+}
+.diff-addedline .diffchange {
+    background-color: ${lightblue} !important;
+}
+.diff-deletedline .diffchange {
+    background-color: ${#feeec8} !important;
+}
+@keyframes unseen-fadeout-to-unread {
+    from {
+        background-color: ${#dce8ff} !important;
+    }
+    to {
+        background-color: ${#ffffff} !important;
+    }
+}
+@keyframes unseen-fadeout-to-read {
+    from {
+        background-color: ${#dce8ff} !important;
+    }
+    to {
+        background-color: ${#eaecf0} !important;
+    }
+}
+.main-top {
+    background: none !important;
+}
+ol.references li:target,
+sup.reference:target {
+    background-color: ${lightblue} !important;
+}
+.control-bar {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.k-player,
+body.mediawiki,
+#dialogEngineContainer #dialogEngineDialog {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.template-facttext {
+    background-color: ${#c8c6c3} !important;
+}
+#mw-page-base {
+    background-color: var(--darkreader-neutral-background);
+    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
+}
+body.skin--responsive,
+#menus-cover-background {
+    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
+}
+.vector-sticky-pinned-container::after {
+    background: linear-gradient(transparent, var(--darkreader-neutral-background)) !important;
+}
+[style*="background: rgb(221, 221, 255)"],
+[style*="background-color: rgb(221, 221, 255)"] {
+    background: ${rgb(221, 221, 255)} !important;
+}
+div.mw-warning-with-logexcerpt,
+div.mw-lag-warn-high,
+div.mw-cascadeprotectedwarning,
+div#mw-protect-cascadeon,
+div.titleblacklist-warning,
+div.locked-warning {
+    background-color: ${#ffa9a9} !important;
+    border-color: ${#ffa1a1} !important;
+}
+div.NavFrame div.NavHead {
+    background-image: none !important;
+}
+figure[typeof~="mw:File/Thumb"],
+figure[typeof~="mw:File/Thumb"] > figcaption,
+figure[typeof~="mw:File/Thumb"] > :not(figcaption) .mw-file-element,
+div.thumbinner,
+#filetoc,
+.mw_metadata td,
+div.flaggedrevs_short,
+.wbmi-entityview-captionsPanel,
+.page-actions-menu,
+.content .mw-image-border .mw-file-element,
+.mw-footer,
+.last-modified-bar,
+.minerva-footer-logo,
+.cdx-card,
+.cdx-thumbnail__placeholder {
+    border-color: var(--darkreader-border--border-color-base) !important;
+}
+.mw-parser-output .sidebar,
+.fileinfotpl-type-information tbody div {
+    background-color: var(--darkreader-bg--background-color-neutral-subtle) !important;
+}
+.sidebar-title-with-pretitle,
+.sidebar-below {
+    background: var(--darkreader-bg--background-color-interactive) !important;
+}
+table.layouttemplate {
+    border: var(--border-color-subtle) 2px solid !important;
+}
+.mwe-popups {
+    box-shadow: 0 30px 90px -20px rgba(0,0,0,0.3),0 0 0 1px var(--darkreader-border--border-color-base) !important;
+}
+.ext-discussiontools-init-targetcomment {
+    background-color: rgba(192,192,255,0.25) !important;
+}
+.mw-parser-output .ib-company-logo img {
+    background-color: transparent !important;
+}
+html[data-darkreader-scheme="dark"] img[src*="Eagle_with_fasces.svg"],
+html[data-darkreader-scheme="dark"] img[src*="wikimedia-button.svg"] {
+    filter: brightness(200%) !important;
+}
+.cdx-button:enabled.cdx-button--weight-quiet:hover {
+    background-color: ${#BBBBBB} !important;
+    mix-blend-mode: screen !important;
+}
+td.infobox-data span.legend-color[style*="background-color:##FFFFFF"] {
+    background-color: white !important;
+}
+
+IGNORE INLINE STYLE
+#on_image_elements span
+.legend-color:not(table.wikitable .legend-color)
+
+IGNORE IMAGE ANALYSIS
+.k-player .k-menu-bar li a
+.mf-icon-expand
+.mw-wiki-logo
+.toc-title-icon
+body:not(.ns-0):not(.ns-2):not(.ns-100) .gallerybox .thumb img
+
+================================
+
+medium.com
+
+INVERT
+.svgIcon
+.svgIcon-use
+a[href="/"]>svg
+div[role="separator"]
+
+================================
+
+medium.freecodecamp.org
+
+CSS
+span.markup--quote.markup--p-quote.is-other {
+    background-image: linear-gradient(rgba(14, 255, 167, 0.2), rgba(14, 255, 167, 0.2)) !important;
+}
+
+================================
+
+medrxiv.org
+
+INVERT
+.blood_logo
+.logo-img
+
+================================
+
+meduza.io
+
+CSS
+mark {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+meet.google.com
+
+IGNORE INLINE STYLE
+svg[preserveAspectRatio*="meet"] *
+
+================================
+
+meet.jit.si
+
+IGNORE INLINE STYLE
+.jitsi-icon *
+
+================================
+
+mega.nz
+
+INVERT
+a.fm-files-view-icon
+a.top-icon.menu
+div.checkdiv.megaapp-download.checkboxOff.switches
+div.fm-dialog-close.medium
+div.nw-tree-panel-arrows.icons-sprite
+i.small-icon.context
+i.small-icon.dialog-sprite.arrows-to-bottom
+i.small-icon.dialog-sprite.arrows-to-top
+i.small-icon.download-as-zip
+i.small-icon.icons-sprite.tiny-grey-tick
+i.small-icon.import-to-cloud
+i.top-menu-icon.menus-sprite
+i.transfer-progress-icon
+span.top-icon.language
+
+CSS
+.grid-wrapper {
+    outline-color: var(--darkreader-bg--surface-main);
+}
+.topbar-searcher {
+    background: var(--darkreader-bg--surface-grey-2) !important;
+}
+div.mega-dialog.dialog-template-action.two-factor-dialog.verify-two-factor-login {
+    background-color: var(--darkreader-bg--surface-main) !important;
+}
+#msgDialog {
+    background: var(--darkreader-bg--surface-grey-2) !important;
+}
+
+================================
+
+meijer.com
+
+CSS
+[class*="bv-rnr_"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+meituan.com
+
+INVERT
+.dpLogo
+.header-title
+.site-logo
+
+================================
+
+memtest.org
+
+INVERT
+.logo-default
+
+================================
+
+mendeley.com
+
+INVERT
+#pdfcontainerId > div[class^="PDFReaderWithAnnotations"]
+.highlightLayer > *
+div[class^="AnnotationMenuStyle"]
+svg[class^="IconMendeley__Icon"]
+a[class^="TabCloseButton__CloseTabLink"]
+g#cross3
+svg[class^="ColourCircle"]
+
+CSS
+.highlightLayer * {
+    background-color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+menshealth.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/menshealth/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d2232e" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
+menti.com
+
+INVERT
+div#__next svg[role="img"] > title ~ g
+img[src^="https://images.mentimeter.com/themes/832111/tyett7pf-brand-light.svg"]
+
+================================
+
+mercialys.com
+
+INVERT
+#header .logo img
+
+CSS
+.swiper-slide img,
+article.data_year a.js-analytics img,
+.figure-article img {
+    background-color: white !important;
+}
+
+================================
+
+merriam-webster.com
+
+INVERT
+circle.outline.Oval
+
+CSS
+.logo-cnt path[fill="#004990"] {
+    fill: ${#0085e0} !important;
+}
+
+================================
+
+mersenneforum.org
+
+INVERT
+img[src*="mimetex"]
+
+================================
+
+messages.android.com
+
+INVERT
+.x4Tquc
+.QrWqSe
+.XCHXxd
+.pXeIKc
+
+================================
+
+messages.google.com
+
+INVERT
+.x4Tquc
+.QrWqSe
+.XCHXxd
+.pXeIKc
+
+CSS
+.input-background {
+    --input-bg-fade-color: #202124 !important;
+}
+
+================================
+
+messenger.com
+
+INVERT
+._4rv6
+a._4ce_
+div[aria-label="Change Position"]
+div[role="slider"]
+
+CSS
+._8rsr {
+    fill: #0098ff !important;
+}
+._576q mask path {
+    fill: white !important;
+}
+._576q mask rect {
+    fill: black !important;
+}
+._576q div {
+    background-color: transparent !important;
+}
+.j7vl6m33,
+.a8c37x1j,
+.bp9cbjyn,
+mask[id*="jsc_c"] > circle {
+    fill: var(--always-white) !important;
+}
+.a8c37x1j > rect {
+    fill: var(--darkreader-bg--fds-white) !important;
+}
+.__fb-light-mode {
+    --darkreader-border--messenger-card-background: var(--darkreader-bg--messenger-card-background) !important;
+    --filter-blue-link-icon: invert(73%) sepia(29%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(103.25%) hue-rotate(189deg) brightness(101%) contrast(101%) !important;
+    --filter-disabled-icon: invert(100%) opacity(30%) !important;
+    --filter-negative: invert(25%) sepia(33%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(110%) hue-rotate(345deg) brightness(132%) contrast(96%) !important;
+    --filter-placeholder-icon: invert(59%) sepia(11%) saturate(200%) saturate(135%) hue-rotate(176deg) brightness(96%) contrast(94%) !important;
+    --filter-positive: invert(37%) sepia(61%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(115%) hue-rotate(91deg) brightness(97%) contrast(105%) !important;
+    --filter-primary-icon: invert(100%) !important;
+    --filter-secondary-icon: invert(62%) sepia(98%) saturate(12%) hue-rotate(175deg) brightness(90%) contrast(96%) !important;
+    --filter-warning-icon: invert(77%) sepia(29%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(200%) saturate(128%) hue-rotate(359deg) brightness(102%) contrast(107%) !important;
+}
+.qbubdy2e {
+    fill: none !important;
+}
+.tdjehn4e,
+.oo1teu6h {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+}
+.tdjehn4e:hover,
+.ovq5dppa:hover {
+    background-color: rgba(255, 255, 255, 0.2) !important;
+}
+i.eb18blue {
+    filter: none;
+}
+div[style][title] > div[style^="transform"] {
+    z-index: 0 !important;
+}
+.x1g6sh6t {
+    fill: none !important;
+}
+.x1g6sh6t {
+    fill: none !important;
+}
+.x1k4qllp {
+    outline: 10px solid var(--darkreader-bg--mwp-message-row-background) !important;
+}
+
+IGNORE INLINE STYLE
+[role="button"] svg
+[role="button"] svg line
+div svg[viewBox="0 0 36 36"] mask path
+mask > rect
+g > rect
+mask > circle
+.html-div svg path
+
+================================
+
+metacareers.com
+
+INVERT
+a[href="/"] img.img
+#careersContentContainer div[style^="background-image: "]
+#careersContentContainer div[style^="background-image: "] > *
+
+================================
+
+metal.equinix.com
+
+INVERT
+.tw-logo
+
+================================
+
+metalmadness.org
+
+INVERT
+img[alt="Rules"]
+
+CSS
+.forabg,
+.forumbg,
+#subsilver-nav-topic {
+    background-blend-mode: multiply !important;
+}
+
+================================
+
+meteo.imgw.pl
+
+INVERT
+.meteo-chart > div > canvas
+#map-container svg
+
+CSS
+.menu-close img {
+    filter: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.gory-imgw a
+
+================================
+
+meteofrance.com
+
+INVERT
+.marianne
+
+CSS
+.chartjs-render-monitor {
+    background: ${#bbb} !important;
+}
+
+================================
+
+metrics.torproject.org
+
+INVERT
+img[src^="/images/flags/"]
+g > text
+g > line
+
+CSS
+.dot {
+    fill: var(--darkreader-neutral-background) !important;
+}
+div > img[src] {
+    filter: invert(90%) !important;
+}
+
+================================
+
+metro.co.uk
+
+INVERT
+#masthead__logo-default
+
+================================
+
+metrobyt-mobile.com
+
+INVERT
+#digital-header-logo-img
+
+CSS
+#Desktop-img {
+    z-index: 0 !important;
+}
+
+================================
+
+mewe.com
+
+CSS
+body > .ember-view {
+    background-color: ${#ebf0f3} !important;
+}
+body > .ember-view.dialog_wrapper {
+    background-color: transparent !important;
+}
+
+================================
+
+microchip.com
+
+INVERT
+.mchp-logo
+
+================================
+
+microsoft.com
+
+INVERT
+.m-updated-quicklinks .c-carousel.f-single-slide ul > li > a.c-hyperlink > img.large-icon
+.carousel-inner .card-background
+.key-message .card-background
+.animated-hero-media
+.section-master .section-master__image .ocr-img img:not(#mainContent > div > div > div > div.secondary-sticky-nav.aem-GridColumn.aem-GridColumn--default--12 > div.scrollspy-container > div:nth-child(9) > div > div > div.section-master__image > div > img)
+
+CSS
+#announce picture + div h3,
+#announce picture + div p,
+.edgeconsumer.features .m-hero h1,
+.edgeconsumer.features .m-hero p {
+    color: var(--darkreader-neutral-background) !important;
+}
+div[aria-label="Download Microsoft Edge dialog"] {
+    background-color: #389fef !important;
+}
+.block-heading,
+.pill-bar__item {
+    text-shadow: ${white} 1px 1px 0px !important;
+}
+
+================================
+
+microsoftedge.microsoft.com
+
+INVERT
+rect[x="7.5"]
+text[text-anchor="middle"]
+
+================================
+
+midkar.com
+
+CSS
+body {
+    background-image: unset !important;
+}
+
+================================
+
+mikanani.me
+
+INVERT
+.an-res-row-bg
+
+================================
+
+mikrotik.com
+
+INVERT
+img[alt="MikroTik Logo"]
+img[src*="down.png"]
+img[src*="file.png"]
+img[src*="md5.png"]
+
+CSS
+img[src*="ros.jpg"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[src*="demo.png"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[src*="install.png"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[src*="cloud.png"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[src*="read.png"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[src*="buy.png"] {
+    filter: invert(1) !important;
+    mix-blend-mode: exclusion !important;
+}
+img[alt="MikroTik App"] {
+    filter: invert(1) hue-rotate(180deg) !important;
+    mix-blend-mode: difference !important;
+}
+img[alt="MikroTik Home App"] {
+    filter: invert(1) hue-rotate(180deg) !important;
+    mix-blend-mode: difference !important;
+}
+img[alt="Beacon Manager app"] {
+    filter: invert(1) hue-rotate(180deg) !important;
+    mix-blend-mode: difference !important;
+}
+img[src*="map_lv.jpg"] {
+    filter: invert(1) hue-rotate(180deg) saturate(5) !important;
+    mix-blend-mode: difference !important;
+}
+
+================================
+
+miktex.org
+
+INVERT
+.icon-bar
+
+CSS
+body,
+.site-footer {
+    background-image: none !important;
+}
+
+================================
+
+mimecast.com
+
+INVERT
+img[alt="Mimecast Logo"]
+.header__hamburger-icon
+
+================================
+
+mindfactory.de
+
+INVERT
+.col-icons
+img[src*="icon_cart.svg"], img[src*="icon_gamepad.png"], img[src*="icon_schnaepp.png"], img[src*="schnaeppshop_logo_icon.webp"]
+#dienst_montage, #dienst_montage .icons, img[src*="mindfactory_komplettsystemmontage.png"]
+#ic_aboutus > div:nth-child(2), img[src*="ueberuns/middle.jpg"]
+.ms_group_icon > a > img
+.text-center > a > img
+
+CSS
+.ms_product {
+    background-blend-mode: difference !important;
+}
+.itemhighlight > .ms_product {
+    background-color: var(--darkreader-selection-text) !important;
+}
+.p {
+    background-blend-mode: normal !important;
+}
+#dienst_montage > div > p {
+    color: var(--darkreader-neutral-background) !important;
+}
+body,
+.ground-layer {
+    background-blend-mode: soft-light !important;
+}
+
+================================
+
+minecraft.net
+
+INVERT
+.feature-details img
+.ms-accordion .shade
+.ms-accordion td.platform-data
+.nav-links__tab-icon
+
+CSS
+.ms-accordion td.platform-data {
+    background-color: white !important;
+}
+div[style*="background-image: url("][style*="/background-images/bg-wool-white.png"],
+.promo-area .bg-wool-light {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.promo-area .trans-top-dark
+
+================================
+
+minecraftitemids.com
+
+CSS
+.cc-tbl--full-color {
+    background-color: rgba(var(--col-rgb), 1) !important;
+    color: rgba(var(--col-rgb-text), 1) !important;
+}
+.cc-tbl--copy-row {
+    color: #444 !important;
+}
+.cc-tbl-copy-btn > svg {
+    fill: rgba(0, 0, 0, 0.4) !important;
+}
+
+================================
+
+minecraftskins.com
+
+CSS
+.farbtastic .overlay {
+    background-image: url("https://www.minecraftskins.com/bundles/app/images/mask.png") !important;
+}
+.header__menu-outer > ul > li > a {
+    color: black !important;
+}
+
+IGNORE INLINE STYLE
+.color
+#color
+
+IGNORE IMAGE ANALYSIS
+.farbtastic .overlay
+
+================================
+
+minesweeper.online
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+minsu.dianping.com
+
+INVERT
+.zg-map
+
+================================
+
+mint.intuit.com
+
+INVERT
+.recharts-cartesian-axis-ticks
+
+CSS
+[class*="ExpandableCard-wrapper"] {
+    background: none !important;
+}
+[class*=' TextField-TFInput'] {
+    background: var(--darkreader-neutral-background) !important;
+}
+[class*='BudgetCardstyle__ProgressLine'],
+[class*='OverviewCardUIstyle__ProgressLine'] {
+    border-right-color: ${black} !important;
+    opacity: 1 !important;
+}
+
+IGNORE INLINE STYLE
+.recharts-sector
+
+================================
+
+miro.com
+
+INVERT
+#pixiCanvasContainer > :nth-child(1)
+#widgetsOverlay > canvas:not([style*="display: none"])
+.b-icon
+
+================================
+
+mistral.ai
+
+INVERT
+img[alt="linkedin"]
+img[alt="facebook"]
+img[alt="twitter"]
+img[alt="Black"]
+a[aria-label="X"] img
+a[aria-label="Linkedin"] img
+a[aria-label="Discord"] img
+#splide01-list img
+
+CSS
+img[src^="https://cms.mistral.ai/assets"] {
+    filter: none !important;
+    mix-blend-mode: normal !important;
+}
+.blog-rich-text p,
+.blog-rich-text h1,
+.blog-rich-text h2,
+.blog-rich-text h3 {
+    color: inherit;
+}
+.subMenuItem,
+a.inline-block {
+    background-clip: initial !important;
+    background-image: none !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.menuItem.animate-shine-black {
+    background-image: none !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.relative.svg-container svg path,
+.size-3.svg-container svg path,
+.svg-container:not([class*=' ']) svg path,
+.hidden.svg-container svg path {
+    fill: #EC6D36 !important;
+}
+body > main > div.pointer-events-none.fixed.inset-x-0.bottom-0.z-50.flex.justify-center.px-4.pb-8.transition-all.duration-300.ease-in-out.translate-y-0.opacity-100 > form > div > button,
+body > main > div:nth-child(2) > div.relative.flex.max-h-\[690px\].min-h-\[690px\].items-center.justify-center > div > form > div > button,
+body > main > div:nth-child(8) > article > div > header > a > h4 > button {
+    background-color: #EC6D36 !important;
+}
+table {
+    border-color: inherit !important;
+}
+td,
+th {
+    border-color: inherit !important;
+}
+thead {
+    background-color: ${white} !important;
+}
+span.h-\[11px\].w-px.bg-foreground {
+    background-color: ${black} !important;
+}
+.divider.h-full.w-px.bg-primary.z-20.top-0.absolute.pointer-events-none {
+    background-color: red !important;
+}
+.items-center button,
+.container,
+.w-full {
+    text-shadow: black 1px 1px 0px !important;
+}
+
+================================
+
+mit.edu
+
+INVERT
+.mit-logo
+
+================================
+
+mitx.*
+
+CSS
+img {
+    background-color: white !important;
+}
+
+================================
+
+mixcloud.com
+
+INVERT
+.cQABPj
+
+IGNORE INLINE STYLE
+path[fill="none"]
+path[fill-rule="evenodd"]
+
+================================
+
+mjtnet.com
+
+INVERT
+.navbar-brand
+
+================================
+
+mlb.com
+
+CSS
+#percentile-rank text,
+.legend {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+mnt.ee
+
+CSS
+#zone-content-wrapper {
+    color: var(--darkreader-neutral-text) !important;
+}
+#zone-content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+mobiel.nl
+
+INVERT
+.credit-warning__image
+.dt-carousel-home__dots
+.spec__network
+img[alt="Tele2"]
+img[alt="hollandsnieuwe"]
+.header-main__icon
+.spec__network-ready
+
+IGNORE INLINE STYLE
+.version-without-subscription-row__color
+.gEJLdA
+
+================================
+
+mobile.bg
+
+CSS
+table .tablereset {
+    background-image: none !important;
+}
+
+================================
+
+modelrailroadforums.com
+
+CSS
+code.bbCodeInline,
+pre {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    margin: 0.5em 0 !important;
+    outline: none !important;
+    padding: 0.5em !important;
+}
+[data-darkreader-scheme="dark"] code.bbCodeInline,
+pre {
+    color: ${#00cc00} !important;
+}
+
+================================
+
+moegirl.org.cn
+
+CSS
+span.heimu a.external,
+span.heimu a.external:visited,
+span.heimu a.extiw,
+span.heimu a.extiw:visited {
+    color: #dadada !important;
+}
+.heimu,
+.heimu a,
+a .heimu,
+.heimu a.new {
+    background-color: #dadada !important;
+    color: #dadada !important;
+}
+body:not(.heimu_toggle_on) .heimu:hover,
+body:not(.heimu_toggle_on) .heimu:active,
+body:not(.heimu_toggle_on) .heimu.off {
+    color: black !important;
+}
+body:not(.heimu_toggle_on) .heimu:hover a,
+body:not(.heimu_toggle_on) a:hover .heimu,
+body:not(.heimu_toggle_on) .heimu.off a,
+body:not(.heimu_toggle_on) a:hover .heimu.off {
+    color: darkblue !important;
+}
+body:not(.heimu_toggle_on) .heimu.off .new,
+body:not(.heimu_toggle_on) .heimu.off .new:hover,
+body:not(.heimu_toggle_on) .new:hover .heimu.off,
+body:not(.heimu_toggle_on) .heimu.off .new,
+body:not(.heimu_toggle_on) .heimu.off .new:hover,
+body:not(.heimu_toggle_on) .new:hover .heimu.off {
+    color: #BA0000 !important;
+}
+
+================================
+
+mojosoft.com.pl
+
+INVERT
+img[src*="logo16"]
+img[src*="img/iko"]
+img[src*="img/ideabank"]
+img[src*="img/logo"]
+img[src*="img_logo"]
+#searchbox
+
+CSS
+#viewsh,
+#view,
+#szukajka,
+header,
+header.smaller #szukajka .inputsearch,
+#search_query,
+#mainMenusmall {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+#searchbox,
+select {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+header.smaller
+
+================================
+
+moluch.ru
+
+INVERT
+.logo
+
+CSS
+body {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+momentosesabores.com
+
+INVERT
+header.site-header img[alt="logo-large"]
+
+================================
+
+monde-diplomatique.fr
+
+INVERT
+.logodiplo
+
+================================
+
+money.pl
+
+CSS
+.dynks {
+    color: ${#666666} !important;
+}
+a[href$="twitter.com/money_pl"] path:first-of-type {
+    --darkreader-inline-fill: transparent !important;
+}
+
+================================
+
+mongodb.com
+
+INVERT
+img[alt="MongoDB logo"]
+
+================================
+
+monitor.firefox.com
+
+INVERT
+svg[class="Mozilla-logo"] > path[fill="#ffffff"]
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+img[src="/img/svg/laptop.svg"]
+img[src="/img/svg/globe.svg"]
+img[src="/img/svg/vpn.svg"]
+button[class="vpn-banner-close"]
+
+================================
+
+monokai.pro
+
+INVERT
+.c-icon-process
+
+================================
+
+monstercat.com
+
+CSS
+.volume-slider-outer {
+    background-color: ${#4d4d4d} !important;
+    z-index: -99999999999;
+}
+.volume-slider-inner {
+    background-color: ${#1873cc} !important;
+}
+.volume-slider-handle {
+    background-color: ${#1d1d1d} !important;
+}
+.title,
+h3,
+.line-bottom,
+.line-top,
+a,
+.one-line-ellipsis {
+    color: ${#4b4e50} !important;
+}
+
+================================
+
+monta.ir
+
+INVERT
+.floatLeft
+.formula-pack > img
+.m--content-panel > div > div > canvas
+.highcharts-background
+.customized-field
+.source
+.choice > .layoutImageInline
+.choice > img
+.choice > div > img
+.navbar-item > img
+.empty_state_student
+progress
+td > img
+.notice > div > img
+td > div > img
+.extrapractice > div > img
+.extrapractice > div > div > img
+.empty_teacher
+.GO5O4PB-gc-b
+.GO5O4PB-gc-i
+.GO5O4PB-gc-e
+.GO5O4PB-gc-i > div
+.GO5O4PB-gc-Eb > div > a
+img.is-rounded
+img.is-128x128
+
+CSS
+.GO5O4PB-gc-n {
+    background-image: none !important;
+}
+
+================================
+
+moodle.herzen.spb.ru
+
+INVERT
+.img-responsive
+
+================================
+
+moodle.u-pariscite.fr
+
+INVERT
+img.logo
+
+================================
+
+moovitapp.com
+
+INVERT
+.map
+.logo
+
+================================
+
+morele.net
+
+INVERT
+.h-logo.col
+.h-control-btn > [src="/static/img/shop/icon-bezpieczna-dostawa.svg"]
+.swiper-slide-visible.mx-auto.swiper-slide > .d-flex.img-container
+div.cn-different-frontend.cn-menu-item-hover.cn-shop > .cn-main-name.cn-name > .cn-name-value > span:nth-of-type(1)
+
+================================
+
+morningstar.com
+
+INVERT
+.mbc-legend-top
+.mbc-legend-bottom
+.mbc-legend-item-date
+.mdc-medal
+.mdc-icon
+.legend-group
+.legend-box-text
+.mbc-chart-group
+.square-text
+.min-max
+.axis .tick
+.axis .name
+.mbc-axis .tick
+.mbc-chart-legend-inner
+.mbc-layers .tick
+
+================================
+
+mos.ru
+
+INVERT
+div[class^="src-components-Map-___styles-module__map_container"]
+div[class^="src-components-Map-___styles-module__control"]::before
+div[class^="src-components-Map-___styles-module__control"]::after
+#map_div_container
+#points_layer > text
+
+================================
+
+motherjones.com
+
+INVERT
+.logo
+.footer-logo
+.menu-button
+
+================================
+
+moto.pl
+
+INVERT
+img[src="https://bi.im-g.pl/im/0/24525/m24525630.png"]
+
+CSS
+.main_wrapper,
+.top_section_bg,
+.bottom_section_bg {
+    background-color: ${#e5e5e5} !important;
+}
+
+================================
+
+motorsport.com
+
+CSS
+.ms-schedule-table__cell {
+    background-color: var(--darkreader-neutral-dark) !important;
+}
+
+================================
+
+mowglii.com
+
+CSS
+#itsycalbanner2 {
+    background: url(/itsycal/itsycalbanner2@2x.png?v=1720157892) no-repeat !important;
+    background-position: right center !important;
+    background-size: 550px 430px !important;
+    height: 430px !important;
+    width: 100% !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#itsycalmenubaranimation
+
+================================
+
+mox.com
+
+INVERT
+.logo
+
+================================
+
+mozilla.org
+
+INVERT
+img.sidebar-icon
+h1.c-logo
+.c-navigation-logo-image
+.m24-c-navigation-logo-image
+
+CSS
+div.mzp-c-navigation-logo {
+    background: ${black} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.c-logo.t-browser-word-hor-white-xs
+.c-logo.t-browser-word-hor-xs
+.noodle-browser
+
+================================
+
+mozillafoundation.org
+
+CSS
+.moz-logo {
+    background-image: url("https://assets.mofoprod.net/static/legacy_apps/_images/mozilla-on-black.9aed40133293.svg") !important;
+}
+
+================================
+
+mp.weixin.qq.com
+
+INVERT
+.audio_card_progress
+.audio_card_progress_handle
+
+================================
+
+mpb.com
+
+IGNORE INLINE STYLE
+svg[class*="flag"]
+
+================================
+
+msmgtoolkit.in
+
+CSS
+.cid-r89gzwx5mR .mbr-section-title {
+    color: ${white};
+}
+.cid-r89gzwx5mR .mbr-section-subtitle {
+    color: ${white};
+}
+
+================================
+
+msn.cn
+
+CSS
+.heading span,
+msft-attribution span {
+    color: var(--darkreader-neutral-background) !important;
+}
+.heading + .abstract {
+    color: ${rgb(247, 244, 241)} !important;
+}
+
+IGNORE INLINE STYLE
+.article
+msft-ad-label
+
+================================
+
+msn.com
+
+INVERT
+.logowrapper
+
+================================
+
+msnbc.com
+
+CSS
+.styles_progress__GFuLT::-moz-progress-bar {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.styles_progress__GFuLT {
+    background-color: #666 !important;
+}
+.styles_volume__peSyL::-moz-range-thumb {
+    background: var(--darkreader-neutral-text) !important;
+}
+.styles_volume__peSyL::-moz-range-track {
+    background: #666 !important;
+}
+
+================================
+
+msys2.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+mt.lv
+
+CSS
+.graph > text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+mtggoldfish.com
+
+IGNORE INLINE STYLE
+.manacost path
+
+================================
+
+mturk.com
+
+INVERT
+[src="/assets/images/how-it-works.png"]
+[src="/assets/images/requester_signup.svg"]
+[src="/assets/images/worker_signup.svg"]
+.lb-mid-8.lb-tiny-24.lb-col > .lb-img > div
+
+================================
+
+mubi.com
+
+INVERT
+.css-jd0r3a.e1kjxayp2
+.css-k7pew6.ef3qs2t4 img
+.css-ywuexf
+.css-19064tz
+.css-1w8phor
+.css-n1xrf1
+.css-1dev2nn.e18wowia1 .star
+.css-ker29f.ed6irnx8
+img[src*="logo-small_black.png"]
+img[src*="industry_event_logo_placeholder-small_black.png"]
+.css-zj1tof
+
+CSS
+.css-ztue73 {
+    filter: brightness(1) !important;
+}
+.css-1gez225.e1t0dj1j2 svg *,
+.css-1gez225.e13p4uxl2 svg * {
+    --darkreader-inline-fill: #FFFFFF !important;
+}
+.css-1fdxz4i.e1f1mjpr0 svg *,
+.css-15x1o6o.e19610x52 svg *,
+.css-j9vvv8.e1gnvuk52  svg * {
+    --darkreader-inline-fill: ${#000000} !important;
+}
+
+IGNORE INLINE STYLE
+.star-ratings svg *
+
+================================
+
+mullvad.net
+
+CSS
+#bg {
+    fill: #192E45;
+}
+
+================================
+
+multilingual.com
+
+INVERT
+.td-logo
+
+================================
+
+multitran.com
+
+INVERT
+img[src="/gif/logoe.gif"]
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+mumble.info
+
+INVERT
+.os
+.suggested-download-button-caption
+
+================================
+
+muratordom.pl
+
+INVERT
+.logo
+
+================================
+
+murena.com
+
+INVERT
+picture.wordmark--link
+
+================================
+
+musclewiki.com
+
+INVERT
+img[src="/static/images/logo.png"]
+
+================================
+
+music.163.com
+
+INVERT
+.btns
+.cor
+#g_backtop
+#g_player
+.hot
+.logo
+.m-playbar
+.m-table thead
+.u-btn2
+.u-lv
+.u-btn
+.m-tabs
+.n-srch .pgsrch
+.n-srch .pgsrch .btn
+.n-srch .pgsrch .srch
+
+CSS
+.n-myinfo {
+    background-image: none !important;
+}
+
+================================
+
+music.amazon.*
+music.amazon.*.*
+
+CSS
+.listViewStatusButtonInLibrary .add,
+.listViewStatusButtonInLibrary .added {
+    background-color: ${black} !important;
+}
+.slider .scrubber,
+.slider .scrubberHandle,
+.slider .sliderTrackRemainder {
+    background-color: ${black} !important;
+}
+
+================================
+
+music.apple.com
+
+INVERT
+body:not(.dark-mode) .web-navigation__logo-link.button-reset.ember-view
+body:not(.dark-mode) .native-upsell__logo
+body:not(.dark-mode) .native-upsell__action
+body:not(.dark-mode) .dt-search-box__icon
+.web-chrome-playback-controls
+.dt-media-contextual-menu
+.web-chrome-playback-lcd__contextual-badge--non-marquee.web-chrome-playback-lcd__contextual-badge
+.love-or-popular__popular.love-or-popular__glyph
+.web-chrome-playback-lcd__progress-bar-container
+.web-chrome-playback-lcd__volume
+
+================================
+
+musical-artifacts.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text);
+}
+.light-item {
+    background-color: ${#f8f8f8};
+    border-color: ${#efefef};
+}
+.dark-item,
+.pagination > li > a,
+.pagination > .disabled > a {
+    background-color: ${#eee};
+    border-color: ${#ddd};
+}
+.tag-title,
+a:hover,
+a[href="https://www.gnu.org/licenses/license-list.html#NoLicense"] {
+    color: ${#222};
+}
+a {
+    color: ${#632d4d};
+}
+a.tag-filter:hover {
+    color: ${#111};
+}
+.btn-default {
+    background-color: ${#e6e6e6};
+    border-color: ${#aaa} !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.btn-default:hover,
+.pagination > li > a:hover,
+.pagination > .disabled > a:hover {
+    background-color: ${#aaa};
+    border-color: ${#aaa} !important;
+}
+.form-control {
+    background-color: ${#fff};
+    border: 1px solid ${#ccc};
+    color: ${#555555};
+}
+#artifacts_search_clear {
+    background-color: ${#ddd};
+}
+input.form-control,
+.select2-choices,
+.select2-search-field {
+    background: transparent !important;
+    background-color: transparent !important;
+}
+
+================================
+
+musicmakers.ru
+
+INVERT
+#menubtn > *
+
+================================
+
+musictheory.net
+
+INVERT
+[data-musictheory-id="lesson"] canvas
+
+================================
+
+my.bible.com
+
+CSS
+.nav-title {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+my.canadalife.com
+
+CSS
+.nds-card {
+    background: inherit !important;
+}
+
+================================
+
+my.canngo.express
+
+INVERT
+input[id="beeintraechtigungAlltag"]
+
+================================
+
+my.centraluniversity.ru
+id.centraluniversity.ru
+
+CSS
+tui-root {
+    border-image: none !important;
+}
+
+================================
+
+my.cofc.edu
+
+CSS
+.container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+my.contabo.com
+
+CSS
+#mainmenu > div,
+#submenu > div,
+.button,
+.ui-button {
+    background-image: none !important;
+}
+.ui-button {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+my.frantech.ca
+
+INVERT
+.logo
+
+================================
+
+my.home-assistant.io
+
+CSS
+.ha-card {
+    background: ${white} !important;
+}
+
+================================
+
+my.nextdns.io
+
+INVERT
+.mt-2.mb-4.text-center
+img[src*="/static/media/logo-large"]
+img[src*="/static/media/samsung"]
+img[src*="/static/media/sonos"]
+.d-md-inline > img
+.settings-button
+.stream-button
+.tooltipParent > img
+.list-group-item > div > img
+.d-flex > .text-break > img
+.d-flex > .flex-grow-1 > div > img
+.d-flex.align-items-center.flex-wrap a img
+
+CSS
+.text-right[style*="opacity: 0.3"] {
+    opacity: 0.6 !important;
+}
+g.rsm-geographies {
+    filter: invert(1) hue-rotate(180deg) brightness(130%) !important;
+}
+img[src*="/misc/flags/"] {
+    filter: revert !important;
+}
+
+================================
+
+my.nintendo.com
+
+CSS
+.Layout-app,
+.Modal_contentInner,
+.signUpButton {
+    background-image: none !important;
+}
+
+================================
+
+my.remarkable.com
+
+INVERT
+.menu-button
+img[alt="desktop icon"]
+img[alt="mobile icon"]
+
+================================
+
+my.vega.ua
+
+INVERT
+canvas#traffic_graph_canvas
+
+================================
+
+my.volia.com
+
+CSS
+body.signInPage {
+    background-image: none !important;
+}
+a.mainLogo {
+    background-color: ${grey} !important;
+}
+
+================================
+
+myabandonware.com
+
+INVERT
+.sports
+.duke2
+.heretic
+.hexen
+.strategy
+.simulation
+.blood
+.driving
+.keen
+.playing-rpg
+.jazz-jack
+.war2
+.pitch
+
+CSS
+.top {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+myacademy.oracle.com
+
+INVERT
+#logo
+.login-logo
+.logo--desktop
+.nav-control-mobile span
+.splide--container button
+.dynamic-widget__result .list-view .completion-bar
+.course-details__cta a.play::before
+.thumb__background
+.universal-side-panel__switcher button svg
+.universal img
+.slide-displays-root > div:nth-child(3) > div > :nth-child(2) > div > :nth-child(3)
+.slide-displays-root div:nth-child(3) > div > :first-child > div > :last-child span
+.slide-displays-root svg g path:nth-child(2)
+.quiz-slide-visualizer
+.slide-object-view-icon-placeholder
+.quiz-session-view .choice-view__active-element-container .inline-border
+
+CSS
+header,
+#header {
+    background: ${#ccc} !important;
+}
+.quiz-slide-visualizer span {
+    color: #4e3629 !important;
+}
+.quiz-slide-visualizer .slide-layout > div > :nth-child(3) span,
+.quiz-slide-visualizer .slide-layout > div > :nth-child(8) span {
+    color: #fed6af !important;
+}
+.message-box__icon,
+.quiz-message-box__icon {
+    background-color: white !important;
+    border: 2px solid white !important;
+    border-radius: 50%;
+}
+.slide-displays-root div:has(div) > div :first-child > :first-child > :last-child > svg {
+    opacity: 0 !important;
+}
+#AssessmentForm :not(label) span {
+    color: ${black} !important;
+}
+#AssessmentForm label span {
+    color: ${#222} !important;
+}
+
+================================
+
+myaccount.google.com
+
+INVERT
+.iKN8Oe
+
+================================
+
+myaccount.suse.com
+
+INVERT
+.auth-org-logo
+.logo
+
+================================
+
+myalmacoffee.com
+
+CSS
+:root {
+    --gradient-base-background-1: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+myanimelist.net
+
+INVERT
+.link-provider img
+.theme-songs td[width="8%"]:first-child
+
+CSS
+body:not(.ownlist) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+body {
+    background-color: var(--dakreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+mybrandnewlogo.com
+
+IGNORE INLINE STYLE
+.b-logo-wrap *
+
+================================
+
+myfood4less.com
+
+INVERT
+.elementor-widget-theme-site-logo
+
+================================
+
+mylo.id
+
+INVERT
+div[data-testid="brandLogo"] img:not([alt="Popular Mechanics"], [alt="Redbook"], [alt="Town & Country"])
+a.apple-login-button svg
+
+================================
+
+mymenu.be
+
+INVERT
+.close-icon
+
+CSS
+.uix-steps .item.active .number {
+    color: ${darkred} !important;
+}
+
+IGNORE INLINE STYLE
+.uix-tracking .information .step .number
+
+================================
+
+myorca.*
+
+INVERT
+path.b
+
+CSS
+.m-banner h1,
+.m-banner p {
+    color: black !important;
+}
+
+================================
+
+myunidays.com
+
+INVERT
+.title
+.menu-btn-icon
+
+================================
+
+mywikis.com
+
+INVERT
+.heading-primary
+.heading-subtext
+.hero
+
+================================
+
+n.maps.yandex.ru
+mapeditor.yandex.com
+
+INVERT
+span[class*="nk-icon_id_commit-"] > svg > g > path
+span[class*="nk-icon_id_business-feedback-task"] > svg > g > path
+
+================================
+
+naeu.playblackdesert.com
+
+INVERT
+.top_news_detail_visual
+.top_news_detail_visual h2
+
+CSS
+.top_news_detail_visual {
+    background-image: url("https://s1.pearlcdn.com/NAEU/contents/img/portal/news/news_detail_visual_top.png") !important;
+}
+
+================================
+
+nagatabi-p.jimdofree.com
+
+INVERT
+.cc-imagewrapper > img
+
+================================
+
+nalog.ru
+
+INVERT
+.header__logo
+
+================================
+
+namecheap.com
+
+INVERT
+.whoisguard-img
+
+================================
+
+naps2.com
+
+CSS
+.os-icon[title="Linux"] {
+    background-color: white !important;
+}
+
+================================
+
+narimiran.github.io/nim-basics
+
+CSS
+body,
+#toc.toc2 {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+nasa.gov
+
+IGNORE IMAGE ANALYSIS
+.vjs-has-started .vjs-control-bar .vjs-control.vjs-logo-image
+
+================================
+
+nasdaq.com
+
+INVERT
+div.primary-nav__logo
+.jupiter22-upcoming-events .jupiter22-upcoming-events__list--item img
+
+CSS
+.jupiter22-c-info-card__image,
+.jupiter22-c-content-card__image {
+    background-color: white !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.footer__link-social a[title*="X"]
+
+================================
+
+natemat.pl
+aszdziennik.pl
+innpoland.pl
+dadhero.pl
+mamadu.pl
+
+INVERT
+img[src*="/static/media/"]
+img[alt="close icon"]
+a[href="#comments"]
+.st1
+
+CSS
+img[class*="Footer--Logo"] {
+    background-color: #fff !important;
+}
+
+================================
+
+nation.cymru
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+nationaleaglecenter.org
+
+INVERT
+img[title="logo"]
+
+================================
+
+nationalgeographic.com
+
+INVERT
+.NavBar__Logo__Container
+
+================================
+
+nationalgeographic.com.es
+*.nationalgeographic.com.es
+nationalgeographic.pt
+
+INVERT
+#siguenos-iconos
+.link-header-module img
+.page-header .navbar-toggle
+.page-header .brand .logo
+
+================================
+
+nature.com
+
+INVERT
+.c-header__item--dropdown-menu > a[aria-expanded="false"] > svg
+.c-header__link--search[aria-expanded="false"] > svg
+.c-header__logo
+[href="#search-menu"] > svg
+.c-header__link--chevron > svg
+img[alt="Nature Careers"]
+
+================================
+
+naturemade.com
+
+INVERT
+div.header-banner > svg
+ul.main-nav-child-links > li > a > img
+
+CSS
+:root {
+    --gradient-base-background-1: unset !important;
+}
+form[action="/search"] > div > label {
+    display: none;
+}
+
+================================
+
+nauka.rocks
+
+INVERT
+.navigation-branding
+
+================================
+
+nautil.us
+
+INVERT
+.main-logo
+.menu-button
+.action-header-list img
+.nav-channel-box img
+.topic-header-icons
+
+================================
+
+navalnews.com
+
+INVERT
+.logo
+
+================================
+
+nba.com
+
+INVERT
+.nlProgressBar
+
+================================
+
+nbc12.com
+
+INVERT
+div.logo.logo-slim
+div.logo.logo-large.logo-footer
+
+IGNORE IMAGE ANALYSIS
+.logo
+
+================================
+
+nbcphiladelphia.com
+
+INVERT
+.site-footer__social-list-item .icon
+
+================================
+
+nbi.ku.dk
+
+CSS
+.tile-link {
+    color: var(--darkreader-neutral-color) !important;
+}
+
+================================
+
+ncbi.nlm.nih.gov
+
+INVERT
+.gene-genomic-context p.withnote img
+.home_page .action_bar img
+
+================================
+
+nec.com
+
+INVERT
+.logo
+
+================================
+
+needymeds.org
+
+CSS
+#header {
+    background: unset !important;
+}
+
+================================
+
+neftm.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+================================
+
+nejm.org
+
+INVERT
+a[href="/"] svg
+
+================================
+
+neonet.pl
+
+INVERT
+div[class^="newsSingleBar"] > div[class^="newsSingleBarHeaderWidescreen-category"]
+
+CSS
+div[class^="newsSingleBar"] > div[class^="newsSingleBarHeaderWidescreen-category"] {
+    color: ${white} !important;
+}
+
+================================
+
+neoseeker.com
+
+CSS
+.hidden_text {
+    background-color: var(--darkreader-neutral-text) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.hidden_text.shown {
+    background-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+neowin.net
+
+INVERT
+.comment-link
+.news-view-switcher span
+.author a.twitter-link
+.meta-comments
+.comment-link::before
+.select-wrap::after
+.report-article-button::before
+#comment-help::before
+.comment-button-report
+.comment-interact a
+
+CSS
+.select option {
+    background-color: #1c1e1f !important;
+    color: white !important;
+}
+
+================================
+
+nerdschalk.com
+
+INVERT
+.logo-default
+
+================================
+
+nerdwallet.com
+
+IGNORE INLINE STYLE
+#global-nav *
+
+================================
+
+nero.com
+
+INVERT
+.navbar-brand
+
+================================
+
+netbank.sparthy.dk
+
+CSS
+select option {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+nethackwiki.com
+
+INVERT
+.tex
+
+IGNORE IMAGE ANALYSIS
+.mw-wiki-logo
+
+================================
+
+netia.pl
+
+INVERT
+.main-navigation__logo
+
+================================
+
+netlify.com
+
+INVERT
+.masthead-home-logo
+.logo-wall
+.input
+
+CSS
+.root {
+    data-darkreader-inline-fill: var(--scrim-icon-color) !important;
+}
+.submenu,
+.table-wrapper,
+.table-header,
+td {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.menu,
+.ntl-announcement-bar {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+netonnet.se
+
+INVERT
+img.h-full
+.inline-flex img
+img[class="xs:inline rounded "]
+img.w-8
+
+CSS
+.non .bg-base-black,
+.non .md\:bg-base-black {
+    background-color: rgba(0,0,0,0) !important;
+}
+.text-base-black {
+    text-shadow: ${white} 1px 1px 0px !important;
+}
+@container (min-width: 900px) {
+    .non .\@md\:-translate-x-0 {
+        --tw-translate-x: 0 !important;
+    }
+}
+
+IGNORE INLINE STYLE
+text[fill="black"]
+.justify-center img
+.justify-center
+
+================================
+
+netzpolitik.org
+
+INVERT
+img[src*="/wp-content/themes/liebefeld/images/netzpolitik_logo.svg"]
+img[src*="/wp-content/themes/liebefeld/images/palasthotel.svg"]
+a.menu__canvas--toggle
+
+================================
+
+neuralnetworksanddeeplearning.com
+
+INVERT
+img[src$=".png"]
+img[src^="images/KSH"]
+img[src^="images/bump_function"]
+img[src^="images/high_weight_function"]
+canvas
+svg
+video
+
+================================
+
+new.mta.info
+
+CSS
+.services-container > .ss-header > #service-status-widget > .active > a:link {
+    background-color: #f2a900 !important;
+    color: #002d72 !important;
+}
+.services-container > .ss-header > #service-status-widget > .active > a:link::before {
+    color: #002d72 !important;
+}
+.ss-header {
+    border-bottom: 3px solid #f2a900 !important;
+}
+
+IGNORE INLINE STYLE
+a[title="MTA"] > svg > path
+
+IGNORE IMAGE ANALYSIS
+.block-service-status-block .line-1
+.block-service-status-block .line-2
+.block-service-status-block .line-3
+.block-service-status-block .line-7
+.block-service-status-block .line-A
+.block-service-status-block .line-C
+.block-service-status-block .line-E
+.block-service-status-block .line-SI
+
+================================
+
+newegg.com
+
+CSS
+.show-img-bg .goods-img:not(.bg-lightgray),
+.show-img-bg .goods-img > img {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+newreleases.io
+
+CSS
+.bg-white > .bg-cover {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.95)} !important;
+}
+
+================================
+
+newrepublic.com
+
+INVERT
+.HomePageNavTiny_container .HomePageNav_wordmark--mobile svg
+.HomePageNav_logo svg
+.HomePageNav_wordmark svg
+#hmb-btn
+
+================================
+
+news.mit.edu
+
+INVERT
+.logo > .mit-news
+
+================================
+
+news.mynavi.jp
+
+INVERT
+.itsearch-head .logo
+.site-header__bnr
+.site-header__logo
+
+================================
+
+news.yahoo.co.jp
+
+IGNORE IMAGE ANALYSIS
+.QrZuR
+
+================================
+
+news.yahoo.com
+
+INVERT
+#uh-logo
+.vp-handle
+
+================================
+
+news.ycombinator.com
+
+INVERT
+.votearrow
+
+CSS
+#hnmain {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+#hnmain .toptext {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+newsmax.com
+
+CSS
+#nmMain {
+    background-image: none !important;
+}
+
+================================
+
+newsroom.tiktok.com
+
+INVERT
+img[alt^="TikTok Logo"]
+
+================================
+
+newyorker.com
+
+INVERT
+[data-testid="Logo"]
+[class*="Logo__logo"]
+
+================================
+
+nexojornal.com.br
+
+INVERT
+.g-aiImg
+
+================================
+
+nextdns.io
+
+CSS
+.index .key-features .feature.blocklists {
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+path.rsm-geography
+
+IGNORE IMAGE ANALYSIS
+.index .hero .content .logo
+
+================================
+
+nextjs.org
+
+IGNORE INLINE STYLE
+.banner *
+
+================================
+
+nextron.no
+
+CSS
+.configurator .summary__titles .resource-row {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.configurator .summary__titles .resource-row > .resource-shape {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.configurator .summary__titles .resource-row > .resource-filled {
+    background-color: var(--darkreader-neutral-text) !important;
+    border-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+ngrok.com
+
+INVERT
+.customer-logos
+
+CSS
+.browser path[fill="#BBB"],
+.browser g[fill="#BBB"] {
+    fill: #BBB !important;
+}
+.terminal tspan[fill="#FFF"] {
+    fill: #FFF !important;
+}
+.terminal tspan[fill="#BBB"] {
+    fill: #BBB !important;
+}
+
+================================
+
+nicehash.com
+
+INVERT
+.chart
+img[src*="hashpower@2x]
+
+================================
+
+nicovideo.jp
+
+INVERT
+.NicoruIcon circle
+
+CSS
+@media (prefers-color-scheme: dark) {
+    #IMALinearView iframe {
+        opacity: 0.1 !important;
+    }
+}
+
+================================
+
+niestatystyczny.pl
+
+INVERT
+div#logo > h1 > a > img
+
+================================
+
+nightbot.tv
+
+CSS
+.nightbot-ScrollShadows-module__scrollShadows-IWawz {
+    background: transparent;
+}
+
+================================
+
+nirsoft.net
+
+CSS
+.menub1 a:link,
+.menub1 a:visited {
+    color: #0040ff;
+}
+.menub1 a:hover {
+    color: #ffffd0;
+}
+
+================================
+
+niser.ac.in
+
+CSS
+body,
+#main-content,
+#page {
+    background-image: none !important;
+}
+
+================================
+
+nixos.org
+
+INVERT
+header a[href="/"]::after
+
+CSS
+.demo-preview > .thumbnail svg .background {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.packages-searchbox::before,
+.packages-searchbox::after {
+    background-image: none !important;
+}
+
+================================
+
+njuskalo.hr
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+nlnet.nl
+
+INVERT
+.header_logo
+
+================================
+
+nlopt.readthedocs.io
+
+CSS
+.wy-nav-content-wrap {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+nnmclub.to
+nnm-club.me
+
+INVERT
+img[src$="images/icon_arrow.gif"]
+img[src$="images/freeleech.gif"]
+
+CSS
+div.ui-datepicker {
+    background: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+nodejs.org
+
+CSS
+[data-theme="dark"] h1.special {
+    background-image: linear-gradient(180deg, #fff, hsla(0, 0%, 100%, .8)) !important;
+}
+[data-theme="light"] h1.special {
+    background-image: linear-gradient(180deg, ${#2c3437}, ${rgba(44, 52, 55, .8)}) !important;
+}
+
+================================
+
+nof1sced.org
+
+CSS
+:is(header#SITE_HEADER, footer#SITE_FOOTER) div[data-testid="screenWidthContainerBgCenter"] {
+    background-color: transparent !important;
+}
+header#SITE_HEADER nav[aria-label="Site"] ul {
+    background-color: var(--darkreader-background-ffffff) !important;
+}
+wix-dropdown-menu li.wixui-dropdown-menu__item[data-state~="selected"],
+wix-dropdown-menu li.wixui-dropdown-menu__item[data-state~="link"]:hover,
+wix-dropdown-menu ul.wixui-dropdown-menu__submenu li[data-state~="link"]:hover {
+    background-color: ${#92d2e0} !important;
+}
+html[data-darkreader-scheme="dark"] div.wixui-box {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+wix-dropdown-menu li.wixui-dropdown-menu__item p,
+wix-dropdown-menu ul.wixui-dropdown-menu__submenu p {
+    color: ${#525252} !important;
+}
+
+================================
+
+nofluffjobs.com
+
+INVERT
+ul.posting-info-row li.tw-items-center svg.icon
+
+================================
+
+nokia.com
+
+CSS
+.pds-background-cover > .pds-background-image-set {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.pds-background-cover video {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+nokings.org
+
+INVERT
+.mapboxgl-canvas
+.mapboxgl-ctrl-icon
+.mapboxgl-ctrl-logo
+.mapboxgl-marker > svg > path[opacity="0.25"]
+
+CSS
+.white > .content-wrapper > .content > div[data-fluid-engine="true"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.mapboxgl-ctrl button.mapboxgl-ctrl-zoom-in .mapboxgl-ctrl-icon
+.mapboxgl-ctrl button.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon
+
+================================
+
+nomadgoods.com
+
+INVERT
+header a[href="/"] > svg
+
+================================
+
+nonograms.org
+
+CSS
+.nonogram_table {
+    background-color: #404040 !important;
+}
+
+================================
+
+nonsa.pl
+
+INVERT
+a.mw-wiki-logo
+#p-banner
+
+================================
+
+norton.com
+
+INVERT
+.c-topnav__wrap a
+
+================================
+
+nos.nl
+
+INVERT
+.npo-button
+ul li a::before
+[data-sentry-component="SubNavBar"] a[aria-current="page"]
+[data-sentry-component="SubNavBar"] a:not([aria-current="page"]):hover
+
+IGNORE IMAGE ANALYSIS
+.npo-button
+
+================================
+
+notion.so
+
+INVERT
+img[alt="People using Notion"]
+.global-margin-s .logos
+.persona-grid > .persona-grid-item > .persona-grid-image
+.desktop-illustration
+.illustration .next-image
+.api-section-image .next-image
+.visual .next-image
+.logo svg > :first-child
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+* {
+    caret-color: ${gray} !important;
+}
+.notion-divider-block div div {
+    border-bottom: 1px solid ${rgba(55, 53, 47, 0.4)} !important;
+}
+
+================================
+
+novartis.com
+
+INVERT
+#logo
+
+================================
+
+novelgames.com
+
+CSS
+a#commonLogo {
+    background-image: url("https://staticz.novelgames.com/style/default/common_e.5.png"), linear-gradient(rgb(255, 255, 255), rgb(255, 255, 255)), url("https://staticz.novelgames.com/style/default/common.8.png") !important;
+}
+
+================================
+
+novinky.cz
+garaz.cz
+seznamzpravy.cz
+
+CSS
+.ribbon,
+.szn-input-with-suggest-list {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.szn-input-with-suggest-list {
+    border-color: ${gray} !important;
+}
+
+================================
+
+novnp.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+nowafarmacja.pl
+
+INVERT
+.icon-chevron-down
+.payment-banners
+.hheader::after
+
+================================
+
+nowemedium.pl
+
+INVERT
+.logo-tagline-group
+.menu_toggle
+
+================================
+
+nperf.com
+
+INVERT
+.SpeedTest > .resultPanel
+
+CSS
+.SpeedTest > .resultPanel {
+    background-color: transparent !important;
+}
+
+================================
+
+npmjs.com
+
+INVERT
+header a[href="/"] svg
+#orgs_panel img.h2
+#enterprise_detail_panel img.h2
+#customers_panel img[src*="adobe.full.png"]
+#customers_panel img[src*="bbc.full.png"]
+#customers_panel img[src*="conde-nast.full.png"]
+#customers_panel img[src*="netflix.full.png"]
+#customers_panel img[src*="visa.full.png"]
+._5532dff2
+._93bbf0b4
+
+CSS
+a title + g[data-darkreader-inline-fill] {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+nrc.nl
+
+INVERT
+.header__logo
+.selections-bar__item__image
+.header__button svg
+.block__more-link__arrow path
+.metabox__icon
+.article__byline__icon
+.footer__logo
+.socialbuttons
+
+================================
+
+ntlite.com
+
+CSS
+.fr-wrapper *::selection {
+    background-color: dodgerblue !important;
+}
+
+================================
+
+nu.nl
+
+CSS
+.app-figure--caption-overlay {
+    background: linear-gradient(0deg, var(--darkreader-neutral-background), #fff 40%) !important;
+}
+.main-nav__main {
+    border-top: inherit !important;
+}
+
+================================
+
+nucnet.org
+
+INVERT
+img.hidden[alt="Logo"]
+img.block[title="Person"]
+img[alt="Magnifying glass"]
+img[alt="Letter"]
+button.toggle-mobile-nav span
+
+================================
+
+nvidia.com
+nvidia.in
+
+INVERT
+svg.global-footer__logo
+a.brandLink
+img[src*="Experience"]
+img[src*="tao-toolkit-"]
+img[src*="logo"]:not(img[src*="no-logo"])
+.nvidia-logo
+img[src*="web-skinny-blade"]
+img[src*="glass"]
+
+CSS
+div.nvidia a svg {
+    fill: ${black} !important;
+}
+div.brand-container a svg {
+    fill: ${black} !important;
+}
+.taboff {
+    background-image: none !important;
+}
+.mid-gray {
+    background-color: #999 !important;
+    fill: #999 !important;
+}
+.dark .green40 {
+    background-color: #3b5d00 !important;
+    fill: #3b5d00 !important;
+}
+.green50 {
+    background-color: #598b00 !important;
+    fill: #598b00 !important;
+}
+.dark .green100 {
+    background-color: #76b900 !important;
+    fill: #76b900 !important;
+}
+html[data-darkreader-scheme="dark"] .nv-img-as-bg img {
+    filter: brightness(0.5) !important;
+}
+
+================================
+
+nvidia.pl
+
+INVERT
+.brand-container
+img[src*="Experience"]
+a[href*="facebook"]
+a[href*="twitter"]
+
+CSS
+body,
+.taboff {
+    background-image: none !important;
+}
+
+================================
+
+nxos.org
+
+INVERT
+#logo
+a[href^="#sidewidgetarea"]
+
+================================
+
+nyc.gov
+
+CSS
+.background-gradient {
+    background: none !important;
+}
+
+================================
+
+nymag.com
+
+INVERT
+.article-feed-header svg
+.article-nav-top-center
+#latest-feed-title
+.logo-svg
+#site-feed-curbed-title > .feed-title-wrapper
+.tab-trigger > svg
+.tab-trigger > svg > circle
+.tab-trigger > svg > g > circle
+.title-logo
+#vulture-trigger > svg > g > path:nth-child(1)
+#wwwthecut-trigger > svg > .active > path
+
+CSS
+.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-image-wrap {
+    z-index: 0 !important;
+}
+.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-text-wrap {
+    position: absolute !important;
+    z-index: 1 !important;
+}
+
+================================
+
+nytimes.com
+
+INVERT
+button[aria-label="Listen to article"] path[stroke="#DFDFDF"]
+div[data-testid="masthead-desktop-logo"] > a > svg
+div#live-country-map.live-country-map-embed
+div#live-us-map.live-us-map-embed
+.needle-wrap > svg
+.svelte-1v1dl99
+.vmap-layer-container > g > text
+.vmap-zoom-buttons
+#xwd-board
+.pz-nav__logo > path
+.pz-nav__hamburger-box
+div.Domino-module_dotsWrapper__fkTri
+.cell-letter
+.sb-input-invalid
+
+CSS
+.letter.filled.remaining {
+    background-color: var(--darkreader-bg--spelling-bee-light-yellow) !important;
+}
+polygon.cell-fill {
+    stroke: var(--darkreader-bg--stroke) !important;
+}
+button[aria-label="Listen to article"] path[d="M22 38L37 28L22 18V38Z"],
+button[aria-label="Save article for reading later..."] .saved-stroke {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.css-oylsik,
+.css-nhjhh0 svg,
+.css-18z7m18 svg,
+.css-1q2j1fr svg,
+a[data-testid] > svg {
+    fill: ${black} !important;
+}
+.headline-link div {
+    color: ${black} !important;
+}
+.headline-link div:hover {
+    color: ${#555} !important;
+}
+.pz-nav__logo > rect {
+    fill: var(--darkreader-bg--bg-page);
+}
+.svelte-15nnlbj {
+    font-weight: bold !important;
+}
+#xwd-board rect[class^="Cell-block--"] {
+    fill: ${black} !important;
+}
+#xwd-board text[class^="Cell-hidden--"] {
+    color: ${black} !important;
+}
+#xwd-board rect[class^="Cell-cell--"] {
+    fill: ${darkgrey} !important;
+}
+#xwd-board rect[class^="Cell-highlighted--"] {
+    fill: ${lightgrey} !important;
+}
+#xwd-board rect[class^="Cell-selected--"] {
+    fill: ${white} !important;
+}
+#xwd-board rect[class^="Cell-related--"] {
+    fill: ${goldenrod} !important;
+}
+#xwd-board rect[class^="xwd__cell--cell"] {
+    fill: ${darkgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--highlighted"] {
+    fill: ${lightgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--selected"] {
+    fill: ${white} !important;
+}
+#xwd-board rect[class^="xwd__cell--related"] {
+    fill: ${khaki} !important;
+}
+#xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
+    fill: ${blue} !important;
+}
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="0"] {
+    background-color: rgb(153, 140, 41) !important;
+}
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="1"] {
+    background-color: rgb(82, 133, 40) !important;
+}
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="2"] {
+    background-color: rgb(60, 116, 144) !important;
+}
+html[data-darkreader-scheme="dimmed"] [class*=SolvedCategory-module_solvedCategory][data-level="2"] {
+    background-color: var(--bg-connections-medium) !important;
+}
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="3"] {
+    background-color: rgb(120, 58, 133) !important;
+}
+[class*=Card-module_label] {
+    background-color: ${#dbdbdb} !important;
+}
+[class*=Card-module_label][class*=Card-module_selected] {
+    background-color: #404040 !important;
+}
+
+IGNORE INLINE STYLE
+line[style="stroke: var(--tie); stroke: black;"]
+
+================================
+
+nzbget.*
+
+INVERT
+.icon-top
+.icon-bottom
+.icon-up
+.icon-down
+
+================================
+
+nzz.ch
+
+INVERT
+.logo
+
+CSS
+.logo {
+    background-color: unset !important;
+    color: ${white} !important;
+}
+
+================================
+
+o2.co.uk
+
+INVERT
+.brandLogo
+
+================================
+
+oalevelsolutions.com
+
+INVERT
+p > span > img
+
+================================
+
+objectclub.jp
+
+INVERT
+#region-content > div.plain > table > tbody > tr > td > img:nth-child(2)
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+observar.ipma.pt
+
+INVERT
+.container-logos img
+
+================================
+
+obserwatorgospodarczy.pl
+
+INVERT
+.logo-img
+
+================================
+
+oclc.org
+
+IGNORE INLINE STYLE
+.chart-key
+
+================================
+
+odysee.com
+
+INVERT
+.header__navigation-logo
+[data-vjs-player] .vjs-control-bar > [title="Autoplay Next Off"]
+[data-vjs-player] .vjs-control-bar > [title="Autoplay Next On"]::after
+
+CSS
+.content__viewer {
+    border: none !important;
+}
+
+================================
+
+oed.com
+
+INVERT
+img[alt="search"]
+
+CSS
+.wordy {
+    color: var(--darkreader-neutral-text) !important;
+}
+#maincontainer {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+select
+
+================================
+
+oeis.org
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+================================
+
+oferteo.pl
+
+INVERT
+img[src*="oferteo-color"]
+ul.logo-box.text-center
+span.icon-gray.quotation-mark
+
+================================
+
+office.com
+*.office.com
+
+INVERT
+.ms-ohp-svg-Icon.ms-ohp-Icon--privacyLogo
+
+IGNORE IMAGE ANALYSIS
+.ms-ohp-svg-Icon.ms-ohp-Icon--privacyLogo
+.ms-ohp-svg-Icon.ms-ohp-Icon--calendarLogo::before
+.ms-ohp-svg-Icon.ms-ohp-Icon--flowLogo::before
+
+================================
+
+oisd.nl
+
+INVERT
+img[alt="logo"]
+
+================================
+
+okonto.pl
+
+INVERT
+.imageWidget
+
+================================
+
+okta.com
+
+INVERT
+.chiclet--container
+.chiclet--article
+.chiclet--footer
+img[class="logo"]
+
+================================
+
+old.reddit.com
+
+INVERT
+.volume-slider-bar
+.volume-slider-thumb
+.reddit-video-seek-bar-root
+
+CSS
+.seek-bar-progress {
+    background-color: ${#004daa} !important;
+}
+body::before {
+    z-index: 0 !important;
+}
+.footer-parent {
+    position: relative !important;
+    z-index: 1 !important;
+}
+.link .usertext-body .md,
+.commentarea,
+.commentarea > .usertext.cloneable,
+textarea,
+.comment,
+.comment .flat-list li,
+.title-button,
+.linkinfo,
+.side .md > blockquote:first-child,
+body.loggedin .side .redditname::after,
+.side .md > blockquote:first-child > h1 + p a,
+.side .md h2:first-of-type ~ *,
+.side .md > p:first-of-type ~ h2::before,
+.flair::before,
+.flair::after,
+.linkflairlabel::before,
+.linkflairlabel::after {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+#sr-more-link {
+    background-color: black !important;
+    background-image: none !important;
+}
+.dropdown.srdrop .selected {
+    color: inherit !important;
+}
+
+================================
+
+oldmutual.co.ke
+oldmutual.co.*
+
+INVERT
+.om-page-background-image div
+
+CSS
+.om-investment-calculator.theme-uapom {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+oleole.pl
+
+INVERT
+#logo::after
+div[id="brands-carousel"]
+div[id="footer-logo-brands"]
+img[src*="main_menu"]
+img[src*="SG/icon"]
+
+================================
+
+olx.pl
+
+CSS
+.searchmain {
+    background-color: var(--darkreader-inline-bgcolor) !important;
+}
+.wrapper,
+.footer-bottom {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.cat-icon.cat-cmt-icon-628
+.cat-icon.cat-cmt-icon-87
+.cat-icon.cat-cmt-icon-2433
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-1.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-6.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-8.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-7.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-2.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-5.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-4.cat-icon-promo
+.maincategories .maincategories-list .li .item a[data-id="promo"] .category-3.cat-icon-promo
+
+================================
+
+omarapollo.com
+
+INVERT
+.header__heading-logo
+
+CSS
+.gradient {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+omgubuntu.co.uk
+
+CSS
+.header {
+    background: var(--header-background) !important;
+}
+
+================================
+
+omni.se
+
+CSS
+.article,
+.resource,
+.component--storyLink,
+.component--storyHeading,
+.btn--secondary,
+.starbox-star {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+omnicalculator.com
+
+CSS
+.GenericText {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+omnivox.ca
+
+INVERT
+td[style*="/cvir/UI"]
+img[src^="/cvir/UI/Theme/Lea_Defaut/Images/Accueil_LEA"]
+img[src="/cvir/UI/Theme/Lea_Defaut/Images/mesclasses_cg_subtop.jpg"]
+img[src^="/cvir/UI/Theme/Lea_Defaut/Images/accueil_"]
+img[src$="/bas_du_menu.jpg"]
+img[src$="tile.jpg"]
+.cgSelect
+.mioLinks
+.calendrier
+.servLinks
+.descSection
+
+CSS
+.cgSelect > table > tbody > tr > td:nth-child(1) > a > font {
+    color: green !important;
+}
+.calendrier > table > tbody > tr,
+.calendrier > table > tbody > tr > td > img,
+.calendrier > table > tbody > tr > td > table > tbody > tr > td > img {
+    filter: invert(100%) hue-rotate(180deg) contrast(100%) !important;
+}
+table[style*="/cvir/UI"],
+.cgBg {
+    background-image: none !important;
+}
+
+================================
+
+one.kaseya.com
+
+INVERT
+canvas
+kds-card-header img
+
+================================
+
+one.one.one.one
+
+INVERT
+.PerformanceSection--figure-item-bar
+
+================================
+
+one.uf.edu
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+onedrive.live.com
+
+CSS
+.ms-CommandBar {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+onelook.com
+
+INVERT
+img[alt="OneLook"]
+
+================================
+
+onepeterfive.com
+
+CSS
+.gb-has-dynamic-bg {
+    background-image: var(--background-url) !important;
+}
+
+================================
+
+onet.pl
+plejada.pl
+*.onet.pl
+
+INVERT
+[class*="WeatherDay_tempIcon"]
+._3ZySwSLi_pur0unnAQO2No
+.forecast img
+.icon-shareIcon svg
+.locationName svg
+.logo-cls-1
+.logoImageRight
+.serviceIcon
+.sheet
+.weatherBox .iconNow
+[class*="weatherIcon"]
+.websiteLogo
+[class*="Logo_"]
+a.serviceLogo img
+img[alt="O!Konto"]
+img[alt="Plejada.pl"]
+ul.contentList img.icon
+svg[class*="MenuIcon"]
+svg[class*="LoginIcon"]
+svg[class*="ProfileImage_imageSvg"]
+svg path[fill="#fff"]
+.weatherExtrasWidget__category-image img
+[class*="SponsorImage"]
+.windDirectionArrow
+.geoIcon
+.regionsContentList .iconHolder img
+.hSunChart img
+.hMoonChart img
+
+CSS
+.mainBoxBgHolder {
+    background-blend-mode: color;
+    background-color: rgba(0, 0, 0, 0.25);
+}
+.weatherMap .mapLayer .fil0,
+#weatherChartsHolder .chartValue {
+    fill: rgb(128, 128, 128) !important;
+}
+svg path[d^="M50.315,89"],
+path[d^="M15.757"],
+path[d^="M14.989"],
+path[d^="M8.935"],
+path[d^="m14.05"] {
+    fill: ${white} !important;
+}
+.contentPremium * {
+    filter: unset !important;
+}
+div[class*="PremiumLabel_container"] {
+    background-size: 100% !important;
+}
+
+================================
+
+online.yettelbank.rs
+
+CSS
+.css-1kzjn4e {
+    background-color: white !important;
+}
+
+IGNORE INLINE STYLE
+.MuiBox-root div svg *
+
+================================
+
+onlinelibrary.wiley.com
+
+INVERT
+#mainLogo
+
+================================
+
+onlinetrade.ru
+
+INVERT
+.drawCats__item__name
+
+CSS
+.drawCats__item__image {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+onlineuniversities.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+onlyoffice.com
+
+INVERT
+.logo
+
+================================
+
+onnibus.com
+
+INVERT
+.icon
+
+================================
+
+op.gg
+
+INVERT
+.Level
+.ranking-highest__icon .ranking-highest__level
+
+================================
+
+open-meteo.com
+
+CSS
+.highcharts-background,
+.highcharts-tooltip text,
+.highcharts-no-tooltip text {
+    fill: ${white} !important;
+}
+.highcharts-axis-title,
+.highcharts-title,
+.highcharts-axis-labels,
+.highcharts-label-box,
+.highcharts-button-box,
+.highcharts-legend-item text {
+    fill: ${black} !important;
+}
+.highcharts-axis-line {
+    stroke: ${white} !important;
+}
+body {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+body,
+footer .text-secondary-foreground,
+.text-center,
+input button * {
+    color: ${black} !important;
+}
+.text-white * {
+    fill: ${black} !important;
+    text-shadow: none;
+}
+input {
+    color: var(--darkreader-neutral-text) !important;
+}
+.bg-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.bg-accent {
+    background-color: gray !important;
+}
+.-z-10 {
+    z-index: 0 !important;
+}
+
+================================
+
+openaccess.thecvf.com
+
+INVERT
+img
+
+================================
+
+openai.com
+
+INVERT
+figure.release-cover>div:first-of-type>img
+
+CSS
+body {
+    background: initial !important;
+}
+header[style*="background-image"],
+.bg-cover[style*="background-image"] {
+    background: none !important;
+}
+.is-below-fold .header--cover .nav,
+.is-below-fold .post-header--cover .nav {
+    background: ${white} !important;
+    color: ${black} !important;
+}
+span.token.comment {
+    color: ${#aaa} !important;
+}
+span.token.punctuation {
+    color: ${#777} !important;
+}
+a.btn:not(.fade),
+button.btn {
+    background: ${rgba(5, 5, 38, 0.05)} !important;
+    color: ${#050526} !important;
+}
+button.btn:hover {
+    color: ${#b0b0b0} !important;
+}
+figcaption,
+.caption {
+    color: ${rgba(5,5,38,0.5)} !important;
+}
+.content .timeline > li::before,
+.timeline > li::before {
+    color: ${black} !important;
+}
+.content .timeline > li::after,
+.timeline > li::after {
+    background-color: ${black} !important;
+}
+.switch-input:checked + .switch-label {
+    color: ${rgba(0, 0, 0, 0.7)} !important;
+}
+
+================================
+
+openanolis.org
+
+INVERT
+.logo
+
+================================
+
+openbenchmarking.org
+
+INVERT
+g[font-size]:not(g[font-size][fill^="#fff" i]:not(.oborg_expandable_result g))
+g[font-size]:not(g[font-size][fill^="#fff" i]) > text[fill="#005a00"]
+
+IGNORE INLINE STYLE
+g[font-size][fill^="#fff" i]
+
+================================
+
+opencollective.com
+
+INVERT
+img[alt="Open Collective"]
+
+CSS
+#section-contributors > div {
+    background-image: none !important;
+}
+
+================================
+
+openebooks.net
+
+INVERT
+img[src="images/home_banner.png"]
+
+================================
+
+openenglishbible.org
+
+INVERT
+#logo
+img[src="html-logo.png"]
+
+================================
+
+opengeofiction.net
+openstreetmap.org
+openhistoricalmap.org
+
+INVERT
+.map-layout #map .leaflet-tile
+.map-layout #map .leaflet-image-layer
+.ideditor g.vertex .icon
+.ideditor g.point .icon
+.ideditor .icon.areaicon-halo
+
+CSS
+:root {
+    --darkreader-background-7092ff: #4050c0;
+}
+div[dir="ltr", id="map"] {
+    background: #000 !important;
+    filter: none !important;
+}
+.ideditor .labels-group.halo text {
+    stroke: var(--darkreader-neutral-background) !important;
+}
+.map-layout #map {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+img.loader {
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important;
+}
+
+IGNORE INLINE STYLE
+.ideditor .main-content *
+
+================================
+
+openingtree.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+openoffice.org
+
+INVERT
+#ooo-logo
+
+================================
+
+openreview.net
+
+CSS
+#__next {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+opensecrets.org
+
+INVERT
+.dc-header__logo
+
+================================
+
+openspeedtest.com
+
+CSS
+use.Cards {
+    fill: unset !important;
+}
+
+================================
+
+openstax.org
+
+CSS
+input[data-testid$="-search-input"] {
+    background-color: transparent !important;
+}
+
+================================
+
+openvpn.net
+
+IGNORE INLINE STYLE
+.navbar-brand > svg *
+
+================================
+
+openwall.com
+
+INVERT
+.logo
+
+================================
+
+openweathermap.org
+
+INVERT
+#chart-component
+#y-axis
+img.leaflet-tile
+
+================================
+
+openwrt.org
+
+CSS
+#dw__pagetools .menuitem svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+opti-24.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+ordnet.dk
+
+CSS
+body {
+    background: none !important;
+}
+.searchResultBox {
+    background-image: none !important;
+}
+
+================================
+
+orf.at/corona/*
+
+INVERT
+.bg
+.annotation
+.sparkline--fill
+
+================================
+
+origene.com
+
+CSS
+.block .title *,
+.items > li,
+.nav-item *:not(:hover),
+.oti-footer *,
+.product.attribute.sku,
+.product.info.detailed,
+.product-info-main,
+.product-related-container *,
+.switch,
+body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+osu.edu
+ohio-state.edu
+
+CSS
+#osu_navbar {
+    background-image: linear-gradient(rgb(40, 43, 45) 0%, rgb(63, 69, 71) 100%);
+    border-bottom: 5px solid rgb(187, 0, 0);
+}
+body.sidebar-layout #page #content,
+#page #content {
+    background-image: none;
+}
+
+================================
+
+otomoto.pl
+
+INVERT
+.seller-card__links__link__icon
+
+================================
+
+overleaf.com
+
+INVERT
+.canvasWrapper
+div.example img
+
+================================
+
+overpass-turbo.eu
+
+IGNORE INLINE STYLE
+.leaflet-container
+.leaflet-container *
+
+================================
+
+overreacted.io
+
+CSS
+:root {
+    --bg: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+overwatchleague.com
+
+CSS
+div[class^="dynamic-bracketstyles__Container"] .connector {
+    z-index: 0 !important;
+}
+body {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ovhcloud.com
+
+INVERT
+.oof-content-group-line-item
+
+================================
+
+owncube.com
+
+INVERT
+[src="/assets/img/logo.png"]
+
+CSS
+h1,
+h2,
+h3,
+h4,
+h5 {
+    color: var(--darkreader-neutral-color);
+}
+
+================================
+
+oxfordlearnersdictionaries.com
+
+INVERT
+.old_logo
+.logo-footer
+
+================================
+
+ozbargain.com.au
+
+CSS
+div.comment-op {
+    background-image: linear-gradient(#000000, #212121) !important;
+}
+
+================================
+
+ozon.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+p30download.com
+
+CSS
+.article-wrapper {
+    color: ${#090702} !important;
+}
+
+================================
+
+pa.gov
+
+INVERT
+.nav .nav-trigger.nav-open .inner
+
+CSS
+button {
+    border: 2px solid #003e51 !important;
+}
+.nav-trigger:hover {
+    box-shadow: inset 0 0 0 2px #003e51 !important;
+}
+.nav-wrapper {
+    background: #003e51 !important;
+}
+
+================================
+
+pacjent.gov.pl
+
+CSS
+.hero-content {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+packages.ubuntu.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+pagerduty.com
+
+INVERT
+.navbar-brand
+
+CSS
+[class*="SearchBox_icon"] {
+    filter: invert(80%);
+}
+
+================================
+
+palemoon.org
+
+INVERT
+img[src="images/goanna200x66.png"]
+img[src="images/vpsserver.png"]
+
+================================
+
+pan.baidu.com
+
+INVERT
+.module-header-wrapper dt
+
+================================
+
+pan.quark.cn
+
+INVERT
+img[alt="夸克网盘"]
+img[alt="夸克网盘 logo"]
+
+================================
+
+panapply.org
+
+INVERT
+.logo
+
+================================
+
+panerabread.com
+
+INVERT
+.pds-h-logo
+
+================================
+
+panthema.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+papaya.rocks
+
+INVERT
+.favorite.js-open-login
+.header__title
+.js-logo
+.js-logo-big
+.js-menu-toggle
+.js-open-search
+.nav__item--profile
+.search__button
+.search__close
+
+================================
+
+paradoxwikis.com
+*.paradoxwikis.com
+
+INVERT
+.mwe-math-fallback-image-inline
+
+================================
+
+parallel42.com
+
+INVERT
+.header__logo-image
+
+CSS
+.content-over-media::before {
+    background: rgb(var(--content-over-media-overlay)) !important;
+}
+.buy-buttons button {
+    background-color: black !important;
+}
+.buy-buttons button:hover {
+    opacity: 0.75 !important;
+}
+
+================================
+
+park-in.gr
+
+CSS
+.div-background {
+    z-index: 0 !important;
+}
+.container {
+    position: relative !important;
+    z-index: 1 !important;
+}
+
+================================
+
+partitionwizard.com
+
+CSS
+.pw-banner {
+    background-image: none !important;
+}
+
+================================
+
+passport.baidu.com
+
+INVERT
+.pass-header-logo
+.right-icon
+
+================================
+
+passport.bilibili.com/login
+
+CSS
+.qrcode-box {
+    background: white !important;
+    padding: 10px !important;
+}
+
+================================
+
+passport.jd.com
+
+CSS
+.qrcode-img {
+    background: white !important;
+}
+
+================================
+
+passport.yandex.*
+
+CSS
+.MagicField-qr {
+    background-color: white !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+paste.rs
+
+CSS
+pre {
+    --darkreader-inline-bgcolor: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+pathfinderwiki.com
+
+CSS
+body {
+    background-color: ${rgb(245,245,245)};
+    background-image: none;
+}
+.mw-page-container-inner {
+    background-color: ${rgb(225,225,245)};
+    background-image: none;
+}
+.fw-alignment-on {
+    --darkreader-inline-bgcolor: royalblue !important;
+}
+.fw-alignment-on a {
+    color: ${black} !important;
+}
+
+================================
+
+patreon.com
+
+INVERT
+a[href^="https://docs.google.com"] img
+a[href^="https://forms.gle"] img
+button[data-tag="menuToggleDiv"] svg
+[data-tag="creator-public-page-social-twitch"]
+[data-tag="creator-public-page-social-twitter"]
+[data-tag="pages-creator-public-page-Header-ShareCampaign"]
+
+CSS
+div[data-tag="comment-actions"] svg,
+div[data-tag="post-details"] svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+patriotmemory.com
+
+INVERT
+.w-nav a[href="/"] img
+.w-nav-brand
+
+================================
+
+patuscada.bar
+
+INVERT
+.topo
+.topo > *
+.patuscada-logo
+.botoes-topo a:last-child img
+.logo
+
+IGNORE IMAGE ANALYSIS
+.etiqueta-vermelha
+
+================================
+
+paulgraham.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+paypal-doladowania.pl
+
+INVERT
+img[src*="/img/bank-logos/"]
+
+================================
+
+paypal.com
+
+INVERT
+span[style*="svg"]
+
+CSS
+input.invoiceNumber,
+input.transactionAmount {
+    border-style: solid !important;
+    border-width: 1px !important;
+}
+.cw_tile-promo-title-container_dw2.css-1cak51m-card_base {
+    background: none !important;
+}
+.tab_container,
+.listing_bg {
+    background-color: ${#faf8f5} !important;
+}
+.listing_container,
+.listing_container_background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div[data-testid="federated-moneyfragment"] span[class*="css-"]::before {
+    font-family: PPUI-Icons, "Helvetica Neue", Arial, sans-serif !important;
+}
+div[data-testid="payment-indicator"]:not(.bg-experimental-black) svg {
+    fill-opacity: 0 !important;
+}
+
+================================
+
+payu.com
+
+CSS
+img[src$="PayU-Map_Homepage_World.svg"] {
+    filter: invert(90%) hue-rotate(180deg) contrast(90%) !important;
+}
+
+================================
+
+pbs.org
+
+CSS
+BODY.normal td.bodyarea,
+body[background] {
+    background-image: none !important;
+}
+
+IGNORE INLINE STYLE
+.page-header__brand > svg > path
+
+================================
+
+pcdiga.com
+
+CSS
+.data {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+input,
+textarea {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+li.level0 > a {
+    color: var(--darkreader-neutral-text) !important;
+}
+li.level0 > a:hover {
+    color: #ff4d23 !important;
+}
+
+================================
+
+pcgamer.com
+
+INVERT
+img[alt="Best Buy"]
+img[alt="Amazon"]
+
+CSS
+img {
+    mix-blend-mode: normal !important;
+}
+
+IGNORE INLINE STYLE
+path
+
+================================
+
+pcgamesn.com
+
+CSS
+article a.text_link,
+.entry-meta.end-of-post a,
+.article_affiliate_disclaimer a {
+    background-image: none !important;
+    color: var(--primary-color) !important;
+    text-decoration: none !important;
+}
+[data-darkreader-scheme="dimmed"] article a.text_link,
+[data-darkreader-scheme="dimmed"] .entry-meta.end-of-post a,
+[data-darkreader-scheme="dimmed"] .article_affiliate_disclaimer a {
+    filter: brightness(0.6) saturate(2) !important;
+}
+article p,
+aside li a,
+.article_affiliate_disclaimer {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+pcgamingwiki.com
+
+INVERT
+img[alt="Gamesplanet logo.svg"]
+.infobox-steamdb
+
+CSS
+div.svg-icon {
+    background-size: contain !important;
+}
+.headerSort {
+    background-size: initial !important;
+}
+body {
+    height: auto !important;
+}
+.infobox-steamdb {
+    background-image: url("https://www.pcgamingwiki.com/w/skins/overclocked/resources/icons/infobox-steamdb.svg?31569") !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.thumbs-down
+.tickcross-false
+
+================================
+
+pch24.pl
+
+INVERT
+a[href="https://pch24.pl"] svg
+
+CSS
+a[href="https://pch24.pl"] svg path[fill="#1d1e1d"] {
+    --darkreader-inline-fill: ${white} !important;
+}
+
+================================
+
+pcloud.com
+
+INVERT
+.logo
+
+================================
+
+pcmag.com
+
+INVERT
+label[aria-label="Hamburger Menu Toggle"]
+label.after\:bg-gray-700::after
+
+================================
+
+pcmonitors.info
+
+CSS
+.skinset-main.nv-skin,
+.custom-layer {
+    background: none !important;
+    background-image: none !important;
+}
+
+================================
+
+pcpartpicker.com
+
+IGNORE INLINE STYLE
+.price-history-legend-color
+
+================================
+
+pcworld.com
+
+INVERT
+a#siteSearch-close-button svg
+a#mobileNav-close-button svg
+
+================================
+
+peardeck.com
+
+INVERT
+.boxy-svg
+.mc-answer__check-inner
+.check-svg
+
+================================
+
+pennylane.ai
+
+INVERT
+div[style*="xanadu-background.png"]
+div[style*="xanadu-background.png"] > div
+div[style*="banner.png"]
+div[style*="banner.png"] > div
+
+================================
+
+peonaviveu.blogspot.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+perfekcyjnawdomu.pl
+
+INVERT
+img[src*="logo"]
+
+================================
+
+petco.com/shop/en/petcostore
+
+INVERT
+a[class^="LogoAnchor__Container"]
+button[class^="HamburgerButton"]
+img.center-block.margin-top-sm
+h1.pals-header
+
+================================
+
+petdex.crafter.run
+
+IGNORE INLINE STYLE
+.pet-sprite
+
+IGNORE IMAGE ANALYSIS
+.pet-sprite
+
+================================
+
+petri.com
+
+INVERT
+.logo
+
+================================
+
+pgatour.com
+
+CSS
+.score-card tr td.birdie {
+    background-color: rgb(1, 76, 181);
+    background-image: initial;
+}
+
+================================
+
+pgp.net.nz
+
+INVERT
+img[src*="DotNZ.svg"]
+img[src*="InternetNZ.svg"]
+
+================================
+
+phoenixframework.org
+
+CSS
+.eva {
+    font-family: "Eva-Icons" !important;
+}
+
+================================
+
+phonescoop.com
+
+INVERT
+#sitelogo
+
+CSS
+div#outer.wide,
+#socpage,
+div#top.top-lg,
+div#outer {
+    background-image: none !important;
+}
+
+================================
+
+phoronix.com
+
+INVERT
+img[type="image/svg+xml"]
+
+================================
+
+photofeeler.com
+
+INVERT
+.navbar-brand
+
+================================
+
+photopea.com
+
+CSS
+.block .panelhead div .cross {
+    background-image: var(--icon_cross);
+}
+.window .whead .cross {
+    background-image: var(--icon_cross);
+}
+[data-darkreader-inline-fill] {
+    fill: ${white} !important;
+}
+* {
+    border-color: var(--darkreader-bg--bg-panel) !important;
+}
+
+================================
+
+photos.google.com
+
+CSS
+svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.RSjvib a:hover {
+    background: var(--darkreader-bg--gm3-sys-color-secondary-container) !important;
+}
+.RSjvib a.uprWmb {
+    background: var(--darkreader-bg--gm3-sys-color-surface-tint) !important;
+}
+
+================================
+
+phys.nagoya-u.ac.jp
+
+INVERT
+img[src="img/top_94.gif"]
+
+CSS
+#wrap table {
+    background-image: none !important;
+}
+
+================================
+
+physics.gmu.edu
+
+INVERT
+img.math-display
+
+================================
+
+pianistdiscography.com
+
+CSS
+.bg_white {
+    background-image: none !important;
+}
+
+================================
+
+piazza.com
+
+CSS
+.dashboard_toolbar,
+.page_feed_bucket_header {
+    background: linear-gradient(to bottom, ${#c5c7cd} 0%, ${#dfe1e2} 100%) !important;
+}
+
+================================
+
+picknsave.com
+
+INVERT
+.KrogerHeader-Logo--inner
+
+================================
+
+picrew.me
+
+IGNORE INLINE STYLE
+.imagemaker_colorpalette li
+
+================================
+
+pilot.wp.pl
+
+INVERT
+.logo
+div > button > svg
+
+================================
+
+ping.sx
+
+INVERT
+.ring-0
+
+CSS
+#headlessui-switch-1 {
+    filter: brightness(70%) !important;
+}
+
+================================
+
+pinterest.com
+*.pinterest.com
+
+INVERT
+[aria-label="Home"][style*="data:image/svg+xml"]
+[style*="%23111111"][style*="data:image/svg+xml"]
+
+================================
+
+pipewire.org
+
+CSS
+body,
+img,
+video,
+iframe {
+    filter: none !important;
+}
+
+================================
+
+pipiwiki.com
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+#logo_img
+
+================================
+
+pir2.forumeiros.com
+
+INVERT
+img[src*="latex"]
+
+================================
+
+pirateship.com
+
+INVERT
+.pdf-preview
+
+================================
+
+pirg.org
+
+CSS
+.wrap1:not(.-breakout) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.wrap1.-breakout:has(div[x-data="carousel()"]) {
+    background-color: var(--darkreader-bg--c_a1) !important;
+}
+#footer {
+    background-color: var(--darkreader-bg--c_a2) !important;
+}
+
+================================
+
+pixabay.com
+
+INVERT
+#logo
+
+================================
+
+pixaful.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+pixilart.com
+
+CSS
+.dark-mode-visible {
+    display: inline-block;
+}
+.light-mode-visible {
+    display: none;
+}
+.navbar-nav > .nav-item > .navbar-brand > img {
+    content: url("/images/public/logo_pixilart_simple_white.png?v=1.1");
+}
+
+IGNORE IMAGE ANALYSIS
+#image-art-modal
+
+================================
+
+pixiv.net
+
+CSS
+.jAENWx,
+.iYRMgo {
+    color: ${aliceblue} !important;
+}
+
+================================
+
+pixivision.net
+
+INVERT
+.hdc__logo
+.ghdsp__logo
+.sidebar-visible-button
+._search-field-visible-button
+
+================================
+
+pixlab.pl
+
+INVERT
+img[src*="trust_us"]
+
+================================
+
+pizzahut.com
+
+INVERT
+.jss44
+
+================================
+
+pkg.go.dev
+
+CSS
+.go-Select {
+    background-position: right center;
+    background-repeat: no-repeat;
+}
+
+================================
+
+pkgs.org
+
+CSS
+.text-bg-light {
+    background-color: ${rgb(248, 249, 250)} !important;
+}
+
+================================
+
+pl.glosbe.com
+
+INVERT
+footer > div > div > a > img
+
+================================
+
+planet.gnome.org
+
+CSS
+div.post {
+    background-image: none !important;
+}
+
+================================
+
+planetagracza.pl
+
+INVERT
+p.site-title
+#footer .site-title a
+
+================================
+
+planetminecraft.com
+
+CSS
+#container,
+.forum_replies_container,
+.forum_reply,
+.contents,
+.spoiler_header,
+#resource-log,
+.tag,
+.view_more:not(:hover),
+#popup,
+code {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+plannedparenthood.org
+
+INVERT
+a.top-level-nav-link::after
+a.top-level-nav-link::before
+a.top-level-nav-link > span::after
+
+================================
+
+plantuml.com
+
+INVERT
+.scale
+
+================================
+
+play.date
+*.play.date
+
+INVERT
+.navbar-top li::before
+.navbar-top li form
+.panic::before
+#prevButton::after
+#nextButton::after
+.postWrapper::after
+.go_button::after
+
+================================
+
+play.google.com
+
+INVERT
+.bUWb7c
+.WF1WQd
+img[src="https://www.gstatic.com/android/market_images/web/play_prism_hlock_2x.png"]
+a[href*="about/products"]
+
+CSS
+a:visited {
+    color: ${black} !important;
+}
+div {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+play.google.com/apps/publish
+
+INVERT
+.IXNAUGB-u-e
+.IXNAUGB-U-g img
+.IXNAUGB-U-g
+img[src^="data:image/png;"]
+.LTMPNY-u-e
+
+================================
+
+play.google.com/books/listen
+
+INVERT
+a[href*="books/audiobooks"]
+
+CSS
+.chapter-item:not(.iron-selected) .chapter-title {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+play.google.com/music
+
+INVERT
+.music-logo
+a[title="Google apps"]
+.song-row .rating-container
+
+================================
+
+play.google.com/store/paymentmethods
+
+CSS
+body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+playinterference.com
+
+CSS
+.col.col-1 div:not(.selected-colour) {
+    border-color: rgba(0,0,0,0) !important;
+}
+.selected-colour {
+    --darkreader-border-000000: rgb(0,0,0) !important;
+}
+.fa-circle:not(.selected-colour .fa-circle) {
+    visibility: hidden !important;
+}
+.fa-circle {
+    color: rgb(255,255,255) !important;
+}
+.p-1 div {
+    border-color: rgb(185,185,185) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 255)"],
+.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: rgb(255, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 102, 102)"],
+.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
+    background-color: rgb(102, 102, 102) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 128)"],
+.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
+    background-color: rgb(255, 128, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 179, 128)"],
+.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
+    background-color: rgb(255, 179, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 128)"],
+.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
+    background-color: rgb(255, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(128, 255, 128)"],
+.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
+    background-color: rgb(128, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(179, 255, 255)"],
+.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
+    background-color: rgb(179, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(153, 204, 255)"],
+.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
+    background-color: rgb(153, 204, 255) !important;
+}
+.col div[style*="background-color: rgb(179, 128, 255)"],
+.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
+    background-color: rgb(179, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 255)"],
+.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
+    background-color: rgb(255, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(128, 230, 204)"],
+.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
+    background-color: rgb(128, 230, 204) !important;
+}
+.col div[style*="background-color: rgb(247, 215, 196)"],
+.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
+    background-color: rgb(247, 215, 196) !important;
+}
+.col div[style*="background-color: rgb(204, 204, 204)"],
+.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
+    background-color: rgb(204, 204, 204) !important;
+}
+.col div[style*="background-color: rgb(51, 51, 51)"],
+.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
+    background-color: rgb(51, 51, 51) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 0)"],
+.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
+    background-color: rgb(255, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 102, 0)"],
+.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
+    background-color: rgb(255, 102, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 0)"],
+.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: rgb(255, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 255, 0)"],
+.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
+    background-color: rgb(0, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(102, 255, 255)"],
+.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
+    background-color: rgb(102, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(51, 153, 255)"],
+.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
+    background-color: rgb(51, 153, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 0, 255)"],
+.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
+    background-color: rgb(102, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 255)"],
+.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
+    background-color: rgb(255, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(0, 204, 153)"],
+.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
+    background-color: rgb(0, 204, 153) !important;
+}
+.col div[style*="background-color: rgb(142, 86, 46)"],
+.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
+    background-color: rgb(142, 86, 46) !important;
+}
+.col div[style*="background-color: rgb(153, 153, 153)"],
+.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
+    background-color: rgb(153, 153, 153) !important;
+}
+.col div[style*="background-color: rgb(0, 0, 0)"],
+.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
+    background-color: rgb(0, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 0)"],
+.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
+    background-color: rgb(127, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 51, 0)"],
+.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
+    background-color: rgb(127, 51, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 127, 0)"],
+.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
+    background-color: rgb(127, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 127, 0)"],
+.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
+    background-color: rgb(0, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(51, 127, 127)"],
+.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
+    background-color: rgb(51, 127, 127) !important;
+}
+.col div[style*="background-color: rgb(25, 76, 127)"],
+.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
+    background-color: rgb(25, 76, 127) !important;
+}
+.col div[style*="background-color: rgb(51, 0, 127)"],
+.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
+    background-color: rgb(51, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 127)"],
+.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
+    background-color: rgb(127, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(0, 102, 76)"],
+.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
+    background-color: rgb(0, 102, 76) !important;
+}
+.col div[style*="background-color: rgb(51, 25, 0)"],
+.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
+    background-color: rgb(51, 25, 0) !important;
+}
+
+================================
+
+playstation.com
+
+CSS
+.pills__container {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+plotkibiznesowe.pl
+
+INVERT
+#logo
+
+================================
+
+plumbingforums.com
+
+INVERT
+.node-icon::before
+
+CSS
+div,
+.node-icon {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.input:focus,
+.input.is-focused::placeholder {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+pmc.ncbi.nlm.nih.gov
+
+INVERT
+.pmc-header__logo a
+.usa-card__img img
+
+================================
+
+pochta.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+pocketbase.io
+
+INVERT
+.landing-hero
+
+CSS
+.landing-hero div.wrapper:nth-child(2),
+.page-header {
+    filter: inherit !important;
+}
+div.eye-socket {
+    background-color: #fff !important;
+}
+
+================================
+
+podcast.adobe.com
+
+INVERT
+.bWTYPJ
+.cylKGQ
+sp-action-button > img
+.track
+footer > img
+
+CSS
+sp-button.sc-eSNLA-D.joqRAB {
+    background-color: ${black} !important;
+}
+sp-button.sc-eSNLA-D.joqRAB > span {
+    color: ${white} !important;
+}
+
+================================
+
+podium.com
+
+INVERT
+.logoWrap
+
+================================
+
+poeditor.com
+
+INVERT
+.chart img
+
+================================
+
+pogoda.interia.pl
+
+INVERT
+[id^="chart-container"]
+.canvas_wrapper [class*="label"]
+
+IGNORE IMAGE ANALYSIS
+.weather-map-container.is-europe
+.portugalia .weather-map-container-highlight.is-europe
+.hiszpania .weather-map-container-highlight.is-europe
+.francja .weather-map-container-highlight.is-europe
+.irlandia .weather-map-container-highlight.is-europe
+.wielka-brytania .weather-map-container-highlight.is-europe
+.belgia .weather-map-container-highlight.is-europe
+.luksemburg .weather-map-container-highlight.is-europe
+.holandia .weather-map-container-highlight.is-europe
+.niemcy .weather-map-container-highlight.is-europe
+.polska .weather-map-container-highlight.is-europe
+.czechy .weather-map-container-highlight.is-europe
+.slowacja .weather-map-container-highlight.is-europe
+.szwajcaria .weather-map-container-highlight.is-europe
+.wlochy .weather-map-container-highlight.is-europe
+.austria .weather-map-container-highlight.is-europe
+.wegry .weather-map-container-highlight.is-europe
+.slowenia .weather-map-container-highlight.is-europe
+.chorwacja .weather-map-container-highlight.is-europe
+.bosnia .weather-map-container-highlight.is-europe
+.serbia .weather-map-container-highlight.is-europe
+.albania .weather-map-container-highlight.is-europe
+.macedonia .weather-map-container-highlight.is-europe
+.grecja .weather-map-container-highlight.is-europe
+.bulgaria .weather-map-container-highlight.is-europe
+.rumunia .weather-map-container-highlight.is-europe
+.moldawia .weather-map-container-highlight.is-europe
+.bialorus .weather-map-container-highlight.is-europe
+.ukraina .weather-map-container-highlight.is-europe
+.litwa .weather-map-container-highlight.is-europe
+.lotwa .weather-map-container-highlight.is-europe
+.estonia .weather-map-container-highlight.is-europe
+.finlandia .weather-map-container-highlight.is-europe
+.norwegia .weather-map-container-highlight.is-europe
+.szwecja .weather-map-container-highlight.is-europe
+.islandia .weather-map-container-highlight.is-europe
+.dania .weather-map-container-highlight.is-europe
+.rosja .weather-map-container-highlight.is-europe
+.gruzja .weather-map-container-highlight.is-europe
+.turcja .weather-map-container-highlight.is-europe
+.weather-map-container.is-poland
+.weather-map-container-highlight.is-poland
+.weather-map-container.is-world
+
+================================
+
+polar.com
+
+INVERT
+.logo
+
+================================
+
+polarion.*
+polarion.*.*
+polarion.*.*.*
+
+INVERT
+.polarion-dle-toolbar-Button img
+.polarion-dle-toolbar-ButtonWithMenu img
+.polarion-MenuButton img
+.polarion-rp-column-configure-layout img
+
+================================
+
+poll.utm.utoronto.ca
+
+CSS
+.bg-background,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+polsatnews.pl
+
+INVERT
+.nav__item--rss a::before
+.weather-box__arrow::after
+.weather-box__arrow::before
+
+CSS
+.news--over .news__category,
+.news--over .news__time,
+.news--over .news__title,
+.sent__title {
+    filter: none !important;
+}
+
+================================
+
+polskabiega.sport.pl
+
+CSS
+.main_wrapper {
+    background-color: #181a1b !important;
+}
+
+================================
+
+polskatimes.pl
+
+INVERT
+.componentsNavigationNavbar__logo
+
+================================
+
+polskiemarki.info
+
+INVERT
+a[id="powrot"] > img
+img[src*="logo_fakro"]
+
+CSS
+#katalog .container {
+    background-image: none !important;
+}
+
+================================
+
+polymc.org
+polymc.github.io
+
+IGNORE INLINE STYLE
+svg.home *
+
+================================
+
+popularmechanics.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+div[data-tracking-id="topNavSponsor"] img
+main img[src^="/_assets/design-tokens/popularmechanics/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25231c6a65" i])
+main figure:has(audio) input
+
+================================
+
+poradnikzdrowie.pl
+
+INVERT
+.logo
+
+================================
+
+porcporc.com
+
+INVERT
+.top-logo img
+.search-trigger img
+.header-account-link-customer img
+.menu-logo img
+
+================================
+
+porkbun.com
+
+INVERT
+img[src="/images/handshake-icon.svg"]
+
+CSS
+.hsds-beacon .iNBOWp iframe[data-cy="FrameComponent"] {
+    color-scheme: initial !important;
+}
+
+================================
+
+portableapps.com
+
+INVERT
+img[alt="Download, install, and GO"]
+
+================================
+
+portal-portail.apps.cic.gc.ca
+
+INVERT
+footer > div > div > div > div > svg > :nth-child(2)
+header > div > div > div > svg > :nth-child(3)
+ircc-portal-application-status-item img.detailsIcon
+
+================================
+
+portal.edukacja.olsztyn.eu
+
+INVERT
+div.main
+div#welcome-img
+#pageheader
+div#ctl00_TheFooter img
+a.link-gray > p
+
+================================
+
+portal.qiniu.com
+
+INVERT
+.global-loading-content img
+
+================================
+
+portal.saltyfish.io
+
+INVERT
+.logo-img
+
+================================
+
+portalsamorzadowy.pl
+
+INVERT
+.p-logo
+.footer-logo
+
+================================
+
+portswigger.net
+
+INVERT
+img[alt="Web Security Academy"]
+img[alt="The Daily Swig"]
+
+================================
+
+positiveintelligence.com
+
+INVERT
+article.logos-grid__grid
+img.footer__logo
+img.homepage-hero__img
+img.menu__logo
+
+================================
+
+postani-student.hr
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+postnauka.ru
+
+INVERT
+.m-header__logo
+
+================================
+
+poszukiwania.pl
+
+INVERT
+.header-logo
+.footer-logo-address
+
+================================
+
+potplayer.daum.net
+potplayer.tv
+
+INVERT
+.promotion_potplayer
+
+CSS
+body {
+    color: black !important;
+}
+.player_function {
+    background-image: url(https://t1.daumcdn.net/potplayer/main/img/20140314_152220_62522831.png) !important;
+}
+.promotion_potplayer {
+    background-image: url("https://t1.daumcdn.net/potplayer/main/img/20140213_131844_35944898.jpg") !important;
+}
+.player_powerful {
+    background-image: url("https://t1.daumcdn.net/potplayer/main/img/20140213_131903_90444809.jpg") !important;
+}
+.player_view {
+    background-image: url("https://t1.daumcdn.net/potplayer/main/img/20140213_131919_86185869.jpg") !important;
+}
+
+================================
+
+powerapps.com
+*.powerapps.com
+
+CSS
+.ag-cell .ms-Label {
+    color: var(--darkreader-text--white) !important;
+}
+
+================================
+
+praca.pl
+
+INVERT
+img[alt="Praca.pl"]
+
+CSS
+.app-offer__content {
+    background-color: rgb(25, 26, 27) !important;
+}
+.szcont .f1top,
+.szcont .f1template_content {
+    background-blend-mode: color;
+    background-color: rgba(0, 0, 0, 0.25) !important;
+}
+.company__img {
+    padding: 0 0 !important;
+}
+.listing__logo,
+.app-offer__logo-img,
+.company__img,
+.employer-profile-header .logo img,
+.company-job-list .logo img,
+.epc-other-employers .logo img,
+.home__partner-logo {
+    filter: brightness(0.75);
+}
+
+IGNORE IMAGE ANALYSIS
+.szcont .f1top
+.szcont .f1template_content
+
+================================
+
+practicum.yandex.*
+
+INVERT
+img[src$="?color=000"]
+.progress-circle__shape
+.burger
+.lesson-progress__progress-bar
+.scrollbar__control-line
+input[aria-checked="true"] + .radio__control
+
+CSS
+.quiz-task {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.icon-status-error > .shape2,
+.icon-status-error > .shape3,
+.icon-status-success > .shape2 {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+pracuj.pl
+*.pracuj.pl
+
+CSS
+[alt="background"] {
+    display: none !important;
+}
+[data-test="image-background"] {
+    display: none !important;
+}
+[data-test="section-positioned-offers"] {
+    background: ${White} !important;
+}
+
+================================
+
+prairielearn.com
+
+INVERT
+.graph text
+
+CSS
+.question-container img {
+    background: var(--darkreader-neutral-text) !important;
+}
+div[class="pl-code mb-3 "] {
+    --pl-code-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+pravda.com.ua
+
+INVERT
+div.war_img > img
+div.footer_social_wrapper > a > img
+div.interfax > a > img
+div.footer_contacts > div.footer_img > img
+div.main_logo > a.main_logo_link > svg
+div.post_social > a > img
+div.post_statistic > div.post_views > img
+span.icon-menu
+
+================================
+
+preply.com
+
+CSS
+.styles_block__BmN2c {
+    background-color: ${rgb(232, 230, 227)};
+}
+
+================================
+
+pressgazette.co.uk
+
+INVERT
+.site-logo
+
+================================
+
+pressurewasherdb.com
+
+CSS
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
+}
+
+================================
+
+primatelabs.com
+
+INVERT
+.logo
+
+================================
+
+primevideo.com
+
+CSS
+.dv-player-fullscreen > div:nth-child(1) {
+    background-color: black !important;
+}
+
+================================
+
+primewire-connects.de
+
+CSS
+.tweak-overlay-parallax-enabled .Parallax-item {
+    z-index: 0 !important;
+}
+
+================================
+
+printables.com
+
+INVERT
+.navbar-brand .printables-text
+
+CSS
+market-filter-item {
+    --line-color: var(--darkreader-border--line-color) !important;
+}
+
+================================
+
+privat24.ua
+
+CSS
+div[class*=qrContainer] > div > div[class*=qr_] {
+    background-color: white;
+}
+
+================================
+
+pro-run.pl
+
+INVERT
+.td-main-logo
+
+================================
+
+processon.com
+
+INVERT
+#view_container canvas
+
+================================
+
+procyclingstats.com
+
+IGNORE INLINE STYLE
+.svg_shirt
+
+IGNORE IMAGE ANALYSIS
+.flag
+.flag.w32
+.flag.c16
+
+================================
+
+producthunt.com
+
+INVERT
+[class="icon_f5f81"]
+
+================================
+
+productpicnic.beehiiv.com
+
+CSS
+:root {
+    --wt-text-on-background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+profile.gigabyte.com
+
+CSS
+body {
+    background-image: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+profiler.firefox.com
+
+INVERT
+.chartCanvas
+
+================================
+
+pronto.io
+
+CSS
+input.btn-new-group.pointer {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+prospectmagazine.co.uk
+
+INVERT
+.header__logo
+
+================================
+
+prostovpn.org
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+protect-eu.ismartlife.me/login
+
+CSS
+div[class^=login_login] {
+    background-image: none !important;
+}
+div[class^=login_qc-code-content] {
+    background-color: white !important;
+}
+
+================================
+
+protocol.com
+
+INVERT
+img.logo-icon.open
+div#topbar-menu-toggle > svg.icon
+
+================================
+
+proton.me
+mail.proton.me
+
+INVERT
+img[src$="hero-2x.png"]
+iframe[data-testid="rooster-iframe"]
+
+IGNORE IMAGE ANALYSIS
+.md\:bg-\[url\(https\:\/\/pmecdn\.protonweb\.com\/image-transformation\/\?s\=c\&image\=v1757000666\/static\/home\/background-gradients\.svg\)\]
+
+================================
+
+protonvpn.com
+
+INVERT
+.navbar-brand
+.protonmail-link
+#page_home .parallax
+#page_home .parallax > *
+
+================================
+
+provantage.com
+
+CSS
+body,
+body.HOME {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+proxmox.com
+
+INVERT
+#logo
+.uix_logo
+
+================================
+
+proxyium.com
+
+CSS
+[data-darkreader-inline-bgimage] {
+    background-image: none !important;
+}
+
+================================
+
+proxyman.com
+
+INVERT
+a.ml-8[href="/download"]
+div.text-center.w-full.mt-12 > div > a > span
+button[class~="px-2.5"][class~="bg-gray-900"]
+div.px-2.py-1
+div.text-center.mt-14
+button[aria-label="Previous Testimonials Page"]
+button[aria-label="Next Testimonials Page"]
+img[src="/assets/images/wreath_right.svg"]
+img[src="/assets/images/wreath_left.svg"]
+.px-8.py-3.glowingDownloadBtn
+img[alt="ChowNow, a Company that uses Proxyman"]
+img[alt="Cerid, a Company that uses Proxyman"]
+img[alt="Shape, a Company that uses Proxyman"]
+img[alt="Yelp, a Company that uses Proxyman"]
+img[alt="Cisco, a Company that uses Proxyman"]
+img[alt="Shopify, a Company that uses Proxyman"]
+img[alt="Aws, a Company that uses Proxyman"]
+img[alt="Deloitte, a Company that uses Proxyman"]
+img[alt="Atlassian, a Company that uses Proxyman"]
+img[alt="Futirice, a Company that uses Proxyman"]
+img[alt="Atlantic, a Company that uses Proxyman"]
+img[alt="Bytedance, a Company that uses Proxyman"]
+img[alt="Paypal, a Company that uses Proxyman"]
+img[src*="proxyman_dashboard_v6_1.webp"]
+
+================================
+
+psemu.pl
+
+CSS
+.menu-item {
+    text-shadow: rgb(40, 43, 54) 0px 1px 0px !important;
+}
+
+================================
+
+psprices.com
+
+INVERT
+.store-logo
+.highcharts-label text
+.game--description::after
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+psychonautwiki.org
+
+INVERT
+#mw-panel > a > svg
+.mw-headline > a > svg
+a[href="http://www.emcdda.europa.eu/about"] > svg
+img[alt="Tasks.svg"]
+img[alt="Star-o.svg"]
+img[alt="Pencil.svg"]
+#InfoTable > tbody > tr > .Image > div > div > .image
+.dosechart
+
+CSS
+.dosechart,
+.thumbimage,
+.mwe-popups-discreet > svg {
+    background-color: ${black} !important;
+}
+
+================================
+
+psytec.co.jp
+
+INVERT
+[background$="images/square.gif"]
+[background$="images/square.gif"] > *
+td[background*="images/sep_b"]
+
+================================
+
+pt.petitchef.com
+
+INVERT
+header button[aria-label="Toggle navigation"]
+
+================================
+
+publica.fraunhofer.de
+
+INVERT
+img[src="/pub09img/logo-fraunhofer.gif"]
+
+================================
+
+publicinterestnetwork.org
+
+CSS
+.wrap1:not(.-breakout),
+#footer {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.wrap1.-breakout:has(div[x-data="carousel()"]) {
+    background-color: var(--darkreader-bg--c_a1) !important;
+}
+
+================================
+
+publicwww.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+pulumi.com
+
+CSS
+:host {
+    --neutral-fill-stealth-rest: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+pureinfotech.com
+
+INVERT
+.pureinfotech-logo
+
+CSS
+.article-type-standard-css .entry-content::before {
+    color: ${gray} !important;
+}
+
+================================
+
+purerave.com
+
+CSS
+:root {
+    --darkreader-border--border: 1px solid rgba(0, 90, 155, 1) !important;
+}
+div.form-buttons textarea {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: #005a9b !important;
+}
+textarea {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+purevpn.com
+
+CSS
+.inner_banner {
+    background-image: none !important;
+}
+
+================================
+
+pushsquare.com
+
+CSS
+.page {
+    background-image: none !important;
+}
+
+================================
+
+puuilo.fi
+
+CSS
+#customSearchInput {
+    background-image: linear-gradient(var(--darkreader-neutral-background), var(--darkreader-neutral-background)) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.custom-search-submit svg {
+    stroke: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+pycheung.com/checker/
+
+IGNORE INLINE STYLE
+body
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+pyszne.pl
+lieferando.*
+justeat.*
+just-eat.*
+takeaway.com
+thuisbezorgd.nl
+
+INVERT
+.gm-style
+
+CSS
+.cover img,
+.logowrapper,
+.orderoverview__restaurant-image-container-inner,
+div[data-qa="avatar"] {
+    background-blend-mode: color;
+    background-color: rgba(255, 255, 255, 0.5) !important;
+}
+
+IGNORE INLINE STYLE
+svg > circle
+svg > text > tspan
+
+================================
+
+pythonanywhere.com
+
+INVERT
+#id_logo
+img[src^="/static/glyphicons/"]
+
+================================
+
+pytorch.org
+
+INVERT
+#site-logo
+.header-holder:not(.homepage-header) > div.container > div.header-container > .header-logo
+
+================================
+
+pz.gov.pl
+
+CSS
+.banner-text {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+q.utoronto.ca
+
+INVERT
+.ic-sidebar-logo__image
+.instructure_file_link_holder > .file_download_btn
+a.external > span > img:first-child
+.equation_image
+span[data-testid="mathml-preview-element"] svg
+
+CSS
+:root {
+    --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
+    --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
+    --darkreader-bgimg--ic-brand-header-image: var(--ic-brand-header-image) !important;
+    --darkreader-border--ic-brand-global-nav-avatar-border: var(--ic-brand-global-nav-avatar-border) !important;
+    --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
+}
+.ic-app-header__menu-list-link:hover,
+.ic-app-header__menu-list-link:focus {
+    background-color: ${rgba(0, 0, 0, 0.2)} !important;
+}
+.ic-DashboardCard {
+    box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 1px 5px !important;
+}
+textarea[data-testid="advanced-editor"] {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+math-field,
+fieldset span {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+qcc.com
+
+INVERT
+.app-login-insert
+.logo
+.pay-insert
+
+================================
+
+qr-code-generator.com
+
+IGNORE INLINE STYLE
+qrcg-generator-qr-code *
+
+================================
+
+qrz.com
+forums.qrz.com
+logbook.qrz.com
+shop.qrz.com
+
+INVERT
+img[src$="qrz_com.svgz"]
+.site-header__logo-image
+
+================================
+
+qt.io
+
+CSS
+.b-background__wrapper .b-background__asset[style^="background-image"] {
+    filter: brightness(50%) sepia(40%) !important;
+}
+div[class*="frontpage"] .scheme--default p {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+quantrimang.com
+
+CSS
+.taxonomyList .navigation a {
+    color: var(--darkreader-neutral-text) !important;
+}
+.taxonomyList .navigation a:hover {
+    color: ${orange} !important;
+}
+
+================================
+
+qubes-os.org
+
+INVERT
+[src$="xen-logo.svg"]
+[src$="whonix-tor.svg"]
+
+================================
+
+quickbase.com
+
+CSS
+td.cell,
+td.label {
+    border-color: rgb(24, 26, 27) !important;
+}
+
+================================
+
+quirksmode.org
+
+INVERT
+.logoPPK
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+quizlet.com
+
+CSS
+.UIKeyboardHint {
+    background-color: transparent !important;
+}
+
+IGNORE INLINE STYLE
+.FeedbackHeading-emoji > svg *
+
+================================
+
+quora.com
+*.quora.com
+
+CSS
+.logo_fill {
+    fill: rgb(219, 87, 83) !important;
+}
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+div.q-box.qu-bg--white {
+    background-color: #181a1b !important;
+    background-image: none !important;
+}
+.rf162uw:hover {
+    color: rgba( 128, 128, 128, 0.15) !important;
+}
+
+IGNORE INLINE STYLE
+#upvote
+#downvote
+
+================================
+
+qwant.com
+
+INVERT
+.background-home__logo
+.home__logo__container .home__logo
+canvas.mapboxgl-canvas
+
+================================
+
+rachel53461.wordpress.com
+
+CSS
+#grad {
+    background-image: none !important;
+}
+
+================================
+
+racketboy.com
+
+CSS
+#rb-split,
+#rb-split > div {
+    background-image: none !important;
+}
+
+================================
+
+radar-opadow.pl
+
+INVERT
+#chase-map
+.ro_tooltip
+
+================================
+
+radeonramdisk.com
+
+INVERT
+#logo
+
+================================
+
+radio17.pl
+
+INVERT
+.main-title
+
+================================
+
+radiokolor.pl
+
+INVERT
+.nav-brand
+.buttons-1
+a.logo-1
+
+CSS
+.content-box-1 {
+    background-image: none !important;
+}
+
+================================
+
+railpassengers.org
+
+INVERT
+.navbar__list-search
+.navbar__logo
+.navbar__mobile-icons
+
+================================
+
+railwaygazette.com
+
+INVERT
+.mastheadLogo
+
+================================
+
+rain.thecomicseries.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+    margin: 0px !important;
+    padding: 8px !important;
+}
+#comicimage {
+    background-color: #ffffff !important;
+}
+
+================================
+
+rakuten.com
+*.rakuten.com
+
+CSS
+span[class*="Checkbox_checkmark"]::after {
+    border-color: rgb(207, 203, 201) !important;
+}
+
+================================
+
+rapidtables.com
+
+IGNORE INLINE STYLE
+td[style^="background:"]
+
+================================
+
+raspberrypi.com
+
+INVERT
+.__rptl-header-logo path[fill="#000"]
+
+CSS
+body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+raspberrypi.org
+
+INVERT
+.site-header__home-link
+
+IGNORE IMAGE ANALYSIS
+.c-at-home__container
+
+================================
+
+rateyourmusic.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+rationalwiki.org
+
+INVERT
+.mw-wiki-logo
+
+================================
+
+rbc.ua
+
+INVERT
+.h-inner > .logo
+
+================================
+
+rct-portal.com
+
+INVERT
+.flow__battery::before
+.flow__panel::before
+.flow__grid::before
+.flow-item__line::after
+.flow-item__line::before
+
+================================
+
+read.amazon.*
+read.amazon.*.*
+lire.amazon.*
+
+INVERT
+.header_bar_icon:not(#kindleReader_button_close)
+.header_bar_button
+#kindleReader_content
+.kg-full-page-img
+.side-menu-close
+.fixed-book-title
+ion-menu
+ion-header
+ion-title
+
+CSS
+.kr-renderer-container,
+.kr-renderer-container-fullpage {
+    z-index: 0 !important;
+}
+
+================================
+
+readme.io
+
+CSS
+.rm-PlaygroundRequest,
+.CodeTabs-toolbar {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+readpaper.com/pdf-annotate/note
+
+INVERT
+.page
+
+================================
+
+readthedocs.io
+*.readthedocs.io
+*.readthedocs.com
+flake8.pycqa.org
+
+INVERT
+:host > div > div.content
+
+CSS
+.toc-drawer,
+.sig,
+code.literal,
+.sidebar-search-container,
+.sidebar-tree .current > .reference {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+real-debrid.com
+
+CSS
+#wrapper_global {
+    background-image: none !important;
+}
+#header_img_right {
+    background-image: none !important;
+}
+
+================================
+
+realmadridfin.net
+
+CSS
+body,
+.botslice,
+.botslice span,
+.button_submit,
+.catbg,
+.cat_bar,
+#content_section,
+.frame,
+#footer_section,
+#header,
+.lowerframe,
+.lowerframe span,
+#shoutbox_b,
+#shoutbox_color,
+#shoutbox_face,
+#shoutbox_i,
+#shoutbox_nosound,
+#shoutbox_u,
+#shoutbox_u + img,
+.titlebg,
+.title_barIC,
+.topslice,
+.topslice span,
+.upperframe,
+.upperframe span {
+    background-image: none !important;
+}
+#shoutbox_message {
+    background-color: none !important;
+}
+
+================================
+
+realmeye.com
+
+INVERT
+img[src*="latex"]
+
+IGNORE IMAGE ANALYSIS
+.character
+
+================================
+
+realmicentral.com
+
+INVERT
+img[itemprop="logo"]
+div.fly-but-wrap.left.relative > span
+
+================================
+
+realtek.com
+
+CSS
+#t3-header,
+body > div.t3-wrapper > div > div.section-wrap.bg-wrap1 > div > div > div.custom > div > a {
+    background: var(--darkreader-neutral-background) !important;
+}
+#t3-header > div > div.col-xs-3.visible-xs-block > button.search-toggle,
+#t3-header > div > div.col-xs-3.visible-xs-block > button.globe-toggle {
+    background-color: inherit !important;
+}
+
+================================
+
+redbookmag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+div[data-tracking-id="topNavSponsor"] img
+footer.footer img[alt="Logo"]
+main img[src^="/_assets/design-tokens/redbookmag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d30c4f" i])
+main figure:has(audio) input
+
+================================
+
+redbubble.com
+
+INVERT
+[data-testid="ds-wordmark"]
+
+================================
+
+redcross.*
+redcross.*.*
+
+CSS
+.lecture-attachment img.is-loaded {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+reddit.com
+new.reddit.com
+
+INVERT
+video ~ div [style^="height"]
+.snoo-cls-1
+.snoo-cls-2
+.snoo-cls-3
+.snoo-cls-8
+
+CSS
+[style^="--background"] {
+    --background: ${#FFFFFF} !important;
+}
+[style^="--canvas"] {
+    --canvas: ${#DAE0E6} !important;
+}
+[style^="--pseudo-before-background"] {
+    --pseudo-before-background: ${#DAE0E6} !important;
+}
+[style^="--comments-overlay-background"] {
+    --comments-overlay-background: ${#DAE0E6} !important;
+}
+[style^="--commentswrapper-gradient-color"] {
+    --comments-overlay-background: ${#DAE0E6} !important;
+}
+[style^="--fakelightbox-overlay-background"] {
+    --fakelightbox-overlay-background: ${#DAE0E6} !important;
+}
+.button:hover {
+    --button-color-background: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+.hover\:text-secondary:hover {
+    color: var(--darkreader-neutral-text) !important;
+}
+.hover\:bg-secondary-background-hover:hover {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+.hover\:border-secondary-background-hover:hover {
+    border-color: var(--darkreader-border--color-neutral-border-medium) !important;
+}
+.before\:border-tone-4::before {
+    border-color: var(--color-tone-4) !important;
+}
+.button-shell {
+    color: var(--darkreader-neutral-text) !important;
+}
+.button-plain {
+    --button-color-text-default: var(--darkreader-neutral-text) !important;
+}
+.button-secondary {
+    --button-color-background-default: var(--darkreader-bg--color-neutral-background) !important;
+    --button-color-text-default: var(--darkreader-text--color-neutral-content-weak) !important;
+}
+.internalBackButton {
+    background-image: linear-gradient(to right,var(--plain-background) 0,var(--darkreader-bg--color-secondary-background) 30%) !important;
+}
+.internalForwardButton {
+    background-image: linear-gradient(to right,var(--plain-background) 0,var(--darkreader-bg--color-secondary-background) 30%) !important;
+}
+.label-container {
+    background: var(--darkreader-bg--color-neutral-background) !important;
+}
+.label-container:hover {
+    background: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+.md p>a[href="#s"]::after,
+a[href="#s"]::after {
+    color: #000;
+}
+.text-neutral-content-strong {
+    color: var(--darkreader-text--color-neutral-content-strong) !important;
+}
+header a[aria-label="Home"] svg:last-child g,
+header > div > div + div a[href] *,
+header > div > div + div button[aria-label] * {
+    fill: var(--darkreader-neutral-text) !important;
+}
+#comment-tree {
+    background-color: var(--darkreader-bg--color-neutral-background) !important;
+}
+#COIN_PURCHASE_DROPDOWN_ID > div {
+    background: linear-gradient(180deg,hsla(0,0%,100%,.1) 45.96%,hsla(0,0%,100%,.57) 46%,hsla(0,0%,100%,0) 130%),${gold} !important;
+}
+#COIN_PURCHASE_DROPDOWN_ID > div > span {
+    color: ${white} !important;
+}
+#search-input-chip {
+    background: var(--darkreader-bg--color-secondary-background-selected) !important;
+}
+.md-spoiler-text:not([data-revealed])::selection {
+    background-color: var(--darkreader-bg--newCommunityTheme-metaText) !important;
+    color: transparent !important;
+}
+button[slot="forward-button"] {
+    background-color: var(--darkreader-border--color-neutral) !important;
+}
+button[slot="back-button"] {
+    background-color: var(--darkreader-border--color-neutral) !important;
+}
+div[slot="tabs"] {
+    background: var(--darkreader-bg--color-neutral-background) !important;
+}
+div[role="menu"][style^="position: fixed"] button button[role="switch"][aria-checked="false"] {
+    background-color: ${gray} !important;
+}
+div[role="menu"][style^="position: fixed"] button button[role="switch"] > div {
+    background-color: ${black} !important;
+}
+object[data="about:blank"] {
+    display: none !important;
+}
+span[class="inline-block mr-[calc(var(--size-button-sm-h)-var(--rem10)-var(--button-border-width-default))] overflow-hidden text-ellipsis"] {
+    color: var(--darkreader-text--color-neutral-content) !important;
+}
+shreddit-comment-tree {
+    background-color: var(--darkreader-bg--shreddit-content-background) !important;
+}
+.self-start {
+    background-color: var(--darkreader-bg--shreddit-content-background) !important;
+}
+#comment-fold-button {
+    background-color: var(--darkreader-bg--shreddit-content-background) !important;
+}
+button.w-lg {
+    background-color: var(--darkreader-bg--shreddit-content-background) !important;
+}
+.bg-neutral-background {
+    background-color: var(--darkreader-bg--shreddit-content-background) !important;
+}
+.text-secondary {
+    color: var(--darkreader-text--color-secondary) !important;
+}
+faceplate-tracker > li > a:hover {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+faceplate-tracker > li > div:hover {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+div#RECENT > li > a:hover {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+span.input-container.stateful-input input {
+    color: var(--darkreader-text--color-tone-1) !important;
+}
+.reddit-search-bar {
+    background-color: var(--darkreader-bg--color-neutral-background) !important;
+}
+.reddit-search-bar .text-neutral-content {
+    color: var(--darkreader-text--color-tone-1) !important;
+}
+faceplate-tracker > li[rpl-selected] > a {
+    background-color: var(--darkreader-bg--color-tone-3) !important;
+}
+faceplate-menu {
+    background-color: var(--darkreader-bg--color-neutral-background-strong) !important;
+}
+faceplate-tracker > button[rpl-selected] {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+faceplate-tracker a[data-testid]:hover {
+    background-color: unset !important;
+}
+faceplate-tracker[noun="trending"] div:hover {
+    background-color: unset !important;
+}
+faceplate-hovercard > div > div > div {
+    background-color: var(--darkreader-bg--color-neutral-background) !important;
+}
+faceplate-hovercard > div > div > div:hover {
+    background-color: var(--darkreader-bg--color-neutral-background) !important;
+}
+#faceplate-tooltip {
+    background-color: var(--darkreader-bg--color-neutral-background) !important;
+}
+faceplate-hovercard p {
+    color: var(--darkreader-text--color-neutral-content-strong) !important;
+}
+.text-secondary-weak {
+    color: var(--darkreader-text--color-secondary-weak) !important;
+}
+button.button-plain:hover {
+    color: var(--button-color-text-default) !important;
+}
+faceplate-menu > li > div {
+    background-color: var(--darkreader-bg--color-neutral-background-hover) !important;
+}
+.text-neutral-content-weak {
+    color: var(--darkreader-text--color-neutral-content-weak);
+}
+:host > #content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.bg-neutral-background-weak {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+reddit.zendesk.com
+
+INVERT
+header > div.logo > a > img
+img.hero-inner-image
+
+================================
+
+redditstatus.com
+
+INVERT
+.logo-container
+
+================================
+
+redgamingtech.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+redhat.com
+*.redhat.com
+
+CSS
+:root {
+    --pf-c-popover__arrow--BackgroundColor: ${white} !important;
+    --pf-c-popover__content--BackgroundColor: ${white} !important;
+    --pf-c-popover__content--Color: ${black} !important;
+    --rh-color-surface-lighter: ${#f2f2f2} !important;
+}
+p,
+li {
+    color: ${black} !important;
+}
+.PFElement,
+[part="content"] {
+    background-color: ${white} !important;
+}
+#container {
+    background-color: ${#f2f2f2} !important;
+}
+#close-button svg path {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+.redhat-logo *
+
+================================
+
+redis.io
+
+CSS
+.bg-gradient-to-bl {
+    background-image: none !important;
+}
+
+================================
+
+redpenreviews.org
+
+CSS
+header a {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+reebok.*
+
+CSS
+div {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+refactoring.guru
+
+CSS
+.recipe {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+referentiemateriaalvo.noordhoff.nl
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+regex101.com
+
+INVERT
+canvas
+
+================================
+
+registry.terraform.io
+
+CSS
+.input {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.button,
+.menu-list a,
+a.dropdown-item {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+reheader.glitch.me
+
+INVERT
+[src=$"GitHub-Mark.png"]
+[src=*"header-image-readme-gen.gif]
+[src=*"Screen%20Shot%202020-07-17%20at%205.19.18%20PM.png"]
+
+CSS
+#add-to-github {
+    background-color: #96943f !important;
+}
+#upload-github {
+    border: 1px solid #dddddd;
+}
+
+================================
+
+rei.com
+
+INVERT
+.logo__img
+
+================================
+
+relay.firefox.com
+
+INVERT
+img.c-landing-hero-brands
+img.c-brand-title
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+.fx-bento-app-link.fx-bento-link.fx-vpn > span::before
+div.glocal-site-options > a > img
+div.glocal-site-options > form > button::before
+
+================================
+
+releasebot.io
+
+INVERT
+svg[aria-label="Releasebot"]
+
+================================
+
+relive.cc
+
+INVERT
+img[src*="logo-relive"]
+
+IGNORE IMAGE ANALYSIS
+.email-button i
+
+================================
+
+rememberthemilk.com
+
+CSS
+div[contenteditable="true"] {
+    border: transparent !important;
+}
+
+================================
+
+render.com
+
+INVERT
+.rm-section.rm-hero
+.rm-section.rm-hero > *:not(.rm-back-bottom)
+.rm-back-top
+.rm-back-large
+
+================================
+
+render.githubusercontent.com/view/ipynb
+
+INVERT
+img.math
+
+================================
+
+replit.com
+
+CSS
+.monaco-editor .cursor {
+    background-color: ${#000};
+}
+
+================================
+
+report.cybertip.org
+
+INVERT
+.col-form-label
+
+================================
+
+repubblica.it
+
+INVERT
+.page-header__logo
+
+================================
+
+research.cloudflare.com
+
+INVERT
+img[src$="logo.svg"]
+
+================================
+
+researchgate.net
+
+CSS
+div.pdf-viewer-page div.pc {
+    background: white !important;
+    color: black !important;
+}
+
+================================
+
+resetera.com
+
+CSS
+.bbc-spoiler:not(:hover):not(:active),
+.bbc-spoiler:not(:hover):not(:active) * {
+    background-color: ${black} !important;
+    color: ${black} !important;
+}
+
+================================
+
+resmigazete.gov.tr
+
+CSS
+img[src="/assets/img/arma.png"] {
+    filter: hue-rotate(180deg) invert(1) brightness(2);
+}
+
+================================
+
+respekt.cz
+
+INVERT
+.sitelogo-link
+
+================================
+
+restaurantji.com
+
+INVERT
+.logo_sticky
+
+================================
+
+restoreprivacy.com
+
+CSS
+body {
+    background-color: var(--darkreader-bg--color-body) !important;
+}
+
+================================
+
+retracmirrors.com
+
+CSS
+body,
+#app > div {
+    background-image: none !important;
+}
+
+================================
+
+reuters.com
+
+INVERT
+path[d^="M121.865 50.29c0"]
+span[data-testid="ReutersLogo"]:not([class^="mobile-menu-module__logo"])
+svg[data-testid="IconSearch"]
+svg[aria-labelledby="EmailIconId"]
+svg[data-testid="IconClose"]
+
+================================
+
+reutersagency.com
+
+INVERT
+img[src*="reuters-logo.svg"]
+
+================================
+
+revisioncentregcse.blogspot.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+revolut.com
+
+CSS
+[class*="Text-rui"] {
+    text-shadow: rgb(40, 43, 54) 1px 1px 0px !important;
+}
+
+================================
+
+revolver.news
+
+INVERT
+h2.title
+h3.category
+
+================================
+
+rfc-editor.org
+
+CSS
+svg.diagram text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+rfi.fr
+
+INVERT
+.o-header__site-nav-link
+
+================================
+
+rg-adguard.net
+
+INVERT
+img[src*="info"]
+img[src*="like"]
+img[src*="donate"]
+img[src*="faq"]
+
+CSS
+body,
+.tftable th {
+    background: none !important;
+}
+
+================================
+
+riflessioni.it
+
+CSS
+body {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+
+================================
+
+rimworldwiki.com
+
+INVERT
+.darkmode-invert
+.mw-wiki-logo
+
+CSS
+html,
+html img {
+    filter: none;
+}
+body {
+    background: var(--darkreader-neutral-background);
+}
+
+================================
+
+ring.com
+
+INVERT
+span[alt="Ring Logo"] svg
+
+IGNORE INLINE STYLE
+span[alt="Ring Logo"] svg *
+
+================================
+
+ringofhonor.com
+
+INVERT
+#SITE_HEADER img[alt="Ring of Honor Logo"]
+
+CSS
+div[data-testid*="svgRoot-comp-"] {
+    fill: var(--fill) !important;
+}
+.xU8fqS .gUbusX {
+    background-color: transparent !important;
+}
+.xTjc1A .JS76Uv {
+    color: var(--darkreader-neutral-text);
+}
+.xTjc1A .JS76Uv:hover {
+    color: rgb(var(--txth)) !important;
+}
+
+================================
+
+riotinto.com
+
+CSS
+.ch-hero-banner .ch-carousel__slide::before {
+    background-color: rgba(0,0,0,calc(var(--carousel-alpha)/100)) !important;
+}
+
+================================
+
+riptutorial.com
+
+CSS
+.whole-container {
+    background-image: none !important;
+}
+
+================================
+
+rmf24.pl
+
+INVERT
+.mainContent3-left iframe
+.belkaNew
+
+CSS
+#twojezdrowieCont .page3,
+#regionySection {
+    background-image: none !important;
+}
+
+================================
+
+rnz.de
+
+INVERT
+.nfy-header img
+
+================================
+
+roadmap.sh
+
+CSS
+svg .done rect {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+roblox.com
+
+CSS
+.checkbox input[type=checkbox]:checked + label::before {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+rocksbox.com
+
+INVERT
+.nav_logo
+
+================================
+
+rockylinux.org
+
+INVERT
+img[alt="Rocky Linux"]
+
+================================
+
+rog.asus.com
+
+IGNORE IMAGE ANALYSIS
+.rog-header .nav-menu .nav-bar
+
+================================
+
+roland.com
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+rollenspiel.monster
+
+CSS
+body {
+    height: 100% !important;
+}
+
+================================
+
+ros.org
+
+CSS
+.bg-ros-dots-grid {
+    background-image: none !important;
+}
+
+================================
+
+roscidus.com
+
+CSS
+span.caption-wrapper img {
+    background-color: white !important;
+}
+
+================================
+
+rosepassion.com
+
+INVERT
+.imgmap
+.famille-content .image
+.les_schemas img
+.rpimage .follow-scroll
+
+CSS
+#selectionner_voiture .bloc .image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+rosettacode.org
+
+INVERT
+.mwe-math-fallback-image-inline
+
+CSS
+.wrong-element-colors {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+.color-picker
+
+IGNORE IMAGE ANALYSIS
+.logo
+
+================================
+
+roskomsvoboda.org
+
+INVERT
+img[src="/static/core/images/logo.svg"]
+
+================================
+
+rosneft-azs.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+rostov.tele2.ru
+
+INVERT
+.header-navbar-logo
+
+================================
+
+rottentomatoes.com
+
+IGNORE IMAGE ANALYSIS
+.icon__fresh
+.fresh
+.icon
+
+================================
+
+royalbank.com
+
+CSS
+.rbc-select-input {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+rozetka.com.ua
+
+INVERT
+div.cabinet-navigation__icon > svg
+span.cabinet-navigation__icon > svg
+
+================================
+
+rp.pl
+
+INVERT
+a[href="/"]
+.burger--menu span
+.icon-logo::before
+.footer--logo
+.footer--copyright--content div
+
+================================
+
+rpcs3.net
+
+CSS
+p,
+.compat-types,
+.compat-hdr-left,
+.compat-status-container {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+rpm.org
+
+IGNORE IMAGE ANALYSIS
+body
+
+================================
+
+rpmfusion.org
+*.rpmfusion.org
+
+CSS
+body {
+    background: none !important;
+}
+#loginform {
+    opacity: 1 !important;
+}
+#loginform fieldset {
+    background-image: none !important;
+}
+#header {
+    background-blend-mode: multiply !important;
+}
+
+================================
+
+rpo.gov.pl
+
+INVERT
+.view-content .field-content > img
+#etykieta_szukaj a
+
+IGNORE IMAGE ANALYSIS
+#bip_kontener
+
+================================
+
+rt.ru
+
+INVERT
+#logo_text
+
+================================
+
+rte.ie
+
+INVERT
+.masthead .nav-btn.menu
+
+CSS
+.masthead .weather-widget .icon {
+    filter: none !important;
+}
+.theoplayer-skin .theo-control-bar-shadow {
+    background-image: linear-gradient(transparent var(--darkreader-neutral-background)) !important;
+}
+
+================================
+
+rtlnieuws.nl
+
+CSS
+section {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+rubenfixit.com
+
+CSS
+.shape-top-left::after,
+.nav-btn::after {
+    border-color: transparent transparent transparent var(--darkreader-neutral-background) !important;
+}
+.shape-top-right::after,
+.nav-btn::before {
+    border-color: transparent transparent var(--darkreader-neutral-background) transparent !important;
+}
+.shape-bottom-left::after {
+    border-color: var(--darkreader-neutral-background) transparent transparent transparent !important;
+}
+.shape-bottom-right::after {
+    border-color: transparent var(--darkreader-neutral-background) transparent transparent !important;
+}
+#blog-isotope-masonry article,
+.shape-top-left,
+.shape-top-right,
+.shape-bottom-left,
+.shape-bottom-right {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+rubjo.github.io
+
+CSS
+select {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+rudeiczarne.pl
+
+INVERT
+#logo
+#footer-logo
+
+================================
+
+rumratings.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+rundfunkbeitrag.de
+
+INVERT
+.keyVisualWrapper::after
+
+CSS
+.header_subMenu {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+runkit.com
+
+INVERT
+.CodeMirror div.CodeMirror-cursor
+
+================================
+
+runtothefinish.com
+
+CSS
+:root {
+    --body-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ryanair.com
+
+CSS
+.calendar-body__cell--disabled {
+    color: gray !important;
+}
+
+IGNORE INLINE STYLE
+.common-header__logo-icon svg *
+
+================================
+
+rynek-kolejowy.pl
+
+INVERT
+.logoTK
+.partnerNaglowka
+.pasekbocznynaglowek span
+.portalLogo
+.tagLogo
+.zawartoscPartner
+img[alt="współpraca"]
+img[class="wspolpraca"]
+img[src*="img/firma"]
+img[src*="katalogkolejowy"]
+
+================================
+
+rynekzdrowia.pl
+
+INVERT
+img[src*="rynekzdrowia.svg"]
+img[alt*="partner"]
+.search
+.copyright > img
+
+================================
+
+rytmy.pl
+
+INVERT
+.logo-rytmy-a
+
+================================
+
+s.weibo.com
+
+INVERT
+.CopyRight_aria_13ebq
+.ProfileHeader_statusCounterLayer_13mzC img
+.hot-band-header-refresh img
+#woo_svg_nav_logo > g > path:nth-child(5)
+
+CSS
+#searchapps > div > div[role=navigation] > div.woo-panel-main {
+    --darkreader-bg--weibo-top-nav-panel-bgColor: var(--darkreader-bg--w-color-light);
+}
+:root {
+    --darkreader-bg--frame-background: var(--darkreader-bg--w-color-light);
+    --darkreader-bg--w-b-flat-default-bg: #FFFFFF11;
+    --darkreader-bg--w-color-gray-6: #FFFFFF11;
+    --darkreader-bg--w-retweet-background: #FFFFFF08;
+    --darkreader-border--w-card-border: #FFFFFF1E;
+    --darkreader-border--w-dividing-line: #FFFFFF11;
+    --darkreader-text--weibo-top-nav-line: #FFFFFF19;
+}
+.woo-divider-x {
+    border-bottom-color: #FFFFFF11;
+}
+.m-main-nav,
+.card-wrap {
+    background-color: #FFFFFF08;
+    border-color: #FFFFFF11;
+}
+.hot-band-container {
+    background-color: #FFFFFF08 !important;
+    border-color: #FFFFFF11 !important;
+}
+.Nav_panel_YI3-j {
+    border-bottom-color: #FFFFFF1E !important;
+}
+.hot-band-tabs-item {
+    background-color: #FFFFFF11 !important;
+}
+.hot-band-footer-link {
+    background-color: #FFFFFF11 !important;
+    border-radius: 8px !important;
+}
+.wbpro-side-opt {
+    background-color: #FFFFFF11 !important;
+    border-radius: 8px;
+    color: rgb(143, 143, 143);
+}
+.m-adv-search dd [type="text"] {
+    background-color: #FFFFFF11 !important;
+    border: none;
+}
+.m-adv-search dd .txt {
+    background-color: #FFFFFF18 !important;
+    border: solid,1px,#FFFFFF11 !important;
+}
+.m-adv-search dd select {
+    background-color: #FFFFFF11;
+    border: none;
+}
+.card-feed .media {
+    background: #FFFFFF08 !important;
+}
+.vote-item_item_2egBf {
+    background-color: #FFFFFF08;
+}
+.card-together .card-more-a a {
+    background: none;
+}
+.wbp-video .wbpv-load-progress div {
+    background: #FFFFFF11 !important;
+}
+.wbp-video .wbpv-play-progress {
+    background-color: #FFFFFF88;
+}
+.woo-panel-main {
+    background-color: #FFFFFF08;
+    border: solid,1px,#FFFFFF11 !important;
+}
+
+================================
+
+safetysign.com
+
+CSS
+div[id*="RollUp-Aluminum-smalltext-preview"],
+div[id*="RollUp-Aluminum-largetext-preview"],
+#_HillGradeCustom-hillgradetext-preview {
+    color: rgb(0, 0, 0) !important;
+}
+
+================================
+
+safeweb.norton.com
+
+INVERT
+.logo img
+
+================================
+
+saladelcembalo.org
+
+INVERT
+#PageDiv td
+
+CSS
+html,
+body,
+input,
+textarea,
+select,
+button {
+    background-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+salon24.pl
+
+INVERT
+.header-main__logo
+
+================================
+
+samcodes.co.uk
+
+INVERT
+.logo
+
+================================
+
+samsung.*
+
+INVERT
+.icon
+.gnb__logo
+
+CSS
+.feature-full-bleed-text img {
+    filter: brightness(50%) sepia(40%) !important;
+}
+.feature-full-bleed-text__content {
+    z-index: 1 !important;
+}
+
+================================
+
+sankei.com
+
+CSS
+html {
+    background-color: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+sanomapro.fi
+
+INVERT
+.equation
+
+================================
+
+santander.pl
+
+INVERT
+img[src*="/santander/footer/"]
+.topVisual__text span
+.topVisual__content.topVisual__content--nobutton
+
+================================
+
+savannah.gnu.org
+
+CSS
+.boxtitle {
+    background-image: none !important;
+}
+
+================================
+
+sba.gov
+
+INVERT
+.usa-header--extended .site-logo
+
+================================
+
+sbb.ch
+shop.sbb.ch
+
+CSS
+#Von0,
+#Nach1,
+#From0,
+#To1,
+#De0,
+#À1,
+#Da0,
+#A1 {
+    background: none !important;
+}
+.sbb-navigation__container::before {
+    background-color: var(--sbb-color-white-alpha-70) !important;
+}
+#sbb-logo__signet,
+.mod_header_logo_content > * > path:not(path[fill='#EC0000']) {
+    fill: white !important;
+}
+.sbb-clock .face circle {
+    fill: ${#dcdad7} !important;
+}
+.sbb-clock .face,
+.sbb-clock .sbb-clock__hand-hours,
+.sbb-clock .sbb-clock__hand-minutes {
+    fill: ${black} !important;
+}
+.sbb-button,
+.sbb-teaser-hero > * > * > * {
+    color: ${black} !important;
+}
+:root {
+    --sbb-color-aluminium-default: ${#d2d2d2} !important;
+    --sbb-color-anthracite-default: ${#5a5a5a} !important;
+    --sbb-color-autumn-default: ${#e84e10} !important;
+    --sbb-color-black-alpha-0: ${transparent} !important;
+    --sbb-color-black-alpha-10: ${rgba(0,0,0,.1)} !important;
+    --sbb-color-black-alpha-15: ${rgba(0,0,0,.15)} !important;
+    --sbb-color-black-alpha-20: ${rgba(0,0,0,.2)} !important;
+    --sbb-color-black-alpha-30: ${rgba(0,0,0,.3)} !important;
+    --sbb-color-black-alpha-40: ${rgba(0,0,0,.4)} !important;
+    --sbb-color-black-alpha-50: ${rgba(0,0,0,.5)} !important;
+    --sbb-color-black-alpha-60: ${rgba(0,0,0,.6)} !important;
+    --sbb-color-black-alpha-70: ${rgba(0,0,0,.7)} !important;
+    --sbb-color-black-default: ${#000} !important;
+    --sbb-color-brown-default: ${#b76000} !important;
+    --sbb-color-cement-alpha-0: ${hsla(0,0%,74%,0)} !important;
+    --sbb-color-cement-alpha-20: ${hsla(0,0%,74%,.2)} !important;
+    --sbb-color-cement-default: ${#bdbdbd} !important;
+    --sbb-color-charcoal-default: ${#212121} !important;
+    --sbb-color-cloud-default: ${#e5e5e5} !important;
+    --sbb-color-granite-default: ${#686868} !important;
+    --sbb-color-graphite-default: ${#b7b7b7} !important;
+    --sbb-color-green-default: ${#008a36} !important;
+    --sbb-color-iron-default: ${#444} !important;
+    --sbb-color-lemon-default: ${#ffde15} !important;
+    --sbb-color-metal-alpha-0: ${hsla(0,0%,46%,0)} !important;
+    --sbb-color-metal-alpha-20: ${hsla(0,0%,46%,.2)} !important;
+    --sbb-color-metal-default: ${#767676} !important;
+    --sbb-color-midnight-default: ${#151515} !important;
+    --sbb-color-milk-default: ${#f6f6f6} !important;
+    --sbb-color-night-default: ${#143a85} !important;
+    --sbb-color-orange-default: ${#f27e00} !important;
+    --sbb-color-peach-default: ${#fcbb00} !important;
+    --sbb-color-pink-default: ${#cf4082} !important;
+    --sbb-color-platinum-alpha-0: ${hsla(0,0%,80%,0)} !important;
+    --sbb-color-platinum-alpha-20: ${hsla(0,0%,80%,.2)} !important;
+    --sbb-color-platinum-default: ${#cdcdcd} !important;
+    --sbb-color-red-alpha-0: rgba(235,0,0,0) !important;
+    --sbb-color-red-alpha-20: rgba(235,0,0,.2) !important;
+    --sbb-color-red-alpha-90: rgba(235,0,0,.9) !important;
+    --sbb-color-red-default: #eb0000 !important;
+    --sbb-color-red-mode-dark: #ff3838 !important;
+    --sbb-color-red125-alpha-0: rgba(198,0,24,0) !important;
+    --sbb-color-red125-alpha-20: rgba(198,0,24,.2) !important;
+    --sbb-color-red125-default: #c60018 !important;
+    --sbb-color-red150-default: #a20013 !important;
+    --sbb-color-silver-default: ${#dcdcdc} !important;
+    --sbb-color-sky-default: ${#0079c7} !important;
+    --sbb-color-smoke-alpha-0: ${hsla(0,0%,55%,0)} !important;
+    --sbb-color-smoke-alpha-10: ${hsla(0,0%,55%,.1)} !important;
+    --sbb-color-smoke-alpha-20: ${hsla(0,0%,55%,.2)} !important;
+    --sbb-color-smoke-alpha-5: ${hsla(0,0%,55%,.05)} !important;
+    --sbb-color-smoke-default: ${#8d8d8d} !important;
+    --sbb-color-storm-default: ${#a8a8a8} !important;
+    --sbb-color-turquoise-default: ${#00a59b} !important;
+    --sbb-color-violet-default: ${#6f2282} !important;
+    --sbb-color-white-alpha-0: ${hsla(0,0%,100%,0)} !important;
+    --sbb-color-white-alpha-20: ${hsla(0,0%,100%,.2)} !important;
+    --sbb-color-white-alpha-30: ${hsla(0,0%,100%,.3)} !important;
+    --sbb-color-white-alpha-50: ${hsla(0,0%,100%,.5)} !important;
+    --sbb-color-white-alpha-60: ${hsla(0,0%,100%,.6)} !important;
+    --sbb-color-white-alpha-70: ${hsla(0,0%,100%,.7)} !important;
+    --sbb-color-white-default: ${#fff} !important;
+}
+
+================================
+
+sbermegamarket.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+scdsb.elearningontario.ca
+
+CSS
+.my-activities {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+
+================================
+
+schnucks.com
+
+CSS
+.text-white {
+    --darkreader-text--tw-text-opacity: 1;
+    color: ${#181A1B} !important;
+}
+
+================================
+
+scholar.google.*
+scholar.google.*.*
+
+INVERT
+a[role="checkbox"] > :nth-child(2)
+div[role="banner"] > a > span
+a[aria-label="Homepage"]
+.gs_ico
+img[src*="scholar_logo"]
+a#gs_hdr_lgo
+a#gs_hdr_drw_lgo
+span.gs_in_cb
+
+CSS
+.gs_fma_cl .gs_fma_snp,
+.gs_fma_cl .gs_fma_fon {
+    z-index: 0 !important;
+}
+
+================================
+
+schwab.com
+
+CSS
+.highcharts-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+sci-hub.*
+
+IGNORE IMAGE ANALYSIS
+#raven
+#logo
+
+================================
+
+scien.cx
+
+CSS
+body.custom-background {
+    background-image: none !important;
+}
+
+================================
+
+science.org
+
+INVERT
+.navbar-brand > .hidden-on-dark
+.main-header__secondary__logo > img
+
+CSS
+h1.news-article__hero__title {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+sciencebasedmedicine.org
+
+INVERT
+.site-logo
+
+================================
+
+sciencedirect.com
+
+CSS
+body,
+.gh-nav .gh-nav-action,
+.search-button-link>.link-button.search-button-outline,
+.link-button-secondary:not(.on-dark-background),
+.button-link-primary,
+.button-alternative-text,
+.button-alternative-text:hover,
+.bibliography,
+.els-footer-content .anchor,
+.button-link {
+    color: ${#1f1f1f} !important;
+}
+#gh-cnt,
+.accessbar-sticky,
+.search-button-link>.link-button.search-button-outline,
+.link-button-secondary:not(.on-dark-background) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.u-bg-grey1,
+.u-bg-white,
+.cookie-btn {
+    background-color: ${#f5f5f5} !important;
+}
+.authors,
+.gh-nav-help-anchor,
+.publication-title-link,
+.pps-count,
+.pps-label,
+.u-margin-s-bottom {
+    color: var(--darkreader-neutral-text) !important;
+}
+.author-highlights,
+#gh-drawer,
+.popover-content-inner {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.popover-content {
+    background-color: rgba(50, 50, 50, .85) !important;
+}
+#gh-overlay {
+    background-color: rgba(20, 20, 20, .85) !important;
+}
+.article-textbox {
+    background-color: ${rgb(213, 211, 207)} !important;
+}
+.Article .topic-link {
+    color: ${rgb(46, 50, 52)} !important;
+    text-decoration-color: ${rgb(46, 50, 52)} !important;
+}
+.u-fill-grey8 {
+    fill: ${#1f1f1f} !important;
+}
+.issue-navigation .button-alternative-tertiary [class*="icon-"] {
+    background: #f5f5f5 !important;
+}
+
+================================
+
+scipy-lectures.org
+
+INVERT
+img.math
+
+================================
+
+scmp.com
+
+INVERT
+.header-menu-container__menu-top-left-wrapper
+.global-menu-features__menu-icon
+.global-menu-features__search-icon
+.global-menu-features__close-icon
+.social-button__twitter--active
+.social-button__email--active
+.footer-wrapper__logo
+
+================================
+
+scpclassic.wikidot.com
+scpexplained.wikidot.com
+scpfoundation.net
+scp-wiki.net
+scp-wiki.wikidot.com
+scp-wiki-cn.wikidot.com
+scpko.wikidot.com
+scpwiki.com
+scp-ru.wikidot.com
+scpfoundation.net
+
+CSS
+div#container-wrap,
+.panel-body,
+.content-panel {
+    background-image: none !important;
+}
+div#container-wrap::before {
+    background-image: url(https://scp-wiki.wdfiles.com/local--files/component:theme/body_bg.png) !important;
+    content: "";
+    height: 162px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+.yui-navset .yui-nav a {
+    background-image: none !important;
+}
+
+================================
+
+scratch-wiki.info
+
+INVERT
+.sb3-comment-label
+.sb3-literal-string
+.sb3-literal-number
+
+================================
+
+scratch.mit.edu/projects
+
+CSS
+path.blocklyFlyoutBackground {
+    fill: rgb(32, 32, 32);
+}
+
+IGNORE INLINE STYLE
+g[data-argument-type="colour"] > path
+.scratchColourPickerLabel + .goog-slider-horizontal
+.color-button_color-button-swatch_37evk
+.color-picker_row-header_173LQ + div > .slider_container_o2aIb
+
+================================
+
+screenconnect.com
+*.screenconnect.com
+
+CSS
+.OuterPanel .MainPanel .MasterPanel .MasterListContainer ul li.HasChildren > div > p {
+    filter: brightness(100%) !important;
+}
+
+================================
+
+scribd.com
+
+INVERT
+.logo
+.document_container
+
+================================
+
+scribe.rip
+scribe.nixnet.services
+scribe.citizen4.eu
+scribe.bus-hit.me
+scribe.froth.zone
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+scribus.net
+
+INVERT
+#site-header img
+
+================================
+
+script.google.com
+
+INVERT
+.docs-icon
+.icon
+.monaco-editor .cursors-layer > .cursor
+
+IGNORE INLINE STYLE
+mask > *
+
+================================
+
+scroll.morele.net
+
+INVERT
+.navbar-logo
+.social-link
+
+================================
+
+se.pl
+
+INVERT
+.mobile-bars
+
+================================
+
+sea.playblackdesert.com
+
+INVERT
+.original .characteristic .desc
+.original .characteristic h3
+.original .characteristic .feature li span
+
+================================
+
+sealegacy.org
+
+INVERT
+.custom-logo
+
+================================
+
+seamonkey-project.org
+
+INVERT
+img[src*="logo.png"]
+
+CSS
+#breadcrumbs {
+    background-image: none !important;
+}
+
+================================
+
+searchenginejournal.com
+
+INVERT
+.sej-footer-logo
+.sej-mobile-logo
+.whitelogo
+
+================================
+
+sec.sangfor.com
+sec.sangfor.com.cn
+
+INVERT
+.en-logo
+
+================================
+
+secondlife.com
+
+INVERT
+nav > div > div > div[class$=-line]
+
+CSS
+div.hero-section.homepage.wf-section {
+    z-index: 0;
+}
+
+================================
+
+sectigo.com
+
+INVERT
+.bg-object-fit
+
+================================
+
+secure.ally.com
+
+INVERT
+.nobd-aob-day
+#lp_invite
+#manageNonAllyAccountsFrame .third-party-iframe
+#billPayFrame
+
+================================
+
+secure.fanboy.co.nz
+
+CSS
+html {
+    background-image: none !important;
+}
+
+================================
+
+secure.runescape.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+secureage.com
+
+INVERT
+.logo-block
+
+================================
+
+security.org
+
+INVERT
+.category-cards img
+.featured-in img
+.grid-x.stats img
+.product-logo
+a.brand
+section[id="our-top-picks"] img
+
+================================
+
+seedr.cc
+
+INVERT
+.content-item-filename
+.content-link
+div[id="folder-up"] img
+
+================================
+
+segger.com
+
+CSS
+.c-page-layout-bg-image {
+    background-image: none !important;
+}
+
+================================
+
+segmentfault.com
+
+INVERT
+.sf-header-logo
+.sf-header__logo
+.sf-logo
+.navbar-brand
+
+================================
+
+sejm.gov.pl
+
+CSS
+.main {
+    background-image: none !important;
+}
+
+================================
+
+sematext.com
+
+INVERT
+#logo
+.sematext-clients-gamma figure
+
+================================
+
+sembr.org
+
+CSS
+mark {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+seminka-chilli.cz
+chilli-shop.sk
+
+CSS
+#pannelWrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+semmle.com
+
+CSS
+#Header-logo * {
+    fill: #ffffff !important;
+}
+
+================================
+
+senscritique.com
+
+INVERT
+.d-media-videos::before
+.eins-wish.black
+.eins-logo-small
+.header-navigation-main-item a img
+.eins-search-header
+.eins-poll
+.eins-compass
+.eins-compass-xl
+.eins-notification
+.eins-tv
+.eins-ticket
+.eins-current.black
+.eins-done.green
+.eins-done.white
+.eins-newspaper
+.juyLRn
+
+CSS
+.ecap-products-next,
+.ecap-products-prev {
+    background-color: hsla(100, 20%, 50%, .8) !important;
+    color: ${black} !important;
+}
+.d-chevron3-b,
+.d-chevron3-l,
+.d-chevron3-r,
+.d-chevron3-t {
+    background-image: -webkit-image-set(url(https://static.senscritique.com/img/layout/icons/chevrons/chevron-size3.png?201710121789416) 1x,url(https://static.senscritique.com/img/layout/icons/chevrons/chevron-size3@2x.png?201710121789416) 2x);
+}
+
+================================
+
+sentienceinstitute.org
+
+CSS
+div.parallax-mirror {
+    z-index: auto !important;
+}
+
+================================
+
+sephora.com
+
+INVERT
+img[alt="Sephora"]
+img[src="/img/ufe/icons/stores.svg"]
+img[src="/img/ufe/icons/community.svg"]
+img[src="/img/ufe/icons/me32.svg"]
+svg[data-at="basket_icon_large"]
+div[aria-label$="stars"]
+
+================================
+
+septa.org
+
+INVERT
+.checked > label > div > .switch-marker
+.clear-btn
+.kt-blocks-accordion-icon-trigger
+.leaflet-control-attribution
+.leaflet-popup
+.listbox-row[role="presentation"] > svg-icon
+.map-container
+.map-zoom-controls > button > i
+.search-icon
+
+CSS
+.bg-black,
+.is-frequent {
+    background-color: var(--darkreader-neutral-text) !important;
+    color: var(--darkreader-neutral-background) !important;
+}
+.bus,
+.circle {
+    border: 2px solid var(--darkreader-neutral-text) !important;
+}
+.leaflet-routes-pane > svg > g > path {
+    stroke: #000 !important;
+}
+.leaflet-stops-pane > svg > g > path,
+.trip-icon-container > svg > path {
+    fill: #fff !important;
+    stroke: #000 !important;
+}
+
+================================
+
+sergeistrelec.name
+
+CSS
+.bl0 {
+    background: #f8fbf8 !important;
+}
+html[data-darkreader-scheme="dark"] .bl2 {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.80)} !important;
+}
+html[data-darkreader-scheme="dark"] .bln li {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.85)} !important;
+}
+html[data-darkreader-scheme="dark"] #footer,
+html[data-darkreader-scheme="dark"] .small-logo,
+html[data-darkreader-scheme="dark"] .sh10 {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.95)} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.bln li
+#footer
+.small-logo
+.bl2
+.sh9
+.sh10
+
+================================
+
+server.pro
+
+INVERT
+svg.server-pro-logo
+
+================================
+
+servercontrolpanel.de
+
+CSS
+body {
+    background-color: transparent !important;
+}
+
+================================
+
+setupbits.com
+
+INVERT
+.td-header-logo
+.td-main-logo
+
+================================
+
+shadertoy.com
+
+INVERT
+.uiButton
+.uiButtonNew
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+shakemap.ipma.pt
+subscricoes.ipma.pt
+
+INVERT
+img[alt="Logo IPMA"]
+img.ImgGeral
+
+================================
+
+shaneco.com
+
+INVERT
+.logo-full
+
+================================
+
+shapecatcher.com
+
+INVERT
+img[src^="https://shapecatcher.com/svg/"]
+
+CSS
+html[data-darkreader-scheme="dark"] img[src*="header.png"] {
+    background-color: #333 !important;
+}
+
+================================
+
+share.dmhy.org
+
+CSS
+.jmd_base td a {
+    color: ${#3391ff};
+}
+.jmd .today a {
+    color: ${#fff};
+}
+
+================================
+
+sharedrop.io
+
+CSS
+.qr-code img {
+    border: 10px solid white !important;
+}
+
+================================
+
+sharepoint.com
+*.sharepoint.com
+
+INVERT
+img.WACPageImg
+
+CSS
+.ms-FocusZone,
+.ms-DetailsRow-cell,
+.ms-Button {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ms-DetailsRow-cell,
+.ms-FocusZone,
+.ms-Button,
+.od-ItemContent-title,
+.ms-DetailsHeader-cellName {
+    color: var(--darkreader-neutral-text) !important;
+}
+.ms-Button {
+    border-color: ${#F0F0F0} !important;
+}
+
+================================
+
+shazam.com
+
+INVERT
+.media.track::after
+
+CSS
+.google,
+.apple-app-store {
+    background-image: url(/resources/f6f457227917dcdfc9538fbbb5a931f111648b3d/sprite.png) !important;
+}
+button[data-shz-cmd="try"] {
+    background-color: rgba(232, 230, 227) !important;
+    color: rgb(29, 33, 34) !important;
+}
+.shz-frame-ux-playerbar-upsell-variant-b {
+    --darkreader-bg--background-color: #1d2122 !important;
+}
+
+================================
+
+shells.com
+
+INVERT
+img[alt="Shells Logo"]
+
+================================
+
+shields.io
+
+INVERT
+#app a
+object
+
+================================
+
+shimadzu.com
+
+INVERT
+.header-logo
+
+================================
+
+shipstation.com
+*.shipstation.com
+
+INVERT
+[class*="sub-item-icon"]
+[data-testid*="note-icon"]
+[class*="pill-content"]
+.quantity-3CkoKmy
+
+CSS
+div[class*="status-text"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+[class*="pill"]
+[class*="color-button"]
+[class*="dropdown-toggler-color"]
+
+================================
+
+shoecarnival.com
+
+INVERT
+.jss140
+
+================================
+
+shop.app
+
+CSS
+.shadow-\[0px_2px_8px_0px_rgba\(0\,0\,0\,0\.06\)\,0px_-1px_30px_0px_\#F2F4F5\,0_0_0_40px_\#FCFCFC\] {
+    --darkreader-bg--tw-shadow: 0px 2px 8px 0px rgba(0,0,0,.06),0px -1px 30px 0px ${#F2F4F5},0 0 0 40px ${#FCFCFC} !important;
+}
+
+================================
+
+shop.dr-rath.com
+
+CSS
+.colored-header-desktop {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+shop.surfboard.com
+
+INVERT
+img.header-logo-image
+
+CSS
+.homepage {
+    background-image: none !important;
+}
+.sb-searchpro .input-group .btn {
+    background-color: ${#fee9a4} !important;
+}
+
+================================
+
+shopify.com
+shopify.dev
+
+INVERT
+.marketing-nav--skin-light > .marketing-nav__logo
+.shopify-logo
+.header-country-select__trigger
+.lia-message-count::before
+.DateTime::before
+img[class^="_Logo_"]
+
+================================
+
+shoppy.gg
+
+INVERT
+.footer-profile__logo
+
+================================
+
+shorthistory.org
+
+INVERT
+.td-logo > .td-main-logo > .td-retina-data
+
+================================
+
+shutupwrite.com
+
+CSS
+.suaw-welcome-section,
+.suaw-how-section,
+.suaw-wp-section,
+.suaw-why-section,
+.suaw-testimonial-section,
+.suaw-organize-section {
+    background: var(--darkreader-neutral-backround) !important;
+}
+
+================================
+
+si.edu
+
+INVERT
+.c-site-logo > .logo__image
+
+================================
+
+sic.pt
+sicnoticias.pt
+
+INVERT
+.main-footer .siga-sic li a img
+.main-footer .g-brands li
+.app-sicnot-wrapper .lojas-sicnot
+.main-footer .siga-sicnot li img
+
+================================
+
+signal.org
+
+INVERT
+.navbar-item .icon
+.signal-logo
+
+================================
+
+significancemagazine.com
+
+INVERT
+a.closed[href="#slide-out-widget-area"] span
+
+================================
+
+signin.ea.com
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+signin.nianticlabs.com
+signin.nianticspatial.com
+
+INVERT
+img[alt="Niantic"]
+
+================================
+
+signulous.com
+
+INVERT
+.checkbox input:checked
+
+CSS
+.checkbox input:checked {
+    background-color: white;
+}
+
+================================
+
+silhouette.com
+
+INVERT
+.retailer-newsletter-teaser__icon
+
+CSS
+div.slideshow-slide[data-swiper-slide-index="1"] {
+    background-image: url('//img2.storyblok.com/0x800/filters:no_upscale():format(webp)/f/40252/1920x800/df0f0f3709/2024_11_dyncwcontour_home-header.jpg') !important;
+}
+
+================================
+
+simepar.br
+
+CSS
+.highcharts-text-outline {
+    display: none !important;
+}
+
+================================
+
+similarweb.com
+
+INVERT
+.app-header__logo
+
+================================
+
+simplemachines.org
+
+INVERT
+h1.forumtitle
+
+CSS
+#header div.frame,
+#header,
+span.botslice span,
+span.botslice,
+span.topslice,
+span.topslice span,
+#content_section,
+#content_section div.frame,
+span.lowerframe,
+span.lowerframe span,
+div.title_bar,
+h4.titlebg,
+h3.titlebg,
+h4.catbg,
+h4.catbg2,
+h3.catbg,
+h3.catbg2,
+.table_list tbody.header td.catbg {
+    background-image: none !important;
+}
+
+================================
+
+simply-v.de
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+simplywall.st
+
+INVERT
+.logo-image
+img[src*="_Frame%20101406.png"]
+img[src*="reviews.svg"]
+img[src*="_eye%201.svg"]
+img[src*="_search%203.svg"]
+img[src*="_activity%202.svg"]
+img[src*="_Header_"]
+img[src*="_image_273%201.png"]
+img[src*="_check.svg"]
+img[src*="stars.svg"]
+img[src*="_Future.png"]
+.screener-idea-visual
+img[src*="_about%20us%20hero.png"]
+img[src*="_Master%20your%20craft.png"]
+img[src*="_Fall%20in%20love.png"]
+img[src*="_Enjoy%20the%20ride.png"]
+img[src*="_Dream%20big.png"]
+img[src*="_Gem_2.png"]
+.social-link-x
+img[src*="_Careers%20hero.png"]
+img[src*="_3%20bears.png"]
+img[src*="_tick.png"]
+img[alt="A user is empowered with analysis"]
+img[alt="Icon of a chain representing connection"]
+.screener-idea-visual-copy > img
+img[alt="tick"]
+img[src*="logos-forbes-afr-cnbc.png"]
+img[src*="logos-techcrunch-skynews.png"]
+img[alt="google-five-stars"]
+img[alt="SP Global logo"]
+img.snowflake-image
+button[data-cy-id="button-apple-login"] svg
+svg.mx-auto:not(.mb-3) path
+
+CSS
+html[data-darkreader-scheme="dark"] .sc-l2psw8-0 svg path {
+    fill: white !important;
+}
+footer .max-w-\[27ch\] a:first-of-type svg path:first-of-type {
+    fill: #007EBB !important;
+}
+footer .max-w-\[27ch\] a:nth-of-type(3) svg path:first-of-type {
+    fill: red !important;
+}
+.white-section-community-copy img {
+    filter: none !important;
+    mix-blend-mode: unset !important;
+}
+.column-13 {
+    color: #d9d6d1 !important;
+}
+svg[width="20"][height="16"] rect {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+a[href="/?view"] *
+a[href="/dashboard"] *
+a[href="https://simplywall.st"] *
+div[class*="mt-[env(safe-area-inset-top)]"] *
+footer *
+svg.mx-auto path
+
+================================
+
+simplywallst.statuspage.io
+
+INVERT
+img[alt="SimplyWallSt logo"]
+
+================================
+
+simracingmachines.com
+
+INVERT
+slider-component div.media.media--transparent > img[class="multicolumn-card__image"][src*=".png" i]
+
+CSS
+.gradient {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+singularlabs.com
+
+INVERT
+img[alt="SingularLabs"]
+
+================================
+
+sio2.staszic.waw.pl
+
+INVERT
+.texmath
+
+================================
+
+sitecheck.sucuri.net
+
+INVERT
+.icon
+.logo
+
+================================
+
+sklepbiegacza.pl
+
+INVERT
+.header__logo
+.button__icon
+.main-slider__nav-item
+.homepage__brand-logo
+.footer__list-image
+img.footer__image[src*=cash]
+.product__brand-logo
+.paypo-info__button
+
+================================
+
+skycash.com
+
+CSS
+.c-hero__newsletter {
+    background-image: none !important;
+}
+
+================================
+
+skyscanner.*
+skyscanner.*.*
+backpack.github.io
+tianxun.cn
+whoflies.com
+
+CSS
+body {
+    background: ${white} !important;
+}
+[class*=bpk-flare-bar__curve] {
+    fill: ${white} !important;
+}
+
+================================
+
+slack.com
+
+CSS
+.c-slacklogo svg path:first-child {
+    fill: var(--darkreader-selection-text) !important;
+}
+.c-button:not(.v--primary, .v--secondary) {
+    background: inherit !important;
+    color: inherit !important;
+}
+.c-button:not(.v--primary, .v--secondary):hover {
+    text-decoration: underline !important;
+}
+
+================================
+
+slackware.com
+
+CSS
+body {
+    background-image: none !important;
+}
+td[bgcolor="#000000"] {
+    border: 1px solid !important;
+}
+
+================================
+
+slader.com
+
+INVERT
+.navigation__logo
+.explanation
+.solution-cell img
+.solution-content img
+.answer img
+
+================================
+
+slashnet.wordpress.com
+
+CSS
+#container,
+.entry,
+body {
+    background-image: none !important;
+}
+
+================================
+
+slazag.pl
+
+INVERT
+.focus__portals__banner__single
+.footer__title__wrapper
+.logo__wrapper
+.social-bar
+.triangle-slazag-svg
+img.section-bg-absolute
+
+================================
+
+slovensko.sk
+*.slovensko.sk
+
+CSS
+.enrollment-portal__authentication-process__qr-image img {
+    background-color: white !important;
+}
+
+================================
+
+smap.uthm.edu.my
+
+CSS
+.slider-background {
+    background: none !important;
+}
+.backstretch {
+    opacity: 0.5 !important;
+}
+
+================================
+
+smcdsb.elearningontario.ca
+
+CSS
+:host([no-padding-footer]) .d2l-dropdown-content-footer,
+:host([no-padding-header]) .d2l-dropdown-content-header,
+:host([no-padding]) .d2l-dropdown-content-container {
+    background: var(--darkreader-neutral-background);
+}
+
+================================
+
+smithsonian.com
+
+INVERT
+div.logos-wrapper img
+
+================================
+
+smithsonianbooks.com
+
+INVERT
+img[src$="/books-logo-black.d7875c6914c9.svg"]
+div#mobileMenuButton > span
+
+================================
+
+smithsonianjourneys.org
+
+INVERT
+img[src$="/Journeys-Logo-black.50b2dd0b2d72.svg"]
+
+================================
+
+smithsonianmag.com
+
+INVERT
+#mobile-icon > span
+
+================================
+
+smithsonianstore.com
+
+INVERT
+img[src$="/smithsonian-institution-vector-logo.svg"]
+span.navbar-toggler-icon
+
+================================
+
+smoglab.pl
+
+CSS
+.main-nav,
+.footer,
+.module-title .main-title {
+    background-image: none !important;
+}
+
+================================
+
+smokin-guns.org
+
+CSS
+#page-body .smoke-grid-9 .inner {
+    background-image: none !important;
+}
+
+================================
+
+smtp2go.com
+
+INVERT
+canvas
+
+================================
+
+smzdm.com
+
+INVERT
+#logo
+.logo-left
+
+================================
+
+snack.expo.io
+
+CSS
+#root > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div:nth-child(2) {
+    background-color: white !important;
+}
+
+================================
+
+snapcraft.io
+
+CSS
+#search-docs {
+    background-image: none !important;
+}
+
+================================
+
+snapeda.com
+
+INVERT
+img[title="SnapEDA"]
+img.part-organization
+canvas:not(#firstfootprint)
+
+================================
+
+sngbonus.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
+softorage.com
+
+CSS
+.tg {
+    background-image: linear-gradient(36deg,#fc466b,#3f5efb) !important;
+}
+
+================================
+
+softpedia.com
+
+IGNORE IMAGE ANALYSIS
+.menubar-hp span.logov
+h1.logov
+
+================================
+
+soha.vn
+
+INVERT
+.page-head__right .head-hanhtrinh img
+
+CSS
+.page-body .page-head,
+.page-menu,
+.page-top,
+.sh_home20-wrapper,
+.sh_home20-wrapper .shcategory.layout-bd-nonebg,
+.sh_home20-wrapper .shnews_box .noticable-news,
+.sh_home20-wrapper .shnews_box .reviewer .list-cmt .item-cmt,
+.news-detail .share {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sh_home20-wrapper .shnews_box .shnews_title,
+.sh_home20-wrapper .sh_hotnews .hotnews-label a,
+.news-detail .news-title,
+.news-content p,
+.list-topic-cate .item-news-cate .title-new-cate,
+.itembigs .related-special-news .item-related-news:first-child,
+.itembigs .related-special-news .item-related-news:first-child a,
+.rowccm li.tincungmucfocus .info h4.ksclili-title a {
+    color: var(--darkreader-neutral-text) !important;
+}
+.page-head,
+.page-top {
+    background-image: none !important;
+}
+
+================================
+
+solid.jobs
+
+INVERT
+.card-body img
+
+================================
+
+songsterr.com
+
+INVERT
+use[href^="#rest"]
+use[href^="#dot"]
+
+CSS
+#tablature svg text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+#tablature svg path {
+    stroke: var(--darkreader-neutral-text) !important;
+}
+section[role="main"] div[style^="transform"] {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+sony.*
+
+IGNORE INLINE STYLE
+.brand-logo-svg > g
+
+================================
+
+sophgo.com
+en.sophgo.com
+
+INVERT
+.logo
+
+================================
+
+soulsplanner.com
+
+CSS
+.form-controls input[type="checkbox"]:not(:checked) + label::before {
+    color: transparent !important;
+}
+
+================================
+
+soundcloud.com
+
+INVERT
+.notificationIcon.messages::before
+
+CSS
+.listenEngagement,
+.commentForm__wrapper {
+    border: none !important;
+}
+body,
+.commentForm__wrapper,
+.searchTitle {
+    background: none !important;
+}
+.sc-classic .header__navMenu > li > a {
+    border-right-color: #454545 !important;
+}
+.headerSearch__input {
+    background: ${#f1f4f6} !important;
+}
+
+================================
+
+souq.com
+
+INVERT
+img[src*="/souqAmazon-logo-v2"]
+li.fashion-menu-link[aria-expanded="false"]
+.userNameField::after
+.filter-icon.deals
+.cart-icon
+
+================================
+
+source.dot.net
+
+CSS
+.r {
+    border-style: none !important;
+}
+
+================================
+
+sourceforge.net
+
+CSS
+.intro,
+.audience {
+    background-image: none !important;
+}
+.all-facets,
+.m-project-search-results {
+    background-color: ${white} !important;
+}
+
+================================
+
+sourcegraph.com
+
+INVERT
+.header__logo
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+sourcing.hktdc.com
+
+INVERT
+.logo
+
+================================
+
+southparkstudios.com
+southpark.de
+
+CSS
+:root {
+    --page-background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+sovietrepublic.net
+
+CSS
+wix-bg-image {
+    background-image: none !important;
+}
+article,
+section.prZ8Wc {
+    background-color: rgba(255,255,255,0.05) !important;
+}
+
+================================
+
+soylent.com
+
+INVERT
+.header-logo__image
+.d-header #site-logo
+
+================================
+
+space.bilibili.com
+
+INVERT
+.count::before
+.h .h-gradient
+
+CSS
+.elec .elec-status {
+    display: none;
+}
+:root {
+    --bg1: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--_container-color: transparent !important;
+    --darkreader-text--_label-text-color: var(--darkreader-text--text3) !important;
+    --graph_bg_thick: var(--darkreader-border--graph_bg_thick) !important;
+}
+
+================================
+
+spaceship.com
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+spaceweather.com
+
+INVERT
+[src$="current_conditions.jpg"]
+[src$="center_tablebg_top_r2_c1.jpg"]
+
+CSS
+[background] {
+    background-image: none !important;
+}
+
+================================
+
+spanish.kwiziq.com
+
+CSS
+.bg-clouds {
+    background-image: none !important;
+}
+.table-scroll-shadow-wrapper table td,
+.table-scroll-shadow-wrapper table th,
+.table-scroll-shadow-wrapper table tr {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+spb-neo.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="patched-for-print"]
+
+================================
+
+spboms.ru
+
+CSS
+body {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+spc.noaa.gov
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+spdx.org/licenses
+
+INVERT
+.gray-diagonal
+#logo
+
+================================
+
+spectrum.com
+
+INVERT
+img[src$="spectrum-logo.svg"]
+
+CSS
+.sp-background-image {
+    background-image: none !important;
+}
+
+================================
+
+spectrum.ieee.org
+
+INVERT
+a[title="Spectrum Logo"] > svg
+
+================================
+
+spectrum.net
+
+INVERT
+.banner-wrapper > .image-container
+img[src$="spectrum-logo.svg"]
+
+CSS
+.unauthenticated-homepage {
+    background-image: none !important;
+}
+
+================================
+
+speed.cloudflare.com
+
+INVERT
+img[src*="speedrabbit-animate.gif"]
+img[src*="speedrabbit-static.png"]
+
+================================
+
+speeddial2.com
+
+INVERT
+img[src*="images/"]
+
+================================
+
+spidersweb.pl
+
+INVERT
+.amp-site-title
+img[alt="logo bizBlog"]
+img[alt="bizblog to ludzie"]
+
+================================
+
+spidersweb.pl/plus
+
+INVERT
+a[href="/plus"] svg
+
+================================
+
+spidersweb.pl/rozrywka
+
+INVERT
+a[href="/rozrywka"] svg
+
+CSS
+a[href="/rozrywka"] svg path[fill="#211D26"] {
+    --darkreader-inline-fill: ${white} !important;
+}
+
+================================
+
+sport5.co.il
+
+INVERT
+.news-room-placeholder .container-message-in .newsroom-row .newsroom-spitz
+
+================================
+
+sports.ru
+
+INVERT
+.nav-top-line__logo
+
+================================
+
+sports.yahoo.com
+
+CSS
+:root ._ys_gupwdl,
+[data-color-scheme=light] [data-color-scheme=auto]._ys_gupwdl,
+[data-color-scheme=light]._ys_gupwdl {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+sporza.be
+
+CSS
+.sc-score,
+.sc-score__away,
+.bouton:hover {
+    color: ${#222} !important;
+}
+.sc-score__wrapper {
+    background-color: ${#BBB} !important;
+}
+.bouton {
+    color: ${#fff} !important;
+}
+.sc-epg--live .sc-epg__program {
+    background-color: ${#CCC} !important;
+}
+.vrt-newsletter {
+    background-color: ${#EEE} !important;
+}
+.vrt-site-footer .vrt-newsletter .vrt-link--newsletter {
+    background-color: ${#AAA} !important;
+}
+.logo__letters {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.vrt-link {
+    background-color: ${rgba(255, 165, 0, 0)} !important;
+    color: ${rgba(50, 50, 50)} !important;
+}
+.vrt-link:hover {
+    background-color: ${rgb(100, 100, 100)} !important;
+}
+.vrt-site-footer__navigation--green {
+    background-color: ${#AAA} !important;
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+spreadprivacy.com
+
+INVERT
+[src^="https://spreadprivacy.com/content/images/2017/07/linux"]
+[src^="https://spreadprivacy.com/content/images/2017/11/Significant-Actions"]
+[src^="https://spreadprivacy.com/content/images/2018/09/ddg-traffic"]
+[src^="https://openclipart.org/image/24px/svg_to_png/28768/qubodup-Cubikopp-smilies"]
+[src="https://spreadprivacy.com/content/images/2017/10/smiley.png"]
+[src="https://spreadprivacy.com/content/images/2018/09/private-browsing4.png"]
+[src="https://spreadprivacy.com/content/images/2017/10/https-in-address-bar26.png"]
+[src="https://spreadprivacy.com/content/images/2018/01/private-browsing-reasons-1.png"]
+[src="https://spreadprivacy.com/content/images/2020/05/search-preference-menu_heatmap.jpg"]
+[src="https://spreadprivacy.com/content/images/2020/10/trilateral-invitation_header-1.png"]
+[src="https://spreadprivacy.com/content/images/2020/05/search-preference-menu_comparison-1.jpg"]
+[src="https://spreadprivacy.com/content/images/2020/05/search-preference-menu_screen-sizes-1.jpg"]
+[src="https://spreadprivacy.com/content/images/2020/02/Awareness-of-Privacy-Risk-of-Public-USB-Charging-.jpg"]
+[src="https://spreadprivacy.com/content/images/2018/02/DuckDuckGo-Extension_Desktop-OnDevice.jpg"]
+
+================================
+
+squareup.com
+
+INVERT
+.logo
+
+================================
+
+src.fedoraproject.org
+pagure.io
+
+INVERT
+#pagureLogo
+
+IGNORE INLINE STYLE
+#cal-heatmap svg rect
+
+================================
+
+ss64.com/pass
+
+CSS
+.mainpw {
+    background-color: #ffffff;
+    color: #202223;
+}
+
+IGNORE INLINE STYLE
+.mainpw
+
+================================
+
+ssllabs.com
+
+INVERT
+#logo
+
+================================
+
+sso.qiniu.com
+
+INVERT
+.navbar-brand
+
+================================
+
+stablediffusionweb.com
+
+INVERT
+img[src="https://r2.stablediffusionweb.com/images/background-faqs.jpg"]
+
+================================
+
+stackage.org
+
+INVERT
+.logo
+
+================================
+
+stackexchange.com
+askubuntu.com
+mathoverflow.net
+serverfault.com
+stackapps.com
+stackoverflow.com
+superuser.com
+*.stackexchange.com
+
+INVERT
+._glyph:not(.top-bar .-logo ._glyph)
+.favicon-mathoverflow
+.favicon-mathoverflowmeta
+.favicon-stackoverflowmeta
+.h-auto[alt="Academia"]
+.h-auto[alt="Anime & Manga"]
+.h-auto[alt="Ask Different"]
+.h-auto[alt="Aviation"]
+.h-auto[alt="Code Review"]
+.h-auto[alt="Electrical Engineering"]
+.h-auto[alt="English Language Learners"]
+.h-auto[alt="Japanese Language"]
+.h-auto[alt="MathOverflow"]
+.h-auto[alt="Mathematics"]
+.h-auto[alt="Server Fault"]
+.h-auto[alt="Skeptics"]
+.h-auto[alt="Software Engineering"]
+.h-auto[alt="Stack Apps"]
+.h-auto[alt="Super User"]
+.h-auto[alt="The Workplace"]
+.h-auto[alt="Theoretical Computer Science"]
+.h-auto[alt="Unix & Linux"]
+.h-auto[alt="Web Applications"]
+.h-auto[alt="Role-playing Games"]
+a.js-gps-track::before
+img[alt="The Stack Exchange Network"]
+button[class^="js-vote"]
+.MathJax img
+
+CSS
+body,
+#content {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+    border-color: var(--darkreader-bg--theme-primary-custom) !important;
+}
+.profile-cards--graph {
+    background-image: repeating-linear-gradient(0deg, transparent, transparent 13px, ${#e4e6e8} -13px, ${#e4e6e8} 21px) !important;
+}
+.c-pointer {
+    color: grey;
+}
+.js-accepted-answer-indicator.fc-green-500 {
+    color: var(--green) !important;
+}
+#newuser-box {
+    background-color: ${#FFF8DC} !important;
+}
+.topbar .icon-site-switcher-bubble {
+    background-repeat: no-repeat !important;
+}
+div.h100.bar-lg.p-bs-wrapper:has(a[href="/questions"]) {
+    background: linear-gradient(0deg, #502502 30%, #FFFFFF) !important;
+}
+div.h100.bar-lg.p-bs-wrapper:has(a[href="https://stackoverflow.co/teams"]) {
+    background: linear-gradient(0deg, hsl(209,100%,26%) 30%, #FFFFFF) !important;
+}
+button[class^="js-vote"] {
+    border-color: var(--darkreader-dark-background) !important;
+}
+
+IGNORE INLINE STYLE
+.chess-replayer-board td
+
+IGNORE IMAGE ANALYSIS
+.hero-background
+
+================================
+
+standards.ieee.org
+
+INVERT
+.logo-link
+
+================================
+
+stardewvalleywiki.com
+
+CSS
+html {
+    background: none !important;
+}
+
+================================
+
+stardock.com
+
+INVERT
+.mid
+.careers
+
+================================
+
+start.gg
+
+CSS
+:root {
+    --color-white: ${white};
+}
+
+================================
+
+start64.com
+
+INVERT
+img[alt="logo"]
+
+================================
+
+startech.com.bd
+
+INVERT
+#nav-toggler
+
+================================
+
+startpage.com
+
+INVERT
+.hamburger-menu .hamburger-button
+
+IGNORE IMAGE ANALYSIS
+.home__section__search-logo
+.header__logo
+.header-settings__logo
+.hamburger-menu .hamburger-button
+
+================================
+
+stat.utels.ua
+
+CSS
+img[src="/i/btm_m1.gif"],
+img[src="/i/top_m1.gif"] {
+    display: none !important;
+}
+[style*="background: url(\"/i/box"],
+td[background="/i/cntr_m1.gif"] {
+    background-image: none !important;
+}
+
+================================
+
+station-drivers.com
+
+INVERT
+img[src*="/topic_icons/"]
+img[src*="/folder_icons/"]
+img[src*="/images/bios_firmware"]
+img[src*="/images/driver.jpg"]
+img[src*="/images/utile"]
+img[src*="/images/rating"]
+img[src*="/images/star"]
+img[src*="/images/downl"]
+img[src*="/components/com_remository/images/file_icons/"]
+img[src*="/images/gohome.gif"]
+
+================================
+
+stats.arp242.net
+
+INVERT
+.chart-line
+
+================================
+
+stats.stackexchange.com
+
+CSS
+.site-header {
+    background-image: none !important;
+}
+
+================================
+
+statshunters.com
+
+INVERT
+.logo
+
+CSS
+.highcharts-background {
+    fill: none !important;
+}
+.highcharts-text-outline {
+    stroke: none !important;
+}
+.highcharts-plot-band {
+    fill: ${rgb(223, 223, 223)} !important;
+}
+.highcharts-tooltip-box {
+    fill: var(--darkreader-neutral-background) !important;
+}
+svg.highcharts-root text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+status.aws.amazon.com
+
+INVERT
+.logo
+.tabStandard
+td > img
+td > a > img
+th > a > img
+th > div > a > img
+
+CSS
+.tabStandard a {
+    color: ${white} !important;
+}
+.tabStandard,
+.selected a {
+    background-color: ${black} !important;
+    color: ${white} !important;
+}
+tbody > tr > th {
+    background: transparent !important;
+}
+table > tbody > tr > td {
+    background: transparent !important;
+}
+.gradient {
+    background: transparent !important;
+}
+
+================================
+
+status.epicgames.com
+
+INVERT
+div.eg-shield.white
+
+================================
+
+status.npmjs.org
+
+INVERT
+.logo-container > a > img
+
+================================
+
+status.quad9.net
+
+INVERT
+svg text
+
+CSS
+path[fill="#ffffff"],
+svg rect[fill="white"] {
+    fill: ${#ffffff};
+}
+path[stroke="#CCC"] {
+    stroke: #aaa;
+}
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+statusinvest.com.br
+
+INVERT
+div.indice-list div.ml-1
+div.indice-list div.mt-2
+i.ml-1
+
+================================
+
+steamdeck.com
+
+INVERT
+section#available-now div.col_9
+section#experience div.col_8
+section#experience h2
+section#topfeature div.col_5
+
+CSS
+section#available-now {
+    background-color: ${#0f0f0f} !important;
+}
+
+IGNORE INLINE STYLE
+#header-logo-arc
+
+================================
+
+stern.de
+
+CSS
+.page {
+    --page-background: var(--darkreader-neutral-background) !important;
+}
+.slide-navigation {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+stevendoesstuffs.dev
+
+INVERT
+.post-img-wrapper img
+
+================================
+
+stine.uni-hamburg.de
+
+CSS
+.appointment {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+stm.info
+
+INVERT
+.map-OSM
+
+================================
+
+stockbit.com
+
+INVERT
+.konvajs-content canvas
+a[href$="chartbit"] canvas
+footer + section img
+footer img
+img[alt*="chart"]
+img[src$="stockbit.svg"]
+
+CSS
+.highlight {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+stolichki.ru
+
+INVERT
+.logoBig__img
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+ymaps[class$="placemark__content-inner"] > ymaps > ymaps
+
+================================
+
+stooq.pl
+
+CSS
+a[href="//stooq.pl"] path:not([fill]) {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+store.google.*
+store.google.*.*
+
+CSS
+[style*="background-image"] {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+store.playstation.com
+
+INVERT
+.psw-brand-text--playstation-store
+
+================================
+
+store.ubi.com
+
+INVERT
+div.primary-logo
+
+CSS
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h2,
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h3,
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide a {
+    color: var(--darkreader-neutral-background) !important;
+}
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a[href$="/deals"] .homepage-custom-slide__content .custom-slide-inner h3 {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+storm.mg
+
+INVERT
+.footer_logo_img
+#logo_img
+
+================================
+
+storyteller.fit
+
+INVERT
+img[src*="icon"]
+
+================================
+
+storytellphys.wordpress.com
+
+INVERT
+img
+
+================================
+
+straightdope.com
+
+CSS
+body {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+strava.com
+*.strava.com
+
+INVERT
+.labelGroup
+#effort-box
+.week.clearfix svg
+#compare-graph svg
+#compare-graph canvas
+.nav-item a::after
+.weekly-goal svg .sport-type
+footer img[alt="Strava"]
+.activity-indicator
+.icon-other
+.icon-caret-up
+.icon-share
+.icon-kudo
+.icon-comment
+.icon-collapse
+.icon-star
+.icon-caret-right
+.btn-icon.remove
+.icon-private
+.icon-group
+text.label
+.MapViewControls--zoomIn--jYuDy
+.MapViewControls--zoomOut--EDC7q
+.MapViewControls_zoomIn__mGcSR
+.MapViewControls_zoomOut__QMFIG
+.follow-action .selection.gear::after
+img[src*="gift"]:not(a.btn-primary img)
+div[class*="FlyoverSpeedControl_flyoverSpeedControlScrubber"]
+.app-icon.icon-rowing
+.icon-close
+.mapboxgl-ctrl-icon
+.mapboxgl-ctrl-attrib-button
+div[class*="GlobalFooter_social"] img
+.app-icon.icon-search
+.app-icon.icon-caret-down
+img[src*="muscle-heatmap"]
+
+CSS
+.base-chart .grid-line,
+#athlete-history-chart .vgrid {
+    stroke: #555555;
+}
+#athlete-history-chart #effort-box {
+    fill: #3e3e3e;
+    stroke: black;
+}
+#basic-analysis .xaxis-container .background,
+#basic-analysis rect.static-info-box,
+#basic-analysis rect.static-label-box {
+    fill: #2c2c2c;
+}
+.base-chart rect.simple-bar.segmentbar {
+    opacity: 1;
+}
+.base-chart rect.simple-bar {
+    fill: #444444;
+    stroke: #252627;
+}
+.current-week-label {
+    fill: black;
+}
+.sum.no-rest {
+    fill: black;
+}
+.options img {
+    filter: invert(40%);
+}
+#infoBox text {
+    color: black;
+}
+.weekly-goal svg .sport-type {
+    opacity: 0.5 !important;
+}
+svg {
+    fill: currentColor;
+}
+[class*="sauce"]:not(.sauce-invoke) {
+    background: transparent !important;
+}
+[class*="sauce"] input,
+.sauce-header {
+    color: inherit !important;
+}
+rect.static-label-box,
+.xaxis-container text {
+    fill: inherit !important;
+}
+[class*="sauce"] tr:hover {
+    background: inherit !important;
+}
+#sauce-kudo-all button {
+    background-color: ${rgba(199, 198, 199, 0.5)};
+}
+div[style='background-image: url("https://web-assets.strava.com/assets/react-18/precheckout/9470c6d4fbd5d9f1f0a1.png");'] {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.5)} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.app-icon.icon-fb
+.app-icon.icon-rowing
+.follow-action .selection.gear::after
+.leaflet-control-attribution::after
+.leaflet-control-zoom-in
+.mapboxgl-ctrl button.mapboxgl-ctrl-zoom-in .mapboxgl-ctrl-icon
+.leaflet-control-zoom-out
+.mapboxgl-ctrl button.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon
+.leaflet-popup-close-button
+.leaflet-control-layers-toggle
+.leaflet-container.dark .map-tooltip .close
+.map-tooltip .close
+.mapbox-icon
+.mapboxgl-ctrl button.mapboxgl-ctrl-geolocate .mapboxgl-ctrl-icon
+.MapViewControls--zoomIn--jYuDy
+.MapViewControls--zoomOut--EDC7q
+.MapViewControls_zoomIn__mGcSR
+.MapViewControls_zoomOut__QMFIG
+.mapboxgl-ctrl-attrib-button
+.app-icon.icon-search
+.app-icon.icon-caret-down
+
+================================
+
+streamable.com
+
+INVERT
+img[alt="Streamable Logo"]
+.logo
+.customer-logos-v2
+
+================================
+
+stripe.com
+
+CSS
+.HomepageHeroHeader__title--overlay {
+    text-shadow: ${rgb(225, 212, 201)} 1px 1px 0px !important;
+}
+
+================================
+
+student.ladok.se
+
+CSS
+#sidomeny .middle {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+studeo.fi
+
+INVERT
+.equation
+
+================================
+
+studio.mittwald.de
+
+CSS
+#root .gREkYX {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+studio.youtube.com
+
+INVERT
+paper-radio-button
+.ytcp-home-button
+
+================================
+
+studip.uni-hannover.de
+
+CSS
+#content-wrapper {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+studip.uni-passau.de
+
+CSS
+#layout_container > div {
+    background-image: none;
+}
+
+================================
+
+studyflix.de
+
+INVERT
+img[title='Rendered by QuickLaTeX.com']
+
+================================
+
+subdivx.com
+
+INVERT
+#cabecera img
+#contenedor_foro .cita img
+#contenedor_foro .datos img[src*="/img/"]
+#perfil_izq img[src*="img/"]
+
+CSS
+BODY * {
+    color: ${#333};
+}
+A {
+    color: ${#0366d6} !important;
+}
+input[type="text"],
+input[type="password"],
+input[type="button"],
+input[type="submit"] {
+    background: ${#bbb};
+    border: 1px solid #999;
+}
+input[type="submit"]:hover {
+    background: ${#999};
+    border: 1px solid #999;
+}
+mark {
+    background: ${#f00} !important;
+    color: ${#fff} !important;
+}
+#barra a,
+#menu_largo a,
+#menu_largo_chat a,
+#foro_tema_menu a,
+#ultimos_foros_renglon .link_foro_tema,
+.titulo_menu_izq {
+    color: #ddd !important;
+}
+#wrapper {
+    background-image: none !important;
+}
+#contenedor_gral {
+    background: ${#e0e0e0} !important;
+    box-shadow: rgba(0, 0, 0, 0.7) 0px 0px 8px;
+    display: table;
+    height: -webkit-fill-available !important;
+    width: fit-content !important;
+}
+#cabecera {
+    background: ${#e4e4e4};
+}
+#barra,
+#menu_top,
+#menu_detalle_buscador,
+#menu_detalle,
+#menu_largo,
+#menu_largo_chat,
+#prog_menu_detalle,
+#primer_msg_voto,
+#reg_menu_detalle,
+#drdivx_menu_detalle,
+#contenedor_foro .fecha,
+#perfil_menu,
+#foro_tema_menu {
+    background: ${rgb(153,173,206)} !important;
+    background: linear-gradient(to bottom, ${rgb(153,173,206)} 0%, ${rgb(75,110,171)} 100%) !important;
+}
+#foro_home,
+#foro_home_renglon,
+#cuadrados_izq,
+#cuadrados_izq_reng,
+#chat_reng,
+#contenedor_foro,
+#contenedor_foro .datos,
+#contenedor_foro .cita,
+#contenedor_foro .mensaje {
+    background: ${#fff} !important;
+}
+#foro_home_datos,
+#cuadrados_izq {
+    color: ${#999} !important;
+}
+#foro_home_datos a {
+    color: ${#669} !important;
+}
+
+================================
+
+subiektywnieofinansach.pl
+
+INVERT
+.logo
+
+================================
+
+submarinecablemap.com
+
+INVERT
+#map
+
+================================
+
+subscene.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+suckless.org
+
+INVERT
+[src="dwm.svg"]
+[src="st.svg"]
+[src="core.svg"]
+[src="surf.svg"]
+[src="blind.svg"]
+[src="farbfeld.svg"]
+[src="quark.svg"]
+[src="sent-bullets-s.png"]
+[src="slstatus.svg"]
+
+================================
+
+sugaroutfitters.com
+
+CSS
+.clearfix {
+    display: none !important;
+}
+
+================================
+
+suggestions.momentumdash.help
+
+CSS
+#__next > div {
+    --color-bg-body: var(--darkreader-neutral-background) !important;
+    --color-bg-default: var(--darkreader-neutral-background) !important;
+    --color-bg-emphasize: ${#ccc} !important;
+}
+
+================================
+
+suite.smarttech-prod.com
+
+INVERT
+.smart-wbp-canvas-layer
+
+================================
+
+suno.com.br
+
+INVERT
+#logoSuno > a > svg
+
+================================
+
+super-productivity.com
+
+CSS
+.hero-title {
+    color: var(--darkreader-neutral-background) !important;
+}
+html[data-darkreader-scheme="dark"] .intro-gradient-wrapper .logo {
+    filter: invert(90%) !important;
+}
+
+================================
+
+superbuy.com
+
+INVERT
+.header-logo
+.logo img
+
+================================
+
+supercoach.com.au
+
+IGNORE INLINE STYLE
+svg *
+
+================================
+
+support.arkadium.com
+
+INVERT
+img[alt="Logo"]
+
+================================
+
+support.discord.com
+
+INVERT
+.logo img
+ol.breadcrumbs li:first-child::before
+
+================================
+
+support.eset.com
+
+INVERT
+i.table-icon.product
+
+================================
+
+support.heymman.com
+
+INVERT
+img[src*="logo.png"]
+
+================================
+
+support.microsoft.com
+
+CSS
+ump-modals {
+    z-index: -1 !important;
+}
+
+================================
+
+support.mozilla.org
+
+INVERT
+.card--topic .card--icon
+img.card--icon-sm
+div.sumo-nav--logo
+.pencil
+.thumbsup
+
+================================
+
+support.signal.org
+
+INVERT
+.logo img
+
+================================
+
+support.simplywall.st
+
+INVERT
+.logo img
+button.lines-button
+
+CSS
+.getting-started img {
+    background: white !important;
+}
+
+IGNORE INLINE STYLE
+.replaced-svg path
+
+================================
+
+support.tiktok.com
+
+INVERT
+span.hamburger-menu
+img.logo-icon:not(footer img)
+img.logo-text:not(footer img)
+img.caret
+img[alt="search icon"]
+
+================================
+
+surfboard.com
+
+INVERT
+.site-logo
+
+================================
+
+survey.ipma.pt
+
+INVERT
+.site-surveylist-logo
+
+================================
+
+survey.stackoverflow.co
+
+INVERT
+section header h1::after
+section header h2::after
+
+IGNORE INLINE STYLE
+div[role="tabpanel"] *
+
+================================
+
+surveymonkey.com
+
+CSS
+.is-high-contrast .radio-button-display,
+.is-high-contrast .checkbox-button-display {
+    opacity: 1 !important;
+}
+.modern-browser .radio-button-display::after,
+.modern-browser .checkbox-button-display::after {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+sverigesradio.se
+
+INVERT
+#sprite-check
+#sprite-facebook
+#sprite-instagram
+#sprite-reddit
+#sprite-twitter
+#sprite-whatsapp
+.circle
+.cross
+.default
+.episode-list-item__controls svg
+.external-link-with-icon__icon
+.gallery-button .icon
+.gallery-button svg g
+.info-teaser-container__title h2
+.link-icon .icon
+.local-weather-item__wind-icon
+.logo
+.menu-icon.icon
+.play-icon__pause-symbol
+.play-icon__play-symbol
+.progress.queue-progress .bar
+.sr-link__svg svg
+.sr-logo-wrapper
+.sound-bars .bar
+.support-info__icon svg
+[data-require="modules/custom-click-tracking"] svg
+[data-require="modules/listen-later"] svg
+[data-require="modules/share-button"] svg
+button.reset
+input[type="range"]::-moz-range-thumb
+input[type="range"]::-moz-range-track
+input[type="range"]::-webkit-slider-runnable-track
+input[type="range"]::-webkit-slider-thumb
+
+CSS
+.weather-icon {
+    filter: invert(1) hue-rotate(180deg) !important;
+}
+.live-marker .dot,
+.live-label::before,
+.active::before {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.search-page em,
+.search-result em,
+.info-teaser-container__title {
+    color: var(--darkreader-neutral-background) !important;
+}
+#sprite-home path,
+#sprite-news path,
+#sprite-podcast path,
+#sprite-direct path,
+#sprite-profile path {
+    fill: var(--darkreader-neutral-text);
+}
+
+================================
+
+svgrepo.com
+
+INVERT
+div[class^="style_socialLinks"] img
+.stylesArray img:not([alt^="Multicolor"]):not([alt^="Flat"]):not([alt^="Bordered"]):not([alt^="Tritone"]):not([alt^="Emoji"]):not([alt^="Logo"]):not([alt^="Gradient"]):not([alt^="Isometric"]):not([alt^="Sticker"]):not([alt^="3D"])
+
+CSS
+div[class^="style_NodeImage_"] img,
+div[class^="style_CollectionVector_"] img {
+    background-color: #fff !important;
+}
+div,
+h1,
+h2,
+p,
+span {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+svt.se
+
+INVERT
+header img[src*=svt]
+.nyh_navigation__menu-toggle
+[class^="VideoPlayerTheme__play-pause-button-simple"]::before
+[class^="_play-pause-button-simple"]::before
+
+CSS
+.nyh_breaking__top-prefix,
+.nyh_teaser__live-text {
+    color: var(--darkreader-neutral-background) !important;
+}
+button[class^="PaginationButton"],
+a[class^="PaginationButton"],
+.nyh_screamer,
+[class^="_RightNowTeaser__title"],
+[class^="_RightNowTeaser__root"] {
+    background: var(--darkreader-bg--nyh-color-white) !important;
+    border-left-color: var(--darkreader-bg--nyh-color-news);
+}
+button[class^="PaginationButton"]:hover,
+a[class^="PaginationButton"]:hover {
+    background: var(--darkreader-border--color-play-white) !important;
+}
+.flexbox .nyh_teaser.nyh_teaser--group-secondary {
+    border-right: none !important;
+}
+[class*="GroupSecondaryTeasers__container___"],
+.nyh_feedbox-item+.nyh_feedbox-item,
+.nyh_teaser.nyh_teaser--no-border-top {
+    border-top: none !important;
+}
+.nyh_navigation .nyh_submenu::before {
+    border-bottom-color: var(--darkreader-bg--nyh-color-white) !important;
+}
+.nyh_teaser.nyh_teaser--story-grid,
+.nyh_icons_caret--factbox {
+    border: none;
+}
+.nyh_submenu-menucard,
+[class*="_Post__contentVisitor___"]::after {
+    border-right-color: var(--darkreader-bg--nyh-color-grey-lighter) !important;
+}
+[class*="CurrentTopics__item___"],
+[class*="GroupSecondaryTeasers__showMoreButton___"],
+.nyh_mobile-menu__list-item,
+.nyh_menu-card__submenu-item,
+.nyh_submenu-menucard,
+.nyh_submenu {
+    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
+}
+.nyh_fact-box {
+    border-bottom: 1px solid var(--darkreader-border--nyh-color-grey-lighter);
+    border-top: 1px solid var(--darkreader-border--nyh-color-grey-lighter);
+}
+.nyh_fact-box__body--closed::after {
+    background: linear-gradient(to bottom, #1e202180 0%, #1e2021 100%);
+}
+.nyh_regional-widget-regions {
+    background: var(--darkreader-bg--nyh-color-grey-lightest);
+}
+.nyh_submenu-menucard {
+    background-color: var(--darkreader-bg--nyh-color-white);
+}
+
+================================
+
+sw.kovidgoyal.net
+
+CSS
+.sidebar-drawer,
+.sidebar-search,
+.toc-drawer {
+    background: var(--darkreader-neutral-background) !important;
+}
+.sidebar-tree a.current,
+.sidebar-tree label:hover {
+    background: var(--darkreader-selection-background) !important;
+}
+code {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+swagger.emby.media
+
+INVERT
+svg.arrow
+svg.locked
+button.close-modal
+div.view-line-link
+.swagger-ui select
+
+CSS
+.swagger-ui select {
+    background: #f7f7f7 url("https://cdn-icons-png.flaticon.com/256/566/566015.png") right 10px center no-repeat !important;
+    background-size: 10px !important;
+    color: #3b4151 !important;
+}
+.swagger-ui .topbar {
+    background: ${#fff} !important;
+}
+
+================================
+
+sweetwater.com
+
+CSS
+.popcat-image img,
+.shop-nav nav .shop-nav__image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+swiatrolnika.info
+
+INVERT
+img[alt*="logo"]
+img[src*="/images/images2/icons/"]
+
+================================
+
+syncplay.pl
+
+CSS
+#access-wrapper {
+    background-image: none !important;
+}
+
+================================
+
+synthetic.new
+
+INVERT
+canvas.absolute
+
+================================
+
+system76.com
+
+INVERT
+svg[class^="sys-logo"]
+
+================================
+
+systemd.io
+
+INVERT
+.page-logo img
+
+================================
+
+t-mobile.pl
+
+INVERT
+img[src*="quick-redirects"]
+.text-base-black ::before
+
+CSS
+.preview-image,
+.inner-container,
+.bg-base-secondary-10 {
+    background-image: none !important;
+}
+
+================================
+
+t.bilibili.com
+
+CSS
+.bg,
+.bgc {
+    background: var(--darkreader-neutral-background) !important;
+}
+#limit-mask-wall::after,
+#limit-mask-wall::before {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, var(--darkreader-bg--bg1) 100%) !important;
+}
+:root {
+    --bg1: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--_container-color: transparent !important;
+    --darkreader-text--_label-text-color: var(--darkreader-text--text3) !important;
+    --graph_bg_thick: var(--darkreader-border--graph_bg_thick) !important;
+}
+
+================================
+
+t.me
+telegram.me
+
+INVERT
+.tgme_logo
+
+================================
+
+tableau.com
+
+INVERT
+.feature-list__icon
+.mobile-nav-button__icon
+.site-logo
+
+CSS
+section {
+    background-image: none !important;
+}
+
+================================
+
+tablesgenerator.com
+
+INVERT
+.icon-all-borders.toolbar-icon
+.icon-no-borders.toolbar-icon
+.icon-edit-borders.toolbar-icon
+.icon-merge-cells.toolbar-icon
+.icon-split-cells.toolbar-icon
+.icon-no-colors.toolbar-icon
+
+IGNORE INLINE STYLE
+.sp-thumb-inner
+.sp-preview-inner
+
+================================
+
+tabletochki.org
+
+INVERT
+.perekaz__list img
+
+================================
+
+tabs.ultimate-guitar.com
+
+INVERT
+.ddUoc
+.JZg5a
+
+================================
+
+tails.net
+
+INVERT
+.blocks .block img
+.laptop
+
+CSS
+body {
+    background-image: none !important;
+}
+#donate-banner p {
+    color: var(--darkreader-neutral-background) !important;
+}
+#donate-banner u {
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#donate-banner
+
+================================
+
+tailscale.com/kb/
+
+CSS
+main aside .sticky > .absolute.from-white {
+    --tw-gradient-from: var(--darkreader-neutral-background) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(from var(--darkreader-neutral-background) r g b / 0) var(--tw-gradient-from-position) !important;
+}
+
+================================
+
+tailwindcss.com
+
+CSS
+.bg-white:not(#docsearch),
+.bg-gray-100 {
+    --bg-opacity: none !important;
+}
+.text-gray-900,
+.hover\:text-gray-900:hover,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    --text-opacity: none !important;
+}
+.bg-center {
+    background: none !important;
+}
+
+================================
+
+tailwindui.com
+
+CSS
+html > body > div > div > img {
+    opacity: 0 !important;
+}
+
+================================
+
+take-a-screenshot.org
+
+INVERT
+.switch-window span::before
+
+================================
+
+talishar.net
+
+CSS
+._ourTurn_199aw_35 {
+    background-image: url("https://talishar.net/assets/turnWidget-Normal-89240b8d.png") !important;
+}
+._pitchBackground_1574e_15 {
+    background-image: url("https://talishar.net/assets/symbol-resource-bca42b67.png") !important;
+}
+
+================================
+
+tandfonline.com
+
+INVERT
+img.no-mml-formula
+
+================================
+
+tanstack.com
+
+CSS
+.bg-gradient-to-r {
+    background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
+}
+
+================================
+
+taobao.com
+
+INVERT
+#J_SearchIcon
+.J_MyShopCoupon
+.J_BtnEditSKU
+.cart-checkbox
+
+CSS
+.tbh-member.J_Module {
+    background-image: none !important;
+}
+#q.search-combobox-input {
+    background-color: var(--darkreader-neutral-background);
+}
+.qrcode-img {
+    background-color: white !important;
+}
+
+================================
+
+tapology.com
+
+INVERT
+.logo
+ul.feedCats
+
+CSS
+ul.feedCats li a:link,
+ul.feedCats li a:visited {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tarnogorski.info
+
+INVERT
+.td-main-logo
+
+================================
+
+tasks.google.com
+
+INVERT
+div[role="listitem"] > div > div > div[role="presentation"]
+
+================================
+
+tass.ru
+
+INVERT
+div[class^="LogoImage_logo"] > svg > path
+button[class^="Footer_icon_app_store"] > svg > g > path:last-of-type
+
+CSS
+div[class^="ds_ext_carousel"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tastoid.com
+
+CSS
+.jumbotron.jumbotron-no-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tc39.es
+
+CSS
+var {
+    color: ${#218379} !important;
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+tcrf.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+teamtrees.org
+
+CSS
+.hypeTemplate_tano {
+    background-color: ${white} !important;
+}
+
+================================
+
+teamviewer.com
+
+INVERT
+img[alt="TeamViewer"]
+
+CSS
+.cmp-container--fullwidth {
+    background-image: none !important;
+}
+
+================================
+
+techmaniak.pl
+activemaniak.pl
+agdmaniak.pl
+appmaniak.pl
+blogomaniak.pl
+fotomaniak.pl
+gizmaniak.pl
+gsmmaniak.pl
+luxmaniak.pl
+mobimaniak.pl
+rtvmaniak.pl
+tabletmaniak.pl
+
+CSS
+body,
+#headerNavBlogomaniak,
+#header,
+#top,
+#bottom,
+#footer,
+#footer_menu,
+.wrapper,
+#search input.search {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+technologyreview.com
+
+INVERT
+a[class^="headerTemplate__logo"]
+
+================================
+
+techpowerup.com
+
+CSS
+html[data-darkreader-scheme="dark"] img.icon,
+html[data-darkreader-scheme="dark"] img.newsicon {
+    background-color: white !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.tradeshow-hero-link
+
+================================
+
+techspot.com
+
+INVERT
+svg#techspot-logo
+
+================================
+
+telegeography.com
+
+INVERT
+.map-tile-loaded
+div#globe-start > canvas
+div#globe-end > canvas
+div.leaflet-map-pane
+img.map-banner
+div.mapboxgl-map
+span.hamburger-box
+a > img[src^="https://www2.telegeography.com/hubfs/"]
+img[alt="TeleGeography"]
+
+================================
+
+telegram.org
+
+CSS
+.tl_main_download_image__android {
+    background: url(../img/SiteAndroid.jpg?2) 50% 0 no-repeat;
+}
+.tl_main_download_image__ios {
+    background: url(../img/SiteiOS.jpg?2) 50% 0 no-repeat;
+}
+.tl_main_download_desktop {
+    background: url(../img/SiteDesktop.jpg?2) 50% 19px no-repeat;
+}
+html[data-darkreader-scheme="dark"] .tl_main_download_desktop,
+html[data-darkreader-scheme="dark"] .tl_main_download_image__android,
+html[data-darkreader-scheme="dark"] .tl_main_download_image__ios {
+    filter: invert(90%) hue-rotate(180deg);
+}
+html[data-darkreader-scheme="dimmed"] .tl_main_download_desktop,
+html[data-darkreader-scheme="dimmed"] .tl_main_download_image__android,
+html[data-darkreader-scheme="dimmed"] .tl_main_download_image__ios {
+    filter: invert(14%);
+}
+html[data-darkreader-scheme="dark"] .tl_main_download_desktop a {
+    color: ${#3dbeff} !important;
+}
+
+================================
+
+teleman.pl
+
+INVERT
+.movieRank
+
+================================
+
+telerik.com
+
+INVERT
+a.TK-Aside-Menu-Link
+a.TK-Aside-Menu-Button
+#ContentPlaceholder1_C377_Col00 > img
+
+CSS
+a.TK-TLRK-Logo svg path[fill="#7c878e"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+a.TK-TLRK-Logo svg path[fill="#4b4e52"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+a.TK-PRGS-Logo-Footer svg path[fill="#4b4e52"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+#ContentPlaceholder1_C418_Col00 > footer {
+    background-image: none !important;
+}
+
+================================
+
+teltarif.de
+
+CSS
+body,
+.ttColBack,
+#tthdrbox {
+    background: var(--darkreader-neutral-background);
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+temu.com
+
+CSS
+._2Fkk_bmp {
+    background-color: transparent !important;
+}
+
+================================
+
+tenforums.com
+
+CSS
+.garhead {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+    border-left-color: var(--darkreader-neutral-background) !important;
+    border-right-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tenor.com
+
+INVERT
+.FlagIcon
+.ShareIcon
+
+================================
+
+terazwy.pl
+
+INVERT
+img[src*="img/loga"]
+img[src*="img/logotr.png"]
+
+================================
+
+terraform.io
+
+IGNORE INLINE STYLE
+.text
+
+================================
+
+terraria.wiki.gg
+
+CSS
+#mw-head {
+    background: var(--theme-navbar-background);
+}
+#mw-panel .portal h3::after {
+    border-color: var(--theme-sidebar-heading-arrow-color) transparent;
+}
+#mw-panel .portal h3:hover::after {
+    border-color: var(--theme-sidebar-heading-arrow-color-hover) transparent;
+}
+#simpleSearch::before,
+#simpleSearch::after {
+    border-color: var(--theme-navbar-search-botton-text-color);
+}
+#simpleSearch:hover::before,
+#simpleSearch:hover::after {
+    border-color: var(--theme-navbar-search-botton-text-color-active);
+}
+
+================================
+
+tesco.com
+
+CSS
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h1,
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h2,
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h3,
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h4,
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h5,
+.ui-components-library .nav-dropdown .dropdown a.nav-toggle h6 {
+    z-index: 0 !important;
+}
+.ddsweb-checkbox__visible svg path {
+    fill: var(--darkreader-neutral-background);
+}
+
+IGNORE INLINE STYLE
+.ddsweb-checkbox__visible svg path
+
+================================
+
+tesla.com
+
+INVERT
+.tds-modal-close-icon
+.tds-menu-header-legacy [id*="tds-menu-header-main--trigger"]:checked ~ [for*="tds-menu-header-main--trigger"] .tds-menu-header-main--cross_hatch
+
+CSS
+.tcl-hero-parallax__heading,
+.tcl-hero-parallax__subheading a,
+.tcl-hero-parallax__additional-link {
+    color: ${gray} !important;
+}
+#block-mainheadernavigation .tds-menu-header-nav--list_link {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+teslarati.com
+
+INVERT
+div.mvp-fly-but-wrap
+div.mvp-search-but-wrap
+
+================================
+
+testudo.umd.edu
+
+CSS
+#secondary-side,
+#widgetbox_widget_parent_0 {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+thalia.de
+
+CSS
+font[color="#000000"] {
+    color: ${#000000} !important;
+}
+.tm-artikelbild-wrapper {
+    z-index: 0 !important;
+}
+
+================================
+
+the-conjugation.com
+
+CSS
+#gauche {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+the-race.com
+
+INVERT
+.img-fluid
+
+================================
+
+the-scientist.com
+
+INVERT
+img[alt="The Scientist Logo"]
+img[alt="TS News Alerts Logo"]
+.object-contain
+section#NewslettersSection.newsletters img.logo
+
+CSS
+div.header-title-content img.aspect-square,
+div.relative.w-full img.aspect-square {
+    background-color: white !important;
+}
+
+================================
+
+the5to9.xyz
+
+CSS
+:root {
+    --wt-text-on-background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+theatlantic.com
+
+INVERT
+[class^="NavHamburgerButton_root"]
+[class^="NudgeShared_chevron"]
+[class^="NonMeteredNudge_desktopTextContainer"]::after
+
+================================
+
+theatlas.com
+
+CSS
+.d4 .axis .tick text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.d4 .axis .tick rect {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+thecamels.org
+
+INVERT
+.block-tags
+.block-client-group-list
+.slider-content-list-item-opinion-logo
+.slider-testimonials-list-item
+
+CSS
+.slider-testimonials-content {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+thecanadianencyclopedia.ca
+
+INVERT
+.edit
+.citation
+.share
+.print
+.dot-1.dot
+.dot-2.dot
+.dot-3.dot
+.accordion-toggler.dropdown-toggler.nav-submenu-toggler
+
+================================
+
+thecode.media
+
+INVERT
+img[src$="/logo.svg"]
+.post-item__arrow
+li::before
+
+================================
+
+thecollegefix.com
+
+INVERT
+img[alt="Student Free Press Association"]
+
+================================
+
+thedailybeast.com
+
+INVERT
+.Logo
+.NavSubDesktop__hamburger-bars
+
+================================
+
+thedispatch.com
+
+INVERT
+li::before
+
+================================
+
+thefreedictionary.com
+
+INVERT
+strong.i.logo
+a.i.keyboard-link.mobile-hidden
+#regButton::before
+ul.social-networks
+a.i.icon-notif
+div.box > a.i
+div.cprh > span.i.A.cpr
+a.i.popup-opener
+ul.logos-list
+
+================================
+
+thefreelibrary.com
+
+INVERT
+div#logo
+
+CSS
+div.main_content {
+    background-image: none !important;
+}
+
+================================
+
+theguardian.com
+interactive.guim.co.uk
+
+INVERT
+a[data-sponsor="guardian.org"]
+a[data-sponsor="open society foundations"]
+div[aria-label="Slide controls"] > div > div
+div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > button > svg
+div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > svg
+div[data-link-name="Crosswords"] input
+div[data-link-name="Crosswords"] text
+html > body > div > div > .artboard-light-mode > img
+section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
+section[data-component="headlines"] .dcr-d4xwbm > svg
+section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]
+section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand texture"]
+
+CSS
+div[data-component="footer"] .dcr-1fespkx,
+gu-island[name="SlotBodyEnd"] div[data-testid="epic=buttons"] > div > a,
+gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] p > strong > span,
+gu-island[name="SlotBodyEnd"] fieldset#P0-0 > div > div > div > div {
+    background: rgb(255, 229, 0) !important;
+    color: rgb(18, 18, 18) !important;
+}
+div[data-component="footer"] .dcr-jgzukx {
+    color: rgb(255, 229, 0) !important;
+}
+div[data-component="youtube-atom"] .dcr-1n5sax3 {
+    background: linear-gradient( 180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 25% ) !important;
+}
+div[data-component="youtube-atom"] .play-icon {
+    background-color: rgba(18, 18, 18, 0.6) !important;
+}
+div[data-link-name="most popular"] .dcr-9rsbaa {
+    background-color: var(--age-warning-background) !important;
+    color: var(--age-warning-text) !important;
+}
+div[role="progressbar"] > span {
+    background-color: var(--video-progress-bar-value) !important;
+}
+gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] div > section {
+    border-top-color: rgb(255, 229, 0) !important;
+}
+gu-island[name="SlotBodyEnd"] label > div > input[type="radio"]:checked,
+gu-island[name="SlotBodyEnd"] label > div:hover > input[type="radio"] {
+    border: 2px solid rgb(255, 229, 0) !important;
+}
+gu-island[name="StickyBottomBanner"] div > div > div > div > div.dcr-1xq78ib {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+gu-island[name="StickyBottomBanner"] div > svg {
+    --darkreader-inline-fill: var(--darkreader-neutral-text) !important;
+}
+gu-island[name="StickyBottomBanner"] div.dcr-bxrjkt > div {
+    background-color: ${rgb(5, 41, 98)} !important;
+}
+gu-island[name="TopBar"] span > a {
+    background: rgb(255, 229, 0) !important;
+    color: rgb(5, 41, 98) !important;
+}
+header[data-component="header"] a[data-link-name="header : logo"] svg {
+    fill: var(--darkreader-text--masthead-nav-link-text) !important;
+}
+header[data-component="header"] .dcr-b3mn8w {
+    background-color: var(--masthead-veggie-burger-background) !important;
+}
+main div.dcr-e1ey7b {
+    background-color: var(--pill-background) !important;
+    color: var(--pill-text) !important;
+}
+main div.dcr-hxw8zi {
+    background-color: var(--star-rating-background) !important;
+}
+section[data-component="documentaries"] p {
+    border-top: 1px solid #ffffff50 !important;
+}
+section[data-component="contact-the-guardian"] a {
+    color: #121212 !important;
+}
+section[data-component="contact-the-guardian"] .btn {
+    background-color: #fff !important;
+}
+section[data-component="contact-the-guardian"] .securedrop {
+    background-color: #ffe500 !important;
+}
+section[data-component="contact-the-guardian"] .securedrop__main > .eyes > .eye > .outside > svg > path {
+    stroke: rgba(230,207,0,.5) !important;
+}
+section[data-component="headlines"] .dcr-d4xwbm {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+section[data-component="headlines"] path[fill="#ddd"] {
+    fill: #BDBDBD !important;
+}
+section[data-component="olympic-medal-table"] circle[r="6.6"],
+section[data-component="paralympic-medal-table"] circle[r="6.6"] {
+    fill: var(--darkreader-bg--section-background) !important;
+}
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"],
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"] {
+    background-color: var(--carousel-arrow-background) !important;
+}
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"]:hover,
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"]:hover {
+    background-color: var(--carousel-arrow-background-hover) !important;
+}
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"] svg,
+section[data-component="video"] .dcr-1bvoox2[data-link-name="video-container-prev"] svg,
+section[data-component="video"] .dcr-1nrzsks[data-link-name="video-container-next"] svg,
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"] svg {
+    fill: var(--carousel-arrow) !important;
+}
+section[data-component="video"] .dcr-1tzmmc7::before {
+    border-top: 1px solid var(--card-border-top) !important;
+}
+section[data-component="video"] .dcr-6r6u10[data-link-name^="carousel-small-nav-dot-"] {
+    background-color: var(--carousel-dot) !important;
+}
+section[data-component="video"] .dcr-zxdpfk[data-link-name^="carousel-small-nav-dot-"] {
+    background-color: var(--carousel-active-dot) !important;
+}
+svg[stroke="var(--article-border)"],
+svg[stroke="var(--straight-lines)"] {
+    stroke: var(--darkreader-border--article-border) !important;
+}
+
+IGNORE INLINE STYLE
+div[data-component="youtube-atom"] .play-icon path[fill="#FFFFFF"]
+header[data-component="header"] .dcr-b3mn8w svg path
+nav[data-component="nav2"] a[data-link-name="nav3 : logo"] svg path
+section[data-component="contact-the-guardian"] *
+section[data-component="documentaries"] path[fill="#121212"]
+section[data-component="headlines"] path
+
+================================
+
+theinformation.com
+
+INVERT
+.logo
+
+IGNORE IMAGE ANALYSIS
+header.locked .logo
+
+================================
+
+theins.ru
+
+INVERT
+header > div > a > svg
+
+================================
+
+thejakartapost.com
+
+INVERT
+.logo-jakartapost
+
+================================
+
+thelancet.com
+
+INVERT
+.journal-logos
+.footer__logo
+
+================================
+
+themis.dk
+
+CSS
+.content {
+    background-image: none !important;
+}
+.box {
+    background-image: none !important;
+}
+
+================================
+
+themoscowtimes.com
+moscowtimes.ru
+
+INVERT
+.site-header__logo
+.footer__logo
+.contribute-teaser__button
+
+================================
+
+themoviedb.org
+
+INVERT
+.glyphicons_v2.link
+.glyphicons_v2.facebook
+.glyphicons_v2.twitter
+.glyphicons_v2.instagram
+.glyphicons_v2.keyboard
+.glyphicons_v2.speech-bubble-alert
+.glyphicons_v2.arrow-thin-right
+.glyphicons_v2.arrow-thin-left
+
+CSS
+.card {
+    background-color: ${#dfe1e2} !important;
+}
+
+================================
+
+thenation.com
+
+IGNORE INLINE STYLE
+.hamburger-icon > svg > line
+
+================================
+
+thenounproject.com
+
+INVERT
+div[class^="styles__Image"]
+a[class^="styles__HeaderLogoLink"]
+
+================================
+
+theoatmeal.com
+
+INVERT
+img.d-inline-block.align-bottom
+
+================================
+
+theonion.com
+
+INVERT
+a[href="//www.theonion.com"] .theonion
+
+================================
+
+thepaper.cn
+
+INVERT
+.head_logo
+
+================================
+
+thepiratebay.org
+
+INVERT
+img[src="https://torrindex.net/images/tpb.jpg"]
+img[src="https://torrindex.net/images/tpbsmall_notext.jpg"]
+
+================================
+
+theportugalpost.com
+
+INVERT
+img[src$="/logo.svg"]
+
+================================
+
+thereader.mitpress.mit.edu
+
+INVERT
+#logo
+
+================================
+
+theregister.*
+theregister.*.*
+
+INVERT
+.row_label.title_rhs_line
+.blocksandfiles_logo
+.devclass_logo
+#sitpub_logo
+
+================================
+
+thetrainline.com
+
+CSS
+.ot-sdk-row,
+.ot-sdk-twelve,
+.ot-sdk-columns {
+    background-color: ${#CDD5E2} !important;
+}
+
+================================
+
+thetruesize.com
+
+INVERT
+map-compass
+map-compass :is(circle, g, text)
+
+================================
+
+theverge.com
+
+INVERT
+.c-global-header__logo
+.c-tab-bar__logo
+.c-footer__logo-link
+
+CSS
+.duet--article--article-body-component p a {
+    box-shadow: inset 0 -1px 0 0 ${#131313} !important;
+}
+.duet--article--article-body-component p a:hover {
+    box-shadow: inset 0 -0.5em 0 0 ${#3cffd0} !important;
+}
+
+================================
+
+thewindowsclub.com
+
+INVERT
+.custom-logo
+
+================================
+
+thisoldhouse.com
+
+INVERT
+.c-masthead__main[style^="background-image"]
+
+IGNORE INLINE STYLE
+.c-footer__logo-link *
+
+================================
+
+thivien.net
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+thomannmusic.com
+thomann.*
+
+INVERT
+.fx-list__item--circle
+.fx-list__item--circle span
+
+CSS
+.country-item__flag,
+.fx-mix-blend-mode--multiply,
+.mix-blend-darken,
+.navigator__item,
+.navigator__item-image,
+.product__image {
+    mix-blend-mode: unset !important;
+}
+
+================================
+
+thompsonstein.com
+
+INVERT
+a.logo
+
+================================
+
+thriftbooks.com
+
+INVERT
+.DesktopHeader-logo
+
+================================
+
+thronemaster.net
+
+INVERT
+.head-info-wild
+
+================================
+
+thunderbird.net
+
+INVERT
+.w-48
+div.devices-container > .graphic > picture > *
+.page-index .floating-icons
+.page-index .planets
+
+CSS
+div.mask svg path {
+    fill: var(--darkreader-neutral-background) !important;
+}
+div.page-separator-cover {
+    color: black !important;
+}
+.page-index #masthead,
+.page-index header {
+    background-image: var(--bg-hero-set), var(--bg-hero-gradient) !important;
+}
+.page-index .floating-icons,
+.page-index .planets {
+    z-index: 0 !important;
+}
+
+IGNORE INLINE STYLE
+a.mozilla-logo *
+
+================================
+
+ti.com
+
+INVERT
+.ti_p-responsiveHeader-top-logo
+
+================================
+
+tianocore.org
+
+INVERT
+.tcLogoArea
+
+================================
+
+tidal.com
+
+INVERT
+svg.rising-logo.color-white path
+img[class^="tidal-image block position-absolute"]:not([alt="LG TV logo"], [alt="Multimedia logo"], [alt="Play Poland logo"], [alt="Tesla logo"], [alt="Waze logo"])
+img[alt="Amazon alexa logo"]
+img[alt="TIDAL | McIntosh"]
+img[alt="TIDAL | Venues logo"]
+img[alt="TIDAL | Volkswagen"]
+img.icon-image
+div.text-left > img.logo
+
+IGNORE INLINE STYLE
+svg.tidal-header-logo--image
+
+================================
+
+tieba.baidu.com
+
+INVERT
+.add-more-forum
+.all-wraper
+.core_title_btns
+.day_rcmd > .class_title
+.fengchao-wrap-box span
+.focus_btn
+img[src*="sign_err.png"]
+.save_face_bg
+.search_bright .nav_wrap_add_border
+.share_btn_wrapper
+.sub_nav_wrap
+.threadlist_rep_num
+.u-f-item
+
+CSS
+.card_banner {
+    filter: brightness(50%);
+}
+.class_title,
+.content-sec,
+.f-d-item,
+.left-sec,
+.page-container,
+.pb_footer,
+.sub_nav_wrap,
+.tb_footer {
+    background-image: none !important;
+}
+.u-f-item {
+    color: var(--darkreader-neutral-background) !important;
+}
+.tang-pass-qrcode-imgWrapper {
+    background-color: white !important;
+}
+
+================================
+
+tiktok.com
+
+INVERT
+.like-container .icon
+div[class*="DivSeekBarContainer"]
+div[class*="DivVolumeControlCircle"]
+div[class*="DivVolumeControlBar"]
+div[class*="DivVolumeControlProgress"]
+.video-control-container-browser
+.volume-control-container-browser
+.seek-bar-container
+.volume-control-container
+svg[class*="StyledLinkLogo"]
+svg[class*="SvgPlayIcon"]
+#svg-music-note > path
+img[alt="TikTok Logo"]:not(#site-footer img, #footer img)
+img[alt="TikTok Logo Icon"]
+img[alt="search icon"]
+svg[alt="TikTok"] path
+img[data-e2e="Header-index-img"]
+#app-header img
+img[class^="background-icon-_"]
+img[alt="Application logo"]
+[id^="animal-welfare-flex-item"] picture img
+[id^="well-being-guide-flex-item"] picture img
+img[data-tt="Sidebar_Sidebar_TikTokLogo"]
+img[data-tt="Sidebar_Sidebar_TikTokStudioLogo"]
+img.cursor-pointer
+span.hamburger-menu
+img.logo-icon
+img.logo-text
+img.header-logo-icon
+img.header-logo-text
+
+CSS
+[data-e2e="like-icon"] svg,
+[data-e2e="comment-icon"] svg,
+[data-e2e="share-icon"] svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+svg[alt="TikTok"] path
+
+================================
+
+til.jakelazaroff.com
+
+CSS
+.wrapper[data-astro-cid-s6tr6vzr] {
+    --sidebar-width: min(40vw, 25rem) !important;
+}
+
+================================
+
+time.com
+
+INVERT
+nav.main .menu-btn .menu-btn-box
+
+================================
+
+timeanddate.com
+
+CSS
+#header {
+    background: ${#DCD9D8};
+}
+.analog-clock__hands :not(.analog-clock__hand--seconds):not(.analog-clock__pin-inner) {
+    stroke: ${#181F2B};
+}
+
+IGNORE IMAGE ANALYSIS
+#header
+
+================================
+
+timesofmalta.com
+
+INVERT
+.na-PrimaryNavigation_Logo
+
+CSS
+html[data-darkreader-scheme="dark"] #st-1 img {
+    filter: none !important;
+}
+
+================================
+
+tinder.com
+
+CSS
+svg > path[style*="--rewind"] {
+    fill: ${black} !important;
+}
+svg > path[style*="--nope"] {
+    fill: ${red} !important;
+}
+svg > path[style*="--super-like"] {
+    fill: ${cyan} !important;
+}
+svg > path[style*="--like"] {
+    fill: ${#22ebc0} !important;
+}
+svg > path[style*="--boost"] {
+    fill: ${purple} !important;
+}
+
+================================
+
+tinkoff.ru
+
+INVERT
+a[title="Tinkoff"]
+
+================================
+
+tinte.railly.dev
+
+IGNORE INLINE STYLE
+.border-t
+svg *
+
+================================
+
+tiny.cloud
+
+CSS
+.doc,
+.doc h1,
+.doc h2,
+.doc h3,
+.doc h4,
+.doc h5,
+.doc h6,
+.nav-menu a,
+.toolbar a,
+.page-versions,
+.version-menu-toggle,
+body {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
+tiptap.dev
+*.tiptap.dev
+
+IGNORE INLINE STYLE
+#app *
+
+================================
+
+titantv.com
+
+INVERT
+img[alt="Home"]
+
+================================
+
+tizen.org
+
+INVERT
+#header #logo
+
+================================
+
+tjournal.ru
+
+INVERT
+mark
+
+CSS
+mark a {
+    color: ${#346eb8} !important;
+}
+.main.layout {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tns-e.ru
+
+INVERT
+img[title*="ТНС энерго"]
+img[src="/img/refresh.png"]
+img[src="/img/logout-black.png"]
+
+================================
+
+to-do.live.com
+
+INVERT
+span[class^="ms-Toggle-thumb"]
+
+CSS
+.backgroundLines {
+    background-image: linear-gradient(180deg, var(--darkreader-bg--bg-primary), var(--darkreader-bg--bg-primary) 52px, var(--darkreader-bg--bg-separator) 52px, var(--darkreader-bg--bg-separator) 52px) !important;
+}
+
+================================
+
+todoist.com
+
+INVERT
+.ist_button_apple > img
+#td-help-logo_svg__a ~ g:last-of-type
+
+CSS
+main > section:first-of-type > div {
+    z-index: 1 !important;
+}
+img[src^="/_next/static/images/"],
+[style*="/_next/static/images/"] {
+    filter: brightness(50%) sepia(40%) !important;
+}
+option,
+.oT9NU,
+footer {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tokfm.pl
+
+INVERT
+.controls span.play svg
+
+CSS
+div.top_section_bg,
+div.bottom_section_bg {
+    background-color: ${#e7e5e4} !important;
+}
+body.desk #content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tombihn.com
+
+INVERT
+.hamburger svg:first-of-type
+.navigation-logo
+
+================================
+
+tomsguide.com
+
+CSS
+.hawk-lazy-image-deal-widget {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+tonsky.me
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+
+================================
+
+torguard.net
+
+INVERT
+img[src$="statusok.gif"]
+img[src$="statusfailed.gif"]
+
+================================
+
+tosdr.org
+
+INVERT
+img[src*="tosdr-logo-128.svg"]
+img[src*="/img/news/"]
+img[src*="guidelines.svg"]
+
+================================
+
+totylkoteoria.pl
+
+INVERT
+.site-branding
+.header__socials
+
+CSS
+.hero {
+    background-image: none !important;
+}
+
+================================
+
+toutatice.fr
+
+INVERT
+.img-responsive
+.banner
+
+================================
+
+towardsdatascience.com
+
+CSS
+article picture > img {
+    background-color: ${black} !important;
+}
+
+================================
+
+towersemi.com
+
+INVERT
+.Logo
+
+================================
+
+towhee.io
+
+INVERT
+.logo-wrapper
+
+================================
+
+town-of-salem.fandom.com
+breezewiki.com/town-of-salem/
+bw.artemislena.eu/town-of-salem/
+
+IGNORE INLINE STYLE
+span[style^="text-shadow"]
+span[style*="background: linear-gradient"]
+a *
+
+================================
+
+townandcountrymag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel button[aria-label="Close"] svg
+div[data-tracking-id="topNavSponsor"] img
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/townandcountrymag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25239a0500" i])
+main figure:has(audio) input
+
+================================
+
+tpgi.com
+
+CSS
+.hero__module,
+.bg-overlay {
+    background-image: none !important;
+}
+
+================================
+
+trac.ffmpeg.org
+
+INVERT
+img[src$="trac_logo_mini.png"]
+img[src="/ffmpeg-logo.png"]
+
+CSS
+select option {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+tracfone.com
+
+INVERT
+.navbar-container nav .navbar-brand
+
+================================
+
+track.toggl.com
+
+CSS
+#root,
+.content-wrapper > * {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+traderepublic.com
+
+IGNORE INLINE STYLE
+.__socialLinks svg *
+
+================================
+
+trailhead.salesforce.com
+
+INVERT
+lwc-tds-header
+
+CSS
+.search-input__input {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.user-info__name {
+    color: inherit !important;
+}
+.progress-ring__content {
+    background-color: white !important;
+}
+[data-layout="desktop"] .nav-list-item__link:hover,
+[data-layout="desktop"] .nav-list-item__button[aria-expanded="true"] {
+    background: inherit !important;
+}
+
+================================
+
+training.moodys.com
+
+CSS
+body.frameless {
+    background-image: none;
+}
+
+================================
+
+transifex.com
+
+INVERT
+img.close_image
+
+================================
+
+transition2025.com
+
+CSS
+.bg-primary-700 {
+    background-color: var(--color-primary-700) !important;
+}
+.border-\[\#4B4DAC\] {
+    border-color: #4b4dac !important;
+}
+.border-primary-300 {
+    border-color: var(--color-primary-300) !important;
+}
+.flex > .bg-primary,
+.flex-1 > .bg-primary,
+.typography > .bg-primary {
+    background-color: var(--darkreader-text--color-text-heading) !important;
+}
+.flex > .bg-primary > span,
+.flex > .bg-primary > svg,
+.flex-1 > .bg-primary > span,
+.flex-1 > .bg-primary > svg {
+    color: var(--color-primary-foreground) !important;
+}
+.text-primary-400 {
+    color: var(--color-primary-400) !important;
+}
+.typography > a > span {
+    color: var(--darkreader-background-ffffff) !important;
+}
+
+================================
+
+translate.google.*
+translate.google.*.*
+
+INVERT
+.ttsbutton
+.tlid-copy-translation-button
+.starbutton
+.speech-button
+.clear
+.swap > .jfk-button-img
+.morebutton
+.close-button
+.ita-kd-icon-button
+.ita-kd-menuitem-inputtool-icon
+.ita-kd-checkbox
+.vk-t-btn
+.vk-sf-b
+.ita-hwt-backspace-img
+.ita-hwt-enter-img
+.ita-hwt-grip
+.gt-ex-quote
+
+CSS
+.trans-verified-button {
+    background-size: cover;
+}
+canvas.ita-hwt-canvas {
+    cursor: url(https://icons.iconarchive.com/icons/paomedia/small-n-flat/16/pencil-icon.png) 0 16,auto !important;
+}
+.rm1UF,
+.OucA2b {
+    border-color: ${#e1e3e1} !important;
+}
+.bvzp8c.Tht3fc,
+.bvzp8c.DlHcnf {
+    border-color: ${rgb(218 220 224)} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.ita-kd-img
+
+================================
+
+translate.yandex.*
+
+INVERT
+.button.button_tab.state-selected::before
+#optionsButton::after
+#clearButton::after
+#textNativeSpeaker
+#textSpeaker
+#microphone::after
+#keyboardButton::after
+#spellerButton::after
+.button.button_icon.button_icon_swap::after
+#favButton::after
+#translatorSpeaker
+#translatorNativeSpeaker
+#copyButton::after
+#shareButton::after
+#goodVoteButton::after
+#badVoteButton::after
+#editorButton::after
+.toggler::after
+.button.button_icon.button_icon_speaker
+.dictionary-example_toggler::after
+.dictionary-example_meta__vote-buttons
+.icon.button.button_icon.button_icon_sync::after
+.message.message_yellow.message_replace
+.placeholder
+.button.header-button.button_icon.button_icon_clear2::after
+#shareCopyLink::after
+
+================================
+
+translate.yandex.*/collections
+
+INVERT
+.button.header-button.button_icon.button_icon_clear2::after
+.record-line_speaker.button.button_icon.button_icon_speaker::after
+.button.button_icon.button_icon_lines::after
+.button.button_icon.button_icon_trash::after
+#shareCollectionCopy::after
+
+================================
+
+translate.yandex.*/doc
+
+INVERT
+.button.button_tab.state-selected::before
+.listbox-option::after
+
+================================
+
+translate.yandex.*/ocr
+
+INVERT
+.button.button_tab.state-selected::before
+.button.button_icon.button_icon_swap::after
+.button.button_icon.button_icon_plus::after
+.button.button_icon.button_icon_minus::after
+.button.button_icon.button_icon_lines::after
+.button.button_icon.button_icon_words::after
+.button button_icon.button_icon_blocks::after
+.button.button_icon.button_icon_blocks::after
+.button.button_icon.button_icon_reset::after
+
+================================
+
+translate.yandex.*/translate
+
+INVERT
+.button.button_tab.state-selected::before
+#shareButton::after
+.listbox-option::after
+#shareCopyLink::after
+
+================================
+
+translifeline.org
+
+INVERT
+nav > ul > li > a > span > svg
+
+================================
+
+transport.orgp.spb.ru
+
+INVERT
+#map
+
+================================
+
+transum.org
+
+INVERT
+img[src*="Level"]
+
+================================
+
+trello.com
+
+CSS
+.checklist-item-checkbox {
+    background-color: #2f3234 !important;
+}
+
+================================
+
+trendmicro.com
+
+INVERT
+.logo
+
+================================
+
+trezor.io
+
+INVERT
+.hero-image
+
+================================
+
+tribunemag.co.uk
+
+INVERT
+.si-hr-nv__toggle--menu
+.si-hr-sm__item
+
+================================
+
+trip101.com
+
+INVERT
+.logo
+.name
+.partner-logo
+img.partner-img
+
+================================
+
+tripadvisor.com
+tripadvisor.com.hk
+tripadvisor.com.tw
+*.tripadvisor.com
+
+INVERT
+img[alt="Tripadvisor"]
+
+================================
+
+trojmiasto.pl
+
+INVERT
+img[alt*="Trojmiasto.pl"]
+
+================================
+
+truestory.pl
+
+INVERT
+.tdb-logo-img
+
+================================
+
+truity.com
+
+INVERT
+.navbar-btn.logo
+.footer-logo.logo
+
+================================
+
+trustpilot.com
+*.trustpilot.com
+
+INVERT
+div[class*="styles_categoryIcon"] img
+[class^="CDS_Icon"]:not(a[href^="/categories/"] > svg):not(div[class*="styles_iconContainer"] > svg)
+div[class*="icon-button_icon"] button
+img[class*="MultiColumnItem_IconContainer"]
+
+CSS
+[class*="theme-default"] {
+    --darkreader-bg--CDS-color-semantic-surface-default: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tug.org/FontCatalogue
+
+INVERT
+img
+
+================================
+
+tumblr.com
+*.tumblr.com
+
+INVERT
+.QnWzN > div
+div[role="progressbar"]
+
+CSS
+a[data-testid="google-login-button"],
+a[data-testid="apple-login-button"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+footer[role="contentinfo"] > ul > li > a {
+    filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
+}
+:root {
+    --darkreader-bg--secondary-accent: 31, 32, 34 !important;
+    --darkreader-bg--white: 23, 23, 23 !important;
+    --darkreader-text--black: 228, 224, 218 !important;
+}
+
+================================
+
+tuono.dev
+
+CSS
+:root {
+    --mantine-color-body: var(--darkreader-bg--mantine-color-white) !important;
+    --mantine-color-footer-bg: var(--darkreader-bg--mantine-color-footer-bg) !important;
+}
+
+================================
+
+turbolab.it
+
+CSS
+body,
+.main-header,
+footer {
+    background-blend-mode: multiply !important;
+    background-color: ${rgba(255,255,255,0.5)} !important;
+}
+
+================================
+
+tutorialspoint.com
+
+INVERT
+i.fa
+i.fab
+i.fal
+img.tp-logo
+button.slick-prev.slick-arrow::before
+button.slick-next.slick-arrow::before
+span.MathJax img
+
+================================
+
+tuwroclaw.com
+
+INVERT
+.navigation i[class^="ico"]
+.portal-logo
+.partners a img
+.hamburger-wrapper
+img[src*="gfx/ico"]
+
+================================
+
+tuxcare.com
+
+INVERT
+.navbar__logo
+
+================================
+
+tuxedocomputers.com
+
+INVERT
+#logo
+
+================================
+
+tv.yandex.*
+
+INVERT
+.icon_location::after
+.icon_location::before
+.button_arrow_down::after
+
+IGNORE IMAGE ANALYSIS
+.icon_location::after
+.icon_location::before
+.button_arrow_down::after
+
+================================
+
+tvland.com
+
+CSS
+body,
+.header-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+tvn24.pl
+
+INVERT
+.header-menu__more-button
+.hamburger-icon
+.hamburger__button::before
+.account-standard__toggle-button-wrapper::before
+.header-menu-go__wrapper--desktop::before
+
+CSS
+svg path[d^="M23.8898"],
+svg path[d^="M22.9767"],
+svg path[d^="M7.66678"] {
+    fill: #111 !important;
+}
+
+================================
+
+tvp.info
+
+INVERT
+.nav__logo
+.icon-youtube
+
+================================
+
+tvrain.ru
+
+INVERT
+.menu3__logo
+
+================================
+
+tvtropes.org
+
+INVERT
+body.darthWiki > i
+body.wmgWiki > i
+.spi.darthwiki
+.spi.sugarwiki
+.spi.film
+.spi.headscratchers
+.spi.laconic-icon
+.spi.lightnovel
+.spi.manga
+.spi.nightmarefuel
+.spi.radar
+.spi.recap
+.spi.shoutout
+.spi.webcomic
+.spi.wmg
+.spi.ymmv
+img[src="/img/loading-alt.gif"]
+
+IGNORE IMAGE ANALYSIS
+body.sugarWiki #header-spacer-left::after
+body.sugarWiki #header-spacer-right::after
+
+================================
+
+tweakers.net
+*.tweakers.net
+
+INVERT
+.infoBox > .title::before
+#userbar li.icon.selected > a
+
+CSS
+#logo a {
+    background: url("https://tweakers.net/g/if/v3/framework/tweakers_logo_full.svg") no-repeat center !important;
+}
+@media screen and (max-width: 1000px) {
+    #logo a {
+        background: url("https://tweakers.net/g/if/v3/framework/menu_icons_responsive_v6.png") no-repeat -8px -220px !important;
+    }
+}
+.ankeiler > a.commentCount {
+    background-image: url("https://tweakers.net/g/icons/commentcounter_small_bg.svg") !important;
+    text-decoration: none !important;
+}
+#userbar li.icon a {
+    background-image: url("https://tweakers.net/g/if/v3/framework/menu_icons_v2.png") !important;
+}
+#userbar li.icon.flag.nl::after {
+    background-color: #fff !important;
+    border-bottom-color: #014a93 !important;
+    border-top-color: #e7184c !important;
+}
+#userbar li.icon.flag.be::after {
+    background-color: #ffff1a !important;
+    border-left-color: #000 !important;
+    border-right-color: #e7184c !important;
+}
+.thumb.category {
+    border: none !important;
+}
+.ctaButton.play::after {
+    background-color: #FFF !important;
+}
+.relatedContentContainer .relatedContentItems .itemContainer {
+    border-bottom-color: ${#d9d9d9} !important;
+    border-top-color: ${#d9d9d9} !important;
+}
+#categoryBrowser li a {
+    background-color: initial !important;
+    background-image: none !important;
+}
+#categoryBrowser li.more {
+    background-image: url("https://tweakers.net/g/if/categories/arrows.png") !important;
+}
+#categoryBrowser li.more:not(li.active.more) {
+    background-position-y: -17px !important;
+}
+#categoryBrowser li.more.active {
+    background-image: url("https://tweakers.net/g/if/categories/arrows.png"), linear-gradient(rgb(131, 24, 46), rgb(148, 15, 49)) !important;
+}
+#tracker .fakeTop .toggleVisibility .corner::before,
+#tracker .fakeTop .toggleVisibility .corner::after {
+    border-color: ${#ccc} !important;
+}
+@media screen and (max-width: 767px) {
+    #userbar li.icon a {
+        background-image: url("https://tweakers.net/g/if/v3/framework/menu_icons_responsive_v6.png") !important;
+    }
+    #categoryBrowser li.more.active {
+        background-image: none !important;
+        box-shadow: none !important;
+    }
+}
+#contentArea,
+#categoryBrowser,
+#categoryBrowser .sublist,
+#categoryBrowser .mainlist,
+#categoryBrowser ul,
+#categoryBrowser li {
+    border-color: ${#b2b9bd} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#categoryBrowser li a
+table.highlights .title a.showMoreItems
+
+================================
+
+twistedvoxel.com
+
+INVERT
+.penci-logo
+.penci-limg
+.penci-menuhbg-inner
+
+================================
+
+twit.tv
+
+INVERT
+.logo-large
+
+================================
+
+twitch.tv
+*.ext-twitch.tv
+
+INVERT
+.volume-slider__slider-container
+.seekbar-bar
+.mention-fragment--recipient
+.reply-line--mentioned
+.claimable-bonus__icon
+
+CSS
+.seekbar-segment {
+    background-color: rgb(169, 112, 255) !important;
+}
+html,
+iframe {
+    color-scheme: unset !important;
+}
+
+================================
+
+twitter.com
+
+INVERT
+[role="slider"]
+[style^="flex-grow"]
+
+CSS
+main,
+header {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+twosigma.com
+
+INVERT
+.homepage-video-desktop video
+.homepage-video-desktop img
+
+================================
+
+tygodnikkrag.pl
+
+INVERT
+#header-logo-image
+
+================================
+
+typescriptlang.org
+
+CSS
+.dark-theme .markdown pre {
+    filter: none !important;
+}
+:root {
+    --darkreader-bg--raised-background-color: ${#DEE0E3} !important;
+}
+
+================================
+
+typst.app
+staging.typst.app
+
+INVERT
+img[src$=".svg"]:not([alt="Typst"])
+
+CSS
+svg {
+    filter: none !important;
+}
+[class*="_project_"] [class*="_page_"]:not([class*="_new_"])::after {
+    background: #fff4;
+}
+[class*="_themeSwatch_"][class*="_light_"],
+[class*="_themeSwatch_"][class*="_system_"]:not([class*="_systemSecond_"]) {
+    background: #eff0f3;
+    color: #19181f;
+}
+[class*="_themeSwatch_"][class*="_light_"] [class*="_tSheet_"],
+[class*="_themeSwatch_"][class*="_system_"]:not([class*="_systemSecond_"]) [class*="_tSheet_"] {
+    background: #fdfdfd;
+}
+
+================================
+
+typst.app/universe
+staging.typst.app/universe
+
+INVERT
+img[src$=".svg"]:not([alt="Typst"])
+#results li
+#results .title
+#results .description
+#results .template-thumbnail
+#template-thumbnail
+#banner
+#banner .title
+#banner .description
+#banner .featured-label
+#banner .featured-label .icon
+.carousel
+.carousel .top-text
+.carousel .title
+.carousel .bottom-text
+#categories ul li a
+
+CSS
+#results li a,
+#banner {
+    border: 1px solid !important;
+    border-color: lightgray !important;
+}
+
+================================
+
+ubank.com.au
+
+CSS
+.sp-envelope-item {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ubereats.com
+
+INVERT
+img[alt*='Home']
+div[class^='c5'] .gm-style
+#main-content > h1 + div
+#wrapper > div:nth-of-type(2)
+#wrapper > div:nth-of-type(2) > header
+#wrapper > div:nth-of-type(2) > footer
+#wrapper > div:nth-of-type(2) > #main-content > div:first-child
+
+================================
+
+ubisoft.com
+
+INVERT
+.menu span
+
+CSS
+global-navigation,
+.menu {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+ubuntu.com
+
+INVERT
+.cls-2
+.global-nav__header-logo-anchor
+
+CSS
+header[style$="image-background-paper.png);"] {
+    background-image: none !important;
+}
+.chart-key text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+IGNORE INLINE STYLE
+g#ubuntu-logo > path
+
+================================
+
+ubuntubudgie.org
+
+INVERT
+.custom-logo
+
+================================
+
+udemy.com
+
+CSS
+@container ud-content-area (min-width: 653px) {
+    .content-grid-module--grid--YMPin.content-grid-module--root--1AtaF {
+        --content-grid-column-count: 12 !important;
+    }
+}
+
+IGNORE INLINE STYLE
+[data-purpose="star-rating-mask"] > rect
+
+================================
+
+ulta.com
+
+CSS
+.pal-c-Icon {
+    fill: ${black} !important;
+}
+.QrCode {
+    background: white !important;
+    border: 5px solid white !important;
+}
+
+IGNORE INLINE STYLE
+.QrCode > svg *
+
+================================
+
+ultimate-guitar.com
+
+INVERT
+form[action$="/search.php"] > button
+form[action$="/search.php"] > button:not(:hover) > span
+canvas[style^="height: 72px; width: 84px;"]
+canvas[style^="height: 42px; width: 141px;"]
+
+================================
+
+um.edu.mt
+*.um.edu.mt
+
+INVERT
+.logo img
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+umweltinstitut.org
+
+CSS
+.streifenBg {
+    background-image: none !important;
+}
+
+================================
+
+un.org
+
+INVERT
+a.logo[title="United Nations"]
+img[src*="UN-text-EN.svg"]
+
+================================
+
+understandingwar.org
+
+CSS
+#edit-search-block-form--2,
+#nice-menu-1 > li > a {
+    color: var(--darkreader-neutral-background) !important;
+    text-shadow: none !important;
+}
+#mainwrap,
+.secondarybox,
+.content,
+.view-filters {
+    background-image: none !important;
+}
+img[src*="ISW\%20LOGO"],
+img[src*="ISW\%20Logo"] {
+    background-color: white !important;
+}
+body {
+    background-blend-mode: multiply !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+unicodelookup.com
+
+CSS
+.panel .ptl,
+.panel .ptr,
+.panel .pbl,
+.panel .pbr {
+    background-image: none !important;
+}
+.panel .ptl {
+    background: ${lightgray} !important;
+}
+
+================================
+
+unimtx.com
+
+INVERT
+.navbar-brand
+
+================================
+
+unipoll.uni-obuda.hu
+
+CSS
+textarea {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+unlockd.me
+
+CSS
+body {
+    background-color: transparent !important;
+}
+.MuiTypography-colorInherit {
+    color: inherit !important;
+}
+
+================================
+
+unsplash.com
+
+CSS
+li > a[aria-current="page"] {
+    box-shadow: ${rgb(25,25,25)} 0px -2px inset;
+}
+
+================================
+
+uokik.gov.pl
+
+INVERT
+.a-press-office
+.abgLong
+h1[id="logo"]
+p a
+p.nav img
+span[class="number"]
+ul[class="tabs"]
+
+CSS
+#subpage,
+.sWrapper1,
+.sWrapper2,
+.tabs,
+body#page,
+div#right,
+div#top,
+div.fWrapper,
+div[class="b1"],
+h2#here {
+    background-image: none !important;
+}
+#footer .active {
+    color: #000000 !important;
+}
+
+================================
+
+uol.com.br
+
+CSS
+.text a {
+    text-decoration: underline;
+}
+
+================================
+
+upcloud.com
+
+CSS
+.breadcrumbs-link a,
+a.pagination-link,
+a.permalink {
+    -webkit-background-clip: initial !important;
+    -webkit-text-fill-color: initial !important;
+    background-clip: initial !important;
+    background-image: none !important;
+}
+.mt-8.sticky.bottom-0 {
+    box-shadow: 0 -12px 16px var(--darkreader-neutral-background) !important;
+}
+.support-card {
+    background-image: linear-gradient(254deg, #961114 -14.82%, #7b00ff 50.93%, #2e045d 108.08%) !important;
+}
+.support-card .button-white:hover {
+    background-color: rgba(255, 255, 255, 0.85) !important;
+    color: #2d0a4e !important;
+}
+
+================================
+
+ups.com
+wwwapps.ups.com
+
+INVERT
+img[data-icon-name="search"]
+img[data-icon-name="pin"]
+img[data-icon-name="alert"]
+
+CSS
+#ups-alertsWrap,
+#ups-skipNav {
+    background: ${#FE9} !important;
+}
+header {
+    background: linear-gradient(var(--darkreader-border--gray-5) var(--header-ribbon-height), ${white} var(--header-ribbon-height)) !important;
+}
+#icons-sprite-section-arc path {
+    fill: none !important;
+}
+.track .toggle-help,
+.tabs-tab {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+uptimerobot.com
+
+INVERT
+.normal-logo
+.socialWrapper > ul > li
+.feature-icon
+[src$="godaddy-logo.svg"]
+[src$="moodys-logo.svg"]
+[src$="ibm-logo.svg"]
+[src$="expedia-logo.svg"]
+[src$="creditcards.svg"]
+
+CSS
+.page-head,
+.sidebar {
+    background-image: none !important;
+}
+
+================================
+
+upwork.com
+
+CSS
+.profile-completeness-nudges-tiles-alternative .carousel-wrapper .up-icon svg {
+    filter: drop-shadow(0 0 0px var(--white)) drop-shadow(0 0 0px var(--white));
+}
+.up-skill-container .up-btn.up-btn-next::before,
+.up-skill-container .up-btn.up-btn-prev::before {
+    opacity: 0 !important;
+}
+.up-tab-scroll-hint::after {
+    background: none !important;
+}
+.up-d-skeleton {
+    background-color: var(--darkreader-bg--skeleton-color) !important;
+    background-image: linear-gradient(90deg, var(--darkreader-bg--skeleton-color), #24242400, var(--darkreader-bg--skeleton-color)) !important;
+    color: transparent !important;
+}
+
+================================
+
+urbandecay.com
+
+IGNORE INLINE STYLE
+.c-select__icon
+.c-swatch
+
+================================
+
+urbandictionary.com
+
+INVERT
+a.block.flex
+
+================================
+
+urbint.com
+
+IGNORE INLINE STYLE
+.site-header__logo svg *
+
+================================
+
+urpredditodicittadinanza.lavoro.gov.it
+
+CSS
+:root {
+    --lwc-colorContentAreaBackground: transparent !important;
+}
+
+================================
+
+usb.org
+
+INVERT
+.logo
+
+================================
+
+usbank.com
+
+INVERT
+.logo
+
+================================
+
+userstyles.world
+
+INVERT
+nav .menu-icon .i
+
+================================
+
+usosweb.*.edu.pl
+usosweb.*.pl
+usosweb.*.*.pl
+usos.*.*.pl
+web.usos.*.edu.pl
+
+INVERT
+.icons-fontcolor
+.schedimg
+.rejestracja-ikona
+#titlebar > #close:hover
+usos-module-link-tile-container > usos-module-link-tile > h2
+timetable-entry
+
+CSS
+:root {
+    --background: var(--darkreader-bg--background) !important;
+    --background-secondary: var(--darkreader-bg--background-secondary) !important;
+    --font-color: var(--darkreader-neutral-text) !important;
+}
+#page-body {
+    background-color: var(--darkreader-bg--background) !important;
+}
+usos-module-link-tile:hover {
+    background-color: var(--darkreader-border--border) !important;
+}
+#close:hover {
+    background-color: var(--darkreader-text--on-primary) !important;
+}
+#close:focus {
+    background-color: #888 !important;
+}
+#layoutCopyright {
+    color: var(--darkreader-neutral-text) !important;
+}
+div > #icon {
+    background: rgb(94, 136, 213) !important;
+}
+timetable-day {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+timetable-entry {
+    color: #111 !important;
+}
+#titlebar {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+body {
+    background: ${#d8d8d8} !important;
+}
+
+================================
+
+uspassporthelpguide.com
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+usps.com
+
+INVERT
+div[data-gtm-subsection="search"] > div > div > a > img
+img[src$="hamburger.svg"]
+img[src$="search.svg"]
+span.carousel-control-next-icon
+span.carousel-control-prev-icon
+ul.nav-list > li.menuheader::after
+ul.nav-list > li.qt-nav > div > ul > li > a > img
+#usps-logo
+
+CSS
+a.button--primary {
+    background-color: ${#333366} !important;
+    border: 1px ${#333366} solid !important;
+    color: var(--darkreader-neutral-background) !important;
+}
+a.button--primary:hover {
+    background-color: ${#EDEDED} !important;
+    border: 1px ${#EDEDED} solid !important;
+    color: ${#333366} !important;
+}
+ol.carousel-indicators li {
+    border-color: ${#333366} !important;
+}
+ol.carousel-indicators li.active {
+    background-color: ${#333366} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+span.carousel-control-next-icon
+span.carousel-control-prev-icon
+
+================================
+
+utas.hu
+
+INVERT
+.mapboxgl-map
+
+================================
+
+uteka.ru
+
+INVERT
+img[src$="/static/img/logo.svg?v=12"]
+ymaps[class$="ground-pane"]
+
+================================
+
+v.qq.com
+
+INVERT
+.page_user_center .link_logo
+
+================================
+
+v2.bricklink.com
+
+INVERT
+img[alt="BrickLink Logo"]
+
+CSS
+div[data-testid="feature-banner"][style] {
+    --bl-castor-feature-banner-background: ${rgb(255, 213, 2)} !important;
+}
+
+IGNORE INLINE STYLE
+*[data-testid*="Swatch"]
+*[data-testid*="swatch"]
+*[class*="swatch"]
+
+================================
+
+v2ex.com
+
+CSS
+#Wrapper {
+    background-image: none !important;
+}
+
+================================
+
+vaccines.gov
+vacunas.gov
+
+INVERT
+.accIcon
+.Button
+img[src$="/images/bch-logo.svg"]
+img[src$="/images/en-US/wcdt.svg"]
+img[src$="/images/es-US/wcdt.svg"]
+img[src$="/images/hhs-logo.svg"]
+
+================================
+
+vaccines.procon.org
+
+INVERT
+#right-sidebar > aside.widget_media_image > a > img
+
+================================
+
+valgrind.org
+
+CSS
+p {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+vandale.nl
+
+INVERT
+#content-top.form
+
+================================
+
+vanguard.com
+
+INVERT
+.vgn-accordionIcon
+.vgn-arrow::after
+#vgn-searchToggleButtonButton--long-form
+#vgn-searchToggleButtonButton--small-form
+input[id^="buysellForm:"]
+input[id^="HoldingDetailForm:"]
+
+CSS
+.hidePageIfJSdisabled {
+    display: block !important;
+}
+
+================================
+
+vasp.at
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+IGNORE IMAGE ANALYSIS
+.site_logo
+
+================================
+
+vbulletin.com
+
+CSS
+.std {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.hero-text,
+#hometext li,
+#hometext h4,
+#hometext_buttons div p {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+vc.ru
+
+INVERT
+mark
+
+CSS
+.main.layout,
+#page_wrapper {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+vcalc.com
+
+INVERT
+.navbar-brand > img
+
+CSS
+.features-area {
+    background-image: none !important;
+}
+
+================================
+
+vcb-s.com
+
+CSS
+html {
+    background-color: transparent !important;
+}
+
+================================
+
+vechevoikolokol.ru
+
+INVERT
+.map
+.main-page-about .img-responsive
+.header-menu__mobile .img-responsive
+
+CSS
+.main-page-about,
+.main-suggestions,
+.i-about,
+.issues-page__content {
+    background: none !important;
+}
+
+================================
+
+vectra.pl
+
+INVERT
+.bottom-menu-icons div img
+.footer-container_info--contact a img
+.ga-offer-data img
+.html-widget-wrapper a img
+.imgContainer img
+.logo
+.menu-container-level-one a img
+.offerBox_links div img
+.pionowe-menu img
+.singleRegulationLink img
+.widgetGroup div div div img
+a.homepage img
+span.separator img
+span.swiper-pagination-bullet
+.TvContainerClick img
+
+================================
+
+vendors.paddle.com
+
+INVERT
+svg.datamap
+
+CSS
+:host(pui-tabs) {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-bottom: var(--darkreader-neutral-background) !important;
+    color: ${black} !important;
+}
+:host(pui-tabs) ::slotted(button),
+:host(pui-tabs) ::slotted(a) {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: ${black} !important;
+}
+#line-chart .tick {
+    fill: ${black} !important;
+}
+
+================================
+
+venture.com/domains
+
+INVERT
+ul.nav
+div.domain-header-brand-authority
+
+================================
+
+ventusky.com
+
+CSS
+.qo {
+    color: ${white} !important;
+}
+
+================================
+
+vercel.com
+
+INVERT
+[alt="optimized-frameworks"]
+[class^="features_logo"]
+button[class^="header_logo"]
+
+CSS
+:root {
+    --geist-foreground: var(--darkreader-neutral-text) !important;
+}
+div[style="background:var(--accents-1);"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.geist-text-center {
+    color: ${#333} !important;
+}
+
+================================
+
+verou.me
+
+CSS
+body * {
+    mix-blend-mode: normal !important;
+}
+aside.info h4 {
+    color: var(--darkreader-neutral-text);
+}
+main aside:where(:not(.pullquote)),
+.callout,
+.warning,
+.info,
+.note,
+.tip,
+.example {
+    background: var(--darkreader-bg--code-background) !important;
+}
+.prev-next {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+verstka.media
+
+INVERT
+.wp-block-site-logo
+
+================================
+
+versus.com
+
+INVERT
+.searchIcon > span > svg
+img[src="/img/amazon-logo.png"]
+.catGroups > div:not(div:nth-child(14)) > span > svg
+hr
+
+CSS
+div[class^="RadarChart"] > svg:nth-child(2) > g > g:nth-child(1) > * {
+    fill: #181a1b !important;
+    stroke: #999 !important;
+}
+.langList,
+div[class*="Sort__selectWrapper"],
+div[class*="Filter__filter"] > *:is(div, ul),
+div[class*="Property__helpBoxContainer"],
+.catGroupsContainer {
+    box-shadow: rgb(22 22 22) 0px 4px 10px !important;
+}
+div > select {
+    background-color: #181a1b !important;
+    border-radius: .375rem !important;
+}
+div[class*="Comments__translateButton"] > button {
+    border-color: #1c1e1f !important;
+}
+div[class*="Login__icons"] > button,
+div[class*="SuggestionsBox__element"],
+div[class*="Comments__translateButton"] > button:hover {
+    border-color: rgb(66, 72, 75) !important;
+}
+div[class*="Search__inputWrapper"]::before {
+    background-color: #303436 !important;
+}
+.navSearch > input {
+    border-radius: .375rem !important;
+}
+.navSearch > input:focus-visible,
+div[class*="Search__inputWrapper"] > input:nth-child(1):focus-visible {
+    outline: transparent !important;
+}
+div[class*="Login__illustration"] {
+    background-image: url('https://images.versus.io/login_background.png'),linear-gradient(298deg,#7600e0,#3c59fc) !important;
+}
+
+IGNORE INLINE STYLE
+.catGroups > div > span > svg > defs > style:nth-child(2)
+
+================================
+
+vg24.pl
+
+INVERT
+img[alt="VG24.PL logo"]
+
+================================
+
+vice.com
+
+INVERT
+img[src*="article-logo"]
+div.nav-bar__hamburger-button__hamburger
+a.page-footer__logo-vice-link
+
+IGNORE INLINE STYLE
+.logo-vice *
+
+================================
+
+videogameschronicle.com
+
+CSS
+.vgc-layout {
+    background-image: none !important;
+}
+
+================================
+
+videolan.org
+
+CSS
+ul {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+videoman.gr
+
+INVERT
+#logo-custom span
+.logo-single
+
+================================
+
+vijaysales.com
+
+INVERT
+img[src*=".svg"]
+
+CSS
+#vscontainer-c8c1c1c302,
+[style*="Background.jpg"] {
+    background-image: none !important;
+}
+.custom-hamburger .bar {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+vimeo.com
+
+INVERT
+svg[alt="Vimeo"]
+#header-vimeo-logo
+footer > div > div > a > svg > path[d^="M89.05 23.658a12.087 12.087"]
+
+================================
+
+vinted.*
+
+INVERT
+.web_ui__Icon__icon
+
+================================
+
+virtualbox.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+virustotal.com
+
+CSS
+:root {
+    --darkreader-bg--vt-grey-50: ${#eee} !important;
+    --darkreader-bg--vt-grey-700: ${#666} !important;
+    --vt-white: var(--darkreader-neutral-background) !important;
+}
+:host(.filled) .chip {
+    --vt-ui-chips-color: var(--darkreader-bg--vt-grey-200) !important;
+}
+.range-wrapper svg {
+    --vt-grey-200: var(--darkreader-bg--vt-grey-200) !important;
+}
+vt-ui-main-footer {
+    --darkreader-bg--vt-grey-700: ${#a0a6b4} !important;
+    --vt-grey-25: var(--darkreader-bg--vt-grey-200) !important;
+}
+.logo {
+    z-index: 1 !important;
+}
+:host > a:not(.item),
+:host > span {
+    border: var(--vt-ui-button-border, 1px solid black) !important;
+    color: var(--vt-ui-button-color-text, var(--darkreader-text--vt-grey-800, #e8e6e3)) !important;
+}
+:host(vt-ui-text-input) {
+    border: var(--vt-ui-text-input-border, 1px solid var(--darkreader-border--vt-grey-200)) !important;
+}
+.detections[clean],
+.detections[clean] svg {
+    color: var(--vt-green-500) !important;
+    fill: var(--vt-green-500) !important;
+}
+.detections {
+    color: var(--vt-red-500) !important;
+}
+#detections .detection,
+#detections {
+    --darkreader-border--vt-grey-100: var(--darkreader-border--vt-grey-200) !important;
+}
+.avatar-section {
+    background: var(--darkreader-border--vt-grey-200) !important;
+}
+
+IGNORE INLINE STYLE
+.circle-progressbar circle
+
+================================
+
+visa.vfsglobal.com
+
+INVERT
+.image-header-vfs-logo
+.logo-height
+
+================================
+
+visualstudio.microsoft.com
+
+CSS
+@media only screen and (min-width: 861px) {
+    .vs-preview-col,
+    .title-lane {
+        --awb-col-width: var(--awb-width-large) !important;
+    }
+}
+
+================================
+
+vitaexpress.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="default-cluster"] > ymaps
+
+================================
+
+vivaldi.com
+
+INVERT
+.hero-cover
+.hero-cover p
+
+================================
+
+vivaldi.net
+
+INVERT
+#vlogo
+
+================================
+
+vjudge.net
+
+CSS
+body {
+    background-image: none !important;
+}
+#contest-rank-table td.accepted {
+    background-color: ${#b8ffb8} !important;
+}
+#contest-rank-table td.prob.fb {
+    background-color: ${#c8ffc8} !important;
+}
+
+================================
+
+vk.com
+
+CSS
+body[scheme="vkcom_dark"] ._im_dialog_unread_ct {
+    background: var(--counter_primary_background) !important;
+}
+
+================================
+
+vmware.com
+
+INVERT
+h1.banner-title
+div.banner
+
+================================
+
+vnexpress.net
+
+INVERT
+#vibeji-ham span
+.sub-cate img
+.swiper-pagination-bullet
+img[src*="app_ico"]
+img[src*="icon-empty-noti"]
+img[src*="logo_sawaco"]
+.wrap-slide-raovat > .swiper-button-box
+
+CSS
+.wrap-titile-area,
+.inner-section-video .item-news-common {
+    border-color: rgb(55, 60, 62) !important;
+}
+#myvne_apple_login {
+    border-color: rgb(67, 72, 75) !important;
+}
+.ads > svg {
+    background-image: url(https://s1.vnecdn.net/vnexpress/restruct/c/v1990/v2_2019/images/graphics/icon-eclick.svg) !important;
+}
+
+IGNORE INLINE STYLE
+symbol#letter-E > *
+
+================================
+
+vod.tvp.pl
+
+INVERT
+img[alt="serwisy tvp"]
+
+================================
+
+voice.google.com
+
+CSS
+header#gb {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+header#gb form[role="search"] {
+    background: ${#f0f4f9} !important;
+}
+
+================================
+
+voir-anime.to
+voiranime.*
+
+CSS
+[style*="background-image:"][style*="bg-search.jpg"] {
+    background-image: none !important;
+}
+
+================================
+
+volkskrant.nl
+
+INVERT
+#pg-header-logo
+img[alt="Website logo"]
+[data-test-id="premium-label"]
+a[href="https://www.dpgmediagroup.com/"]
+.tm-logo
+aside div::before
+
+CSS
+li:before {
+    background-color: var(--darkreader-neutral-text) !important;
+    box-shadow: var(--darkreader-neutral-background) 0px 0px 0px 0.5rem !important;
+    outline-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+voltalbania.org
+voltbelgium.org
+voltdanmark.org
+voltdeutschland.org
+voltespana.org
+volteuropa.org
+voltfrance.org
+voltluxembourg.org
+voltmalta.org
+voltnederland.org
+voltoesterreich.org
+voltportugal.org
+voltromania.org
+voltslovensko.org
+voltsverige.org
+voltswitzerland.org
+
+CSS
+.hidden.lg\:block:not(.w-full):not(.absolute):not(.group):not(.theme-icon):not(.mx-3) {
+    display: none;
+}
+
+================================
+
+vonatinfo.mav-start.hu
+
+CSS
+#right_panel,
+#legend_panel {
+    background: none !important;
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+vote.gov
+
+INVERT
+.usa-logo path[d^="M44.6,"]
+.usa-logo path[d^="M44.9,"]
+.usa-menu-btn::after
+.usa-nav__close::after
+.usa-nav__primary-item .usa-nav__link span::after
+.usa-nav__primary-item .usa-nav__submenu-item a::after
+.vote-theme-options__button--scale::before
+.vote-theme-options__button--theme::before
+
+CSS
+.vote-hero__image img[src*="/Home-3.jpg?"] {
+    clip-path: rect(0 100% 100% 16rem) !important;
+    width: calc(41.6666666667% + 15rem) !important;
+}
+.vote-theme-options {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+.vote-theme-options__button {
+    border-inline-start: 0 !important;
+}
+.vote-theme-options__button:hover {
+    --darkreader-border--theme-options-button--border: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+votecompass.mzalendo.com
+
+INVERT
+.content_wrapper_2
+.content_wrapper_2 > *
+
+================================
+
+vowi.fsinf.at
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+================================
+
+vox.com
+
+INVERT
+.c-app-nav__logo
+.c-footer__logo-link
+
+================================
+
+vpilot.rosscarlson.dev
+
+CSS
+td:not(td[background="/Assets/Images/header.jpg"]) {
+    background: none;
+}
+img[width="1"] {
+    opacity: 0.01;
+}
+
+================================
+
+vpn.getadblock.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+vrt.be/vrtnws
+
+INVERT
+.vrt-header__logo
+.vrt-nav-toggle-btn
+
+================================
+
+vseinstrumenti.ru
+
+CSS
+img[data-behavior="cart-product-image"] {
+    mix-blend-mode: unset;
+}
+
+================================
+
+vshojo.com
+
+CSS
+.elementor-section,
+.elementor-heading-title {
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+vtimes.io
+
+INVERT
+.site-header__logo
+.sticky-nav__logo
+.article__block__disclaimer__close::after
+.article__block__disclaimer__close::before
+
+================================
+
+vultr.com
+
+CSS
+.svg-banner-shape {
+    fill: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.icon-ui *
+.icon-user *
+.icon-sm *
+.svg-logo *
+.svg-illustration *
+.svg-product *
+.svg-shape *
+
+================================
+
+w.atwiki.jp
+
+CSS
+.atwiki-contents-shadow,
+.main_wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.atwiki-jp-bg2 {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+w3.org
+
+INVERT
+img[alt*="equation" i]
+
+================================
+
+w3champions.com
+
+IGNORE IMAGE ANALYSIS
+.race-icon-HUMAN
+.race-icon-ORC
+.race-icon-NIGHT_ELF
+.race-icon-UNDEAD
+
+================================
+
+w3schools.com
+
+IGNORE INLINE STYLE
+.colorbox .innerbox
+
+================================
+
+wacom.com
+
+INVERT
+img.full-size-logo
+a.logo
+div.minicart-wrapper
+a.footer-brand
+
+CSS
+img,
+div.bg-layer,
+div.flickity-viewport,
+canvas {
+    filter: brightness(50%) sepia(40%) !important;
+}
+
+================================
+
+wakamaifondue.com
+
+CSS
+.upload-button > strong,
+.upload-button > span {
+    color: ${white} !important;
+}
+
+================================
+
+walbrzych24.com
+
+INVERT
+a.social-icons__icon img
+img.page-header__logo
+img.page-footer__img
+
+================================
+
+walmart.com
+
+CSS
+.intro-banner__container {
+    z-index: 0 !important;
+}
+label.w_cA4b[data-automation-id="pickup-store"] > svg > circle {
+    fill: #9ca9cd !important;
+}
+label[data-automation-id="pickup-store"] > svg > circle {
+    fill: #404658 !important;
+}
+
+================================
+
+wanikani.com
+
+INVERT
+[data-question-type="meaning"]
+
+CSS
+.wk-hint,
+.wk-hint__title,
+.subject-character__meaning {
+    text-shadow: None;
+}
+
+================================
+
+warframe.com
+
+INVERT
+.HeaderNavigationBar-logo
+
+CSS
+.wrapper {
+    background-image: none !important;
+}
+
+================================
+
+warframe.huijiwiki.com
+
+CSS
+#wiki-outer-body {
+    background-image: none !important;
+}
+
+================================
+
+washingtonpost.com
+
+INVERT
+.hp-masthead
+.switch
+.switch::after
+nav svg[label$='logo']
+
+CSS
+.flex * {
+    border: none !important;
+}
+nav[data-qa="secondary-nav"] {
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+}
+span[data-testid="headline"] {
+    color: var(--darkreader-neutral-text-color);
+}
+footer,
+div {
+    border-left-color: transparent !important;
+    border-right-color: transparent !important;
+}
+div[data-qa="desktop-copyright"] {
+    border-bottom-color: transparent !important;
+    border-left-color: transparent !important;
+    border-right-color: transparent !important;
+}
+.g-artboard img {
+    filter: opacity(0.5) !important;
+}
+
+IGNORE INLINE STYLE
+.center > svg > path[fill="white"]
+
+================================
+
+wayfarer.nianticlabs.com
+
+INVERT
+wf-logo
+
+================================
+
+waze.com
+
+INVERT
+.wm-map__leaflet
+.leaflet-bottom
+.leaflet-popup-content-wrapper
+
+================================
+
+weather.com
+
+INVERT
+div[class*="DynamicMap"]
+svg[name="arrow-up"]
+svg[name="arrow-down"]
+text[class*="DonutChart"]
+
+IGNORE INLINE STYLE
+[id^="svg-symbol"] *
+svg[class*="alerts--"] *
+#svg-symbol-sun
+
+================================
+
+weather.com.cn
+
+INVERT
+.w_logo
+#hourHolder
+
+CSS
+.lv1,
+.lv2,
+.weatherBg01,
+.weatherBgAll,
+.weatherBgAll01,
+.weatherBgAll02,
+.weatherBgAll03 {
+    background-image: none !important;
+}
+
+================================
+
+weather.gov
+forecast.weather.gov
+
+INVERT
+.header-content > .header-doc
+.header-content > .header-nws
+#headline-container > .headline-bar.headline-watch
+#page-header > #header-doc
+#page-header > #header-noaa
+#page-header > #header-nws
+
+CSS
+.center,
+.footer,
+.footer-legal,
+.header,
+.header-shadow {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+web.archive.org
+
+INVERT
+.sparkline-canvas
+.sparkline-mouse-highlight
+.search-toolbar-logo
+.ia-wordmark
+
+CSS
+.measure {
+    z-index: 0 !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.search-toolbar-logo
+
+================================
+
+web.dev
+
+CSS
+.w-aside--gotchas,
+.w-aside--key-term {
+    color: #b98fff;
+}
+.w-aside--gotchas::after,
+.w-aside--key-term::after {
+    background-color: #b98fff;
+}
+
+================================
+
+web.fulcrumapp.com
+
+INVERT
+.scroll-indicator
+.css-x2uwzm
+.duplicate
+.css-37fxgj svg
+a[data-original-title="Edit App"] .icon
+a[data-original-title="Import Data"] .icon
+a[data-original-title="Export Data"] .icon
+a[data-original-title="App Dashboard"] .icon
+a[data-original-title="View Records"] .icon
+.w14
+.css-212r4o
+.css-7n901
+.css-w98cyk
+
+CSS
+.css-1580o8k,
+.css-1ew50hl,
+.css-zn8522 {
+    border-style: solid !important;
+    border-width: 1px !important;
+}
+.css-1ee8v3h,
+.css-5mtzen,
+.css-16mp2t6,
+.css-1o48rld,
+.css-cf39a2,
+.css-1lkowri,
+.css-1gj6av8,
+.css-vi0msm,
+.icon:is(.edit, .delete),
+.css-3o0h5k {
+    color: rgb(193, 187, 179) !important;
+    fill: rgb(193, 187, 179) !important;
+}
+.css-13dtodi {
+    border-color: rgb(53,58,60) !important;
+    border-style: none none solid none !important;
+    border-width: 1px !important;
+}
+.css-1btrp9o:hover,
+.css-11bfl1m:hover {
+    background-color: rgb(70, 70, 70) !important;
+}
+.css-1btrp9o:hover span {
+    color: rgb(229, 134, 134) !important;
+}
+.css-1btrp9o[style*="color: rgb(235, 19, 0)"] {
+    background-color: rgb(70, 70, 70) !important;
+}
+.css-1btrp9o[style*="color: rgb(235, 19, 0)"] span {
+    color: #ff3d3d !important;
+}
+.css-1580o8k,
+.css-1ew50hl {
+    border-style: solid !important;
+    border-width: 1px !important;
+}
+.monaco-editor .cursors-layer .cursor {
+    background-color: #aaa !important;
+    border-color: #aaa !important;
+    color: #fff !important;
+}
+.monaco-editor .wordHighlightStrong {
+    background-color: rgba(0, 73, 114, 0.72) !important;
+}
+.monaco-editor .selectionHighlight {
+    background-color: rgba(173, 214, 255, 0.10) !important;
+}
+.monaco-editor .view-overlays .current-line {
+    border: 2px solid #282828 !important;
+}
+.rt-td,
+.rt-th {
+    border-color: rgb(53, 58, 60) !important;
+    border-style: none none solid solid !important;
+    border-width: 1px !important;
+}
+mark {
+    background-color: rgba(255, 255, 0, 0.5) !important;
+}
+
+IGNORE INLINE STYLE
+.css-1k0tbw6
+.css-13dtodi
+.css-6tgf2j
+
+================================
+
+web.microsoftstream.com
+
+INVERT
+.vjs-progress-holder
+.vjs-volume-bar
+
+================================
+
+web.telegram.org
+
+INVERT
+.composer_emoji_tooltip_category
+.nano-slider
+.divider
+
+CSS
+.progress-bar {
+    background-color: rgba(255,255,255,.9) !important;
+}
+canvas.chat-background-item-canvas {
+    opacity: 0 !important;
+}
+
+================================
+
+web.whatsapp.com
+
+CSS
+._akau {
+    border: 15px solid white !important;
+}
+span[data-icon="default-user"] path.primary {
+    fill: var(--avatar-placeholder-primary) !important;
+}
+[data-icon="tail-out"] {
+    color: var(--darkreader-bg--outgoing-background) !important;
+}
+[data-icon="tail-in"] {
+    color: var(--darkreader-bg--incoming-background) !important;
+}
+
+================================
+
+webaim.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+webassign.net
+
+INVERT
+img
+
+CSS
+body {
+    color: var(--darkreader-neutral-text);
+}
+#webAssign {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+#webAssignMain,
+#webAssignContent {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+img[alt="seenKey"] {
+    background-color: ${black} !important;
+    filter: unset !important;
+}
+#webAssign select {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sButton {
+    background-image: unset;
+}
+
+================================
+
+webbrowsertools.com
+
+CSS
+.tile {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+webdav.org
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
+webhallen.com
+
+INVERT
+span.vote-up
+span.vote-down
+
+CSS
+.popular-categories-tile li .popular-categories-img {
+    background-color: white !important;
+}
+span.vote {
+    color: black !important;
+}
+
+================================
+
+webkitgtk.org
+
+CSS
+#main_wrapper {
+    background-image: none !important;
+}
+
+================================
+
+weblate.org
+
+INVERT
+h5.list-group-item-heading > svg
+img[src="/static/state/lock.svg"]
+img[src="/static/state/link.svg"]
+img[src="/static/state/source.svg"]
+img[src="/static/auth/password.svg"]
+img[src="/static/auth/email.svg"]
+img[src="/static/auth/github.svg"]
+path[d^="M12,4V2A10,10"]
+img[src="/static/state/link.svg"]
+
+================================
+
+webmd.com
+
+INVERT
+.blogs-webmd-logo-img
+.global-nav-logo
+
+================================
+
+webofscience.com
+
+CSS
+.hh,
+.labl,
+mark {
+    background-color: gray !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+webpagetest.org
+
+CSS
+.scrollableTable table,
+.results-filmstrip-container img,
+div:not(.compare_contain_wrap) > div.waterfall-container img,
+div.overflow-container > *,
+.breakdownFrame_item > div > *,
+.experiment_opportunities-resolved ol > *,
+.experiments_details_desc > ul li {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+webroot.com
+
+INVERT
+.logo
+
+================================
+
+webstatus.dev
+
+CSS
+.details {
+    background-color: var(--darkreader-bg--sl-color-neutral-0) !important;
+}
+.data-table th {
+    background: var(--darkreader-bg--table-header-background) !important;
+}
+
+================================
+
+webtoons.com
+
+INVERT
+.ico_n1
+.ico_n2
+.ico_n3
+.ico_n4
+.ico_n5
+.ico_arr1
+
+CSS
+.info {
+    color: rgb(0,0,0) !important;
+}
+.subj_episode {
+    color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+weddlegame.com
+
+CSS
+.bg-sol-yellow {
+    --darkreader-bg--tw-bg-opacity: 1;
+    background-color: rgb(211 213 76);
+}
+.bg-sol-green {
+    --darkreader-bg--tw-bg-opacity: 1;
+    background-color: rgb(78 190 60);
+}
+.bg-sol-lightGreen {
+    --darkreader-bg--tw-bg-opacity: 1;
+    background-color: rgb(78 190 60);
+}
+
+================================
+
+wegmans.com
+
+INVERT
+img[alt="home"]
+
+================================
+
+wego.here.com
+
+INVERT
+#map
+.route_card_left
+.route_tooltip_icon
+.btn_directions
+
+================================
+
+weibo.com
+
+INVERT
+.CopyRight_aria_1Dnvr
+.ProfileHeader_statusCounterLayer_13mzC img
+#woo_svg_nav_logo > g > path:nth-child(5)
+
+CSS
+#searchapps > div > div[role=navigation] > div.woo-panel-main {
+    --darkreader-bg--weibo-top-nav-panel-bgColor: rgb(24, 26, 27);
+    --darkreader-border--weibo-top-nav-panel-bd: rgb(52, 56, 58);
+}
+:root {
+    --darkreader-bg--frame-background: var(--darkreader-bg--w-color-light);
+    --darkreader-bg--w-b-flat-default-bg: #FFFFFF11;
+    --darkreader-bg--w-color-gray-6: #FFFFFF11;
+    --darkreader-bg--w-retweet-background: #FFFFFF08;
+    --darkreader-border--w-card-border: #FFFFFF00;
+    --darkreader-text--weibo-top-nav-line: #FFFFFF19;
+}
+.Home_split_2r3H7,
+.Card_bottomGap_2Xjqi > div > .woo-divider-x,
+.ALink_none_1w6rm .woo-divider-main,
+.Feed_mar1_E_5ip {
+    color: #FFFFFF11;
+}
+.Nav_panel_YI3-j {
+    border-bottom-color: #FFFFFF22 !important;
+    border-left: solid !important;
+    border-left-color: black !important;
+    border-right: solid !important;
+    border-right-color: black !important;
+    border-top: solid !important;
+    border-top-color: black !important;
+}
+.woo-panel-bottom {
+    background-color: #FFFFFF08;
+    border: #FFFFFF11, 1px, solid;
+}
+.Tool_line_GFygz .woo-divider-shadow,
+.Aria_box_3ZDlW .woo-divider-shadow {
+    color: #FFFFFF19;
+}
+.Nav_popcon__F1hb .woo-pop-ctrl {
+    border-left-color: #FFFFFF11;
+}
+.Nav_inner_1QCVO {
+    background-color: #FFFFFF08;
+    border-color: #FFFFFF11 !important;
+}
+.Feed_normal_12A98,
+div > .wbpro-side,
+.ALink_none_1w6rm .Card_bottomGap_2Xjqi {
+    background-color: #FFFFFF08;
+}
+.title_wrap_3e__u {
+    background-color: #FFFFFF00;
+}
+.title_titleBox_3bh5X {
+    border-bottom-color: #FFFFFF08;
+}
+.RepostCommentFeed_divider_3xqBq {
+    color: #FFFFFF08;
+}
+.wbpro-scrollbar {
+    scrollbar-color: #3a3a3a #FFFFFF11;
+}
+.Card_wrap_2ibWe .woo-divider-main {
+    color: #FFFFFF11;
+}
+.Card_wrap_2ibWe .woo-divider-main,
+.woo-divider-x {
+    color: #FFFFFF11 !important;
+}
+.Viewer_prevList_11Q1N {
+    border-top-color: #FFFFFF11;
+}
+.woo-modal-main {
+    border: none;
+}
+body .wbpro-setup__box .multiselect__tags {
+    background-color: #FFFFFF11;
+}
+.wbpro-setup__box .woo-switch-shadow::after {
+    background: #555555;
+}
+.cardHotSearch_tab_24u_o,
+.wbpro-datapicker input,
+.IconBox_wrap_W3Oz_ {
+    background: #FFFFFF11;
+}
+.wbpro-side .clf {
+    background: #FFFFFF11;
+    border-radius: 8px;
+}
+.card-link_wrap_1ktKS,
+.Feed_retweet_JqZJb,
+.card-vote_original_2JeMZ {
+    background-color: #FFFFFF08;
+}
+.Bar_mid_2zgCp {
+    background-color: #FFFFFF1E;
+}
+.Detail_detail_3typT>article:first-child {
+    background: none;
+    border: none;
+}
+.Side_loading_3FKOe {
+    width: 0;
+}
+.cardHotSearch_tabItem_2GC1B.cardHotSearch_active_24AjL {
+    box-shadow: none;
+}
+.woo-input-wrap {
+    background-color: #FFFFFF19;
+    border-color: #FFFFFF11;
+}
+.SearchBar_noDataBox_3DYkR {
+    border: #FFFFFF29, solid, 1px;
+    border-radius: 8px;
+}
+.wbpro-layer .woo-panel-main {
+    border-left: none;
+    border-right: none;
+    border-top: none;
+}
+
+================================
+
+weightwatchers.com
+
+INVERT
+span[class*="NavigationSlice_logo"]
+
+================================
+
+wellandgood.com
+
+INVERT
+.nav-trigger
+.logo
+
+================================
+
+wellrx.com
+
+INVERT
+.logo
+
+================================
+
+welsh-dictionary.ac.uk
+
+CSS
+#donateButton {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-color) !important;
+    text-shadow: none !important;
+}
+
+================================
+
+wenxuecity.com
+
+INVERT
+.logo
+
+================================
+
+wepe.com.cn
+
+INVERT
+#u0_img
+
+================================
+
+wesbos.com
+
+CSS
+footer > div > div:not(.bottom) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+westerndigital.com
+
+INVERT
+.desktop-brand-logo
+
+================================
+
+westlaw.com
+*.westlaw.com
+*.*.westlaw.com
+
+CSS
+.co_hl.blue,
+.highlightBox.blueBox {
+    background-color: ${lightblue} !important;
+}
+.co_hl.purple,
+.highlightBox.purpleBox {
+    background-color: ${#bd73bd} !important;
+}
+
+================================
+
+wetteronline.de
+
+CSS
+#searchstring {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+whambam3d.com
+
+INVERT
+span.multis-svg
+span.svgbg
+summary.header__icon
+svg.icon-search
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+what-if.xkcd.com
+
+INVERT
+.illustration
+.archive-image
+.logo
+
+================================
+
+whataburger.com
+locations.whataburger.com
+
+CSS
+:root {
+    color: revert;
+}
+.Rewards-info {
+    position: relative;
+}
+.ImageBackground-gradient,
+.ImageBackground-image {
+    z-index: 0;
+}
+.Section-titleStrikethrough {
+    background-color: var(--darkreader-selection-text);
+}
+.Section-titleText {
+    position: relative;
+}
+
+================================
+
+whatruns.com
+
+INVERT
+img[title="Buffer"]
+img[alt*="hatruns"]
+
+================================
+
+whatsapp.com
+
+INVERT
+span[data-icon="audio-download"]
+.landing-main .invisible-space > span
+div.landing-header > span > svg
+#wafaq_search_input
+
+CSS
+[data-asset-intro-image],
+[data-asset-intro-image-light] {
+    background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
+}
+html[dir] .landing-main > :first-child > :nth-child(2) > :first-child {
+    border: 16px solid white !important;
+}
+span[data-icon="tail-in"] {
+    color: rgb(30, 36, 39) !important;
+}
+span[data-icon="tail-out"] {
+    color: rgb(4, 57, 51) !important;
+}
+div#subheader {
+    background-image: url(https://static.whatsapp.net/rsrc.php/v1/yQ/r/dPFl9fRFF9u.jpg) !important;
+    background-size: 100% !important;
+}
+
+IGNORE INLINE STYLE
+path[fill="currentColor"]
+path[fill="#FFFFFF"]
+.landing-main svg path
+
+================================
+
+whitemad.pl
+
+INVERT
+#logo
+#cb-nav-logo
+
+================================
+
+who.int
+
+INVERT
+.background-url-holder > picture > img
+
+================================
+
+whois.arin.net/ui/advanced.jsp
+
+CSS
+td,
+div#content div#subcontent div.box ul li {
+    background-image: none !important;
+}
+
+================================
+
+whois.com
+
+INVERT
+img[src^="logo.gif"]
+
+================================
+
+wiadomoscihandlowe.pl
+
+INVERT
+.dropdown-portal__link
+.hamburger__button span
+.search__icon
+
+================================
+
+widget.trustpilot.com
+
+INVERT
+svg path.tp-logo__text
+.tp-stars
+
+IGNORE INLINE STYLE
+*
+
+================================
+
+wiemy.to
+
+INVERT
+img.site-logo
+.content-font__icon
+.font-dropdown__item
+
+================================
+
+wiesci24.pl
+
+INVERT
+.tdb-logo-img
+
+================================
+
+wifishop.nl
+routershop.nl
+
+INVERT
+.MuiLink-root > img
+
+CSS
+.ProductListItem-imageContainer {
+    background-color: white !important;
+}
+
+================================
+
+wiki.facepunch.com
+
+CSS
+body {
+    background-color: transparent !important;
+}
+.content {
+    background-image: none !important;
+}
+
+================================
+
+wiki.factorio.com
+
+IGNORE INLINE STYLE
+pre
+
+================================
+
+wiki.mozilla.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+wiki.teamfortress.com
+
+INVERT
+.mw-wiki-logo
+
+CSS
+body,
+#mw-page-base,
+#p-logo,
+#content,
+#footer {
+    background-image: none !important;
+}
+div.vectorTabs ul li.selected a,
+#searchInput::placeholder {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+wiki.ubuntuusers.de
+
+CSS
+table:not([class]),
+table[class^="zebra"] {
+    background-image: none !important;
+}
+
+================================
+
+wiki.wargaming.net
+
+INVERT
+.l-description-img_price
+.b-description-img_price
+
+CSS
+.b-main {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+wikihow.com
+
+INVERT
+.qa_obscured_answer_overlay :last-child:not(strong *)
+
+================================
+
+wikimapia.org
+
+INVERT
+#map
+
+================================
+
+wikimedia.de
+*.wikimedia.de
+wikimediastatus.net
+*.wikimediastatus.net
+
+INVERT
+.logo
+.logo-container
+
+================================
+
+wildberries.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+CSS
+.popup__close-btn.j-close,
+.popup__close-btn.j-btn-close,
+.tooltip.tooltip-btn-edit {
+    border: 1px solid rgb(59, 64, 66);
+}
+.popup__close-btn.j-close,
+.popup__close-btn.j-btn-close,
+.tooltip.tooltip-btn-edit .tooltip__content button {
+    color: var(--darkreader-neutral-text);
+}
+.dropdown-filter__btn {
+    color: var(--darkreader-neutral-text);
+}
+#Item_Text {
+    background: #181a1b;
+    color: #d1cdc7;
+}
+
+================================
+
+willthompson.co.uk
+
+INVERT
+body
+body > *
+
+================================
+
+windows.php.net
+
+CSS
+#content-columns .block,
+#page-area .content {
+    background-image: none !important;
+}
+#content-columns .block .corners-top,
+#content-columns .block .corners-bottom,
+#page-area .content .corners-top,
+#page-area .content .corners-bottom {
+    filter: invert(91%) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#content-columns .block .corners-top
+#content-columns .block .corners-bottom
+#page-area .content .corners-top
+#page-area .content .corners-bottom
+#content-columns .block .corners-top span
+#content-columns .block .corners-bottom span
+#page-area .content .corners-top span
+#page-area .content .corners-bottom span
+#main-column .innerbox .corners-top
+#main-column .innerbox .corners-bottom
+#mid-column .innerbox .corners-top
+#mid-column .innerbox .corners-bottom
+#main-column .innerbox .corners-top span
+#main-column .innerbox .corners-bottom span
+#mid-column .innerbox .corners-top span
+#mid-column .innerbox .corners-bottom span
+
+================================
+
+windscribe.com
+
+CSS
+#body_wrap > div.blue-bg.blue-top > div.twinkling-blue {
+    background-image: none;
+}
+
+================================
+
+windsurf.com
+
+INVERT
+img[src*="windsurf-black-wordmark.svg"]
+
+================================
+
+windy.com
+
+INVERT
+.data-table > .forecast-table.progress-bar > canvas
+
+CSS
+#plugin-detail {
+    text-shadow: rgb(40, 43, 54) 0px 1px 0px !important;
+}
+
+================================
+
+winehq.org
+*.winehq.org
+
+CSS
+.winehq_menu_item .winehq_badge .winehq_badge_inner {
+    color: maroon;
+}
+#whq-logo-glass {
+    z-index: 0;
+}
+div {
+    position: relative;
+    z-index: 1;
+}
+body {
+    height: auto !important;
+}
+
+================================
+
+winzip.com
+
+INVERT
+.navbar-brand
+
+================================
+
+wired.co.uk
+wired.com
+
+INVERT
+body a svg
+a[data-testid="Logo"]
+.c-nav__open-icon
+.c-nav__close-icon
+.standard-navigation__logo-image > img
+
+================================
+
+wireshark.org
+
+INVERT
+.navbar-brand
+
+================================
+
+wirtualnemedia.pl
+
+INVERT
+img[src$="logo-black.gif"]
+
+================================
+
+wmar2news.com
+
+INVERT
+.PageLogo-image
+.wx-nav > img
+
+================================
+
+wmata.com
+
+CSS
+.icon-wmata-logo .path1::before {
+    color: #000 !important;
+}
+
+IGNORE INLINE STYLE
+.goog-te-gadget-simple > span > a > span
+
+================================
+
+wmx-api-production.s3.amazonaws.com
+
+INVERT
+g
+img
+
+================================
+
+womenheart.org
+
+CSS
+.et_pb_slider .et_pb_slide_0 {
+    background-image: url(https://www.womenheart.org/wp-content/uploads/2024/09/WomenHeart-Communities-1.webp) !important;
+}
+
+================================
+
+word-view.officeapps.live.com
+
+INVERT
+img.WACPageImg
+
+================================
+
+wordnik.com
+
+INVERT
+img[alt="wordnik logo"]
+.footer-logo
+
+================================
+
+wordpress.com
+
+INVERT
+svg.masterbar__wpcom-wordmark
+div.wp-login__footer.wp-login__footer--jetpack > img
+
+CSS
+svg.social-icons.social-icons__apple.social-icons--enabled {
+    fill: white !important;
+}
+.stats-card {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+.p2020-sidebar {
+    background: var(--darkreader-neutral-background);
+    background-image: none !important;
+}
+.block-editor-rich-text__editable {
+    color: var(--darkreader-neutral-text);
+}
+.block-editor-block-list__layout .block-editor-block-list__block::after {
+    box-shadow: none !important;
+}
+
+================================
+
+workona.com
+
+INVERT
+.style-module--unchecked--208a1
+
+================================
+
+worldcubeassociation.org
+
+CSS
+.event-checkbox input[type="checkbox"] + i.cubing-icon,
+.event-checkbox input[type="radio"] + i.cubing-icon,
+.event-radio input[type="checkbox"] + i.cubing-icon,
+.event-radio input[type="radio"] + i.cubing-icon {
+    color: rgba(0, 0, 0, 1) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.flag-icon-pl
+.flag-icon-kr
+.flag-icon-fi
+.flag-icon-jp
+.flag-icon-ru
+.flag-icon-si
+.flag-icon-co
+.flag-icon-lt
+.flag-icon-sk
+.flag-icon-bg
+.flag-icon-ve
+.flag-icon-ge
+.flag-icon-ec
+.flag-icon-pk
+.flag-icon-uy
+.flag-icon-mg
+.flag-icon-pa
+.flag-icon-cy
+.flag-icon-bh
+.flag-icon-mt
+.flag-icon-bt
+.flag-icon-jm
+
+================================
+
+worldometers.info
+
+INVERT
+#coronavirus-cases-log.active .highcharts-background
+#coronavirus-deaths-log.active .highcharts-background
+#coronavirus-cases-linear.active .highcharts-background
+#coronavirus-deaths-linear.active .highcharts-background
+
+================================
+
+worldtimebuddy.com
+
+CSS
+body,
+.clientarea > :first-child {
+    background-image: none !important;
+}
+
+================================
+
+wowturkey.com
+
+CSS
+body {
+    background: none !important;
+}
+.cevapButton {
+    background-image: none !important;
+}
+span.postdetails span.name a {
+    background: transparent !important;
+}
+
+IGNORE INLINE STYLE
+.cevapButton
+span.name a
+
+================================
+
+wprost.pl
+*.wprost.pl
+
+INVERT
+strong span:not(ul li.bli-tp-default a strong span):not(#header ul li a strong span):not(ul li.bli-cl-red a strong span)
+p.l
+.section-partners div a img
+nav ul li a:not(div.footer-wprost nav ul li a):not(div.header-bar nav ul li a)
+
+================================
+
+wpshout.com
+
+INVERT
+a[rel="home"] > img
+
+CSS
+.site-title {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+wrestlezone.com
+
+CSS
+main,
+footer,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+writefreely.org
+
+INVERT
+img[src*="writefreely.svg"]
+img[src*="icon.svg"]
+img[src*="i.snap.as/"]
+span
+
+================================
+
+wszystkoconajwazniejsze.pl
+
+CSS
+#papier img {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+wuffs.org
+
+CSS
+.heavyShower {
+    background-color: ${#e4b849} !important;
+}
+.lightShower {
+    background-color: ${#ff9} !important;
+}
+.wday-0,
+.wday-6 {
+    background: ${#ccc} !important;
+}
+.wday-0 .mWeekday,
+.wday-6 .mWeekday {
+    color: ${#000059} !important;
+}
+select:focus {
+    color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
+wunderground.com
+
+CSS
+.bar-on {
+    fill: rgba(0, 0, 0, 0.4) !important;
+}
+
+================================
+
+wvpublic.org
+
+INVERT
+.Page-header-logo
+.chevron
+
+================================
+
+www-awu.aleks.com
+
+INVERT
+.ansed_caret
+.aleks-calculator__button--input > div > div > img
+
+CSS
+div > .ansed_root > .ansed_canvas,
+.ansed_scrollcontainer > .ansed_canvas {
+    filter: invert(70%) contrast(200%) brightness(70%) hue-rotate(180deg) !important;
+}
+
+================================
+
+www.vjw.digital.go.jp
+
+INVERT
+.logo
+
+CSS
+body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+www1.bmo.com
+
+CSS
+otp-app input[type="checkbox"]:not(:checked) {
+    background-image: none !important;
+}
+
+================================
+
+www1.flightrising.com
+
+INVERT
+#sitewide-effort-details
+#sitewide-effort-description
+#sitewide-effort-status
+#sitewide-effort-current-milestone-title
+#sitewide-effort-action
+#big-login-form-button
+img[src$="button-subtract-35.png"]
+img[src$="turn-in-button.png"]
+img[src*="effort/banner_overlays"]
+img[src$="button_back.png"]
+.dragontip div[style^="background-image"]
+.dragontip div[style^="background-image"] *
+#bbcode-tag-bar
+.common-hub-item-button:not([href*="dig-sites"],[href*="database"],[id*="archaeology-muster"])
+.common-hub-item-button:not([href*="dig-sites"],[href*="database"],[id*="archaeology-muster"]) .common-hub-item-description
+img[src*="edit."]
+img[src*="feed."]
+#usertab
+.tabstat
+#namespan
+img[src*="down_arrow."]
+#energybar
+#target
+#ltavtr
+#element-banner
+#statusboxcontext
+#status-box-bottom
+#lair-action-mode
+img[src*="customize"]
+img[src*="button-breed."]
+img[src*="bond."]
+img[src*="switch-familiar"]
+img[src*="share"]
+img[src*="predict-morphology"]
+img[src*="add-35"]
+img[src*="edit-bio"]
+img[src*="scenic-mode"]
+img[src*="pagination-previous."]
+img[src*="pagination-next."]
+img[src*="add-tabs"]
+img[src*="add-slots"]
+img[src*="move-to-tab"]
+img[src*="move-to-lair"]
+img[src*="move-to-den."]
+img[src*="exit"]
+#dragon-profile-scene[style*="11.jpg"]
+#dragon-profile-scene[style*="10.jpg"]
+#dragon-profile-scene[style*="9.jpg"]
+#dragon-profile-scene[style*="8.jpg"]
+#dragon-profile-scene[style*="7.jpg"]
+#dragon-profile-scene[style*="6.jpg"]
+#dragon-profile-scene[style*="5.jpg"]
+#dragon-profile-scene[style*="4.jpg"]
+#dragon-profile-scene[style*="3.jpg"]
+#dragon-profile-scene[style*="2.jpg"]
+#dragon-profile-scene[style*="1.jpg"]
+#speech-bubble
+#speech-bubble-content
+.baldwin-create-instruct
+img[src*="baldwincreate."]
+img[src*="incubate."]
+img[src*="icon_help."]
+img[src*="filter"]
+img[src*="mode-hoard"]
+img[src*="function-vault"]
+img[src*="function-ah"]
+img[src*="function-sell"]
+img[src*="function-convert"]
+.hoard-stack-function-toggle-hoard-sell-lock
+img[src*="favorite-off"]
+img[src*="select-all"]
+img[src*="purchase-den"]
+.unlock-slots-dialog-button-remaining
+#compose
+.menu_content
+.achievements-nav
+.pursuits-nav
+.market-actions
+#ah-topright-tray
+.ah-landing-button
+.ah-landing-button p
+.ah-search-tab-up
+.ah-search-tab-down
+img[src*="catalog."]
+img[src*="swipptrade."]
+#raffle-background
+.raffle-winners
+img[alt*="Transmute"]
+img[alt*="Create New"]
+img[src*="dig-sites."]
+img[src*="muster-resources."]
+.archaeology-dig-site-index-row-image
+.archaeology-dig-site-index-row-focus-toggle
+img[src*="rugged-work."]
+img[src*="precise-work."]
+#tradetype
+img[src*="attachdragon."]
+img[src*="tradedetails."]
+.custom-shops-list-item
+.custom-shops-list-item-description
+.faire-tooltip .header
+.faire-tooltip .header h1
+#dominance-background-image
+img[src*="new_posts."]
+#forum-pinglists
+#forum-search
+#toggle-subscribe
+img[src*="icon-alert."]
+img[src*="icon-quote."]
+.wws-carousel-slide
+.wws-carousel-slide-text
+.wws-carousel-navigation-previous
+.wws-carousel-navigation-next
+#toggle_button
+#dressing-room-landing-page
+img[src*="loadoutfit."]
+img[src*="saveoutfit."]
+img[src*="importapparel."]
+img[src*="clearall."]
+#scrybanner > div
+#assay-container
+#assay-container > div
+img[src*="bg_foreseeprogeny."]
+img[src*="offspring_preview."]
+#load-morphology
+#save-morphology
+.common-hub-item-button[href*="database"] img
+#game-database-search-icon
+img[src*="-auction-house."]
+img[src*="suggest."]
+img[src*="icon-help."]
+.btn-restore
+#ticker
+#ticker > div
+#lucky-streak
+#lucky-streak > div
+#fullscreen
+.baldwin-create-instruct
+.baldwin-create-instruct > div
+.ah-listing-clear-button
+.ah-clear-all-btn
+.ah-listing-relist-button
+div#status-box-mid
+div#status-box-mid ol
+div#status-box-mid div
+.status-row-text img
+img[src*="den-slot-unlock."]
+.ah-collect-all-btn
+img[src*="canceltrade."]
+img[src*="newtopic."]
+#dragtext
+#manntext
+#morphtext
+img[src*="success_catch."]
+.ah-listing-buy-button
+#random-dragon
+#random-dragon a
+#baldwin #plus-button
+#divcontrade
+
+CSS
+.main:not([style*="familiar/background."],[style*="custom-shop-b"]) {
+    background-image: none !important;
+}
+.swipp-tradebox {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.lair-supply.lair-supply-meat.common-tooltip {
+    background-image: url("/static/layout/icon_meat.png") !important;
+}
+#trading-post-content {
+    background-image: none !important;
+}
+#crimswap {
+    background-image: none !important;
+}
+#predict-morphology {
+    background-image: none !important;
+}
+#random-dragon {
+    color: black !important;
+}
+.contentcontainer {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.scry-image-rear {
+    background: url(https://i.imgur.com/1b5mZWZ.png) no-repeat !important;
+}
+.outfit-image-rear {
+    background: url(https://i.imgur.com/FrkDinQ.png) no-repeat !important;
+}
+img[src*="ss_scavenge."] {
+    display: none !important;
+}
+.itemmeat {
+    background-image: url(/static/layout/tooltips/food-meat.png) !important;
+}
+div#status-box-mid {
+    background-image: url(/static/layout/sitestatus_spacer.png) !important;
+}
+.status-row-text {
+    color: black !important;
+}
+#dragon-profile-likes[data-active="false"] .dragon-profile-likes-icon {
+    background-image: url(/static/layout/icon_star_disabled.png) !important;
+}
+.ah-listing-buy-button {
+    background-color: lighten(var(--darkreader-neutral-background), 50%) !important;
+}
+#baldwin #plus-button {
+    background-color: lighten(var(--darkreader-neutral-background), 50%) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#gem_pack_1
+#gem_pack_1:hover
+#gem_pack_2
+#gem_pack_2:hover
+#gem_pack_3
+#gem_pack_3:hover
+#ah-topright-buy-button
+#ah-topright-sell-button
+#usertab
+.baldwin-create-instruct
+.archaeology-dig-plot-square
+.scry-image-rear
+.outfit-image-rear
+#baldwin-xpbar-fill
+.hoard-result-item-use[data-type="baldwin"]::after
+.hoard-result-item-use[data-type="den"]::after
+#ticker
+.itemmeat
+li[data-visible="true"] .dr-apparel-visibility
+.lair-supply.lair-supply-meat.common-tooltip
+.archaeology-supply-pickaxe
+.ah-listing-clear-button
+.ah-clear-all-btn
+#archaeology-muster-resources
+.ah-collect-all-btn
+.ah-listing-buy-button
+#baldwin #plus-button
+
+================================
+
+www2.unesp.br
+*.unesp.br
+
+CSS
+.pu-carrossel {
+    --pu-canvas-image-max-height: auto !important;
+    --pu-canvas-image-max-width: 100% !important;
+    --pu-canvas-image-padding: 1rem 2rem !important;
+    --pu-canvas-text-max-width: min(100%,80ch) !important;
+    --pu-canvas-text-padding-y: 1rem !important;
+    --pu-carrossel-container-aspect-ratio: auto !important;
+    --pu-carrossel-container-height: auto !important;
+    --pu-debug-outline-color: pink !important;
+    --pu-dot-size: 0.7rem !important;
+    --pu-font-size-subtitulo: 22px !important;
+    --pu-font-size-titulo: 32px !important;
+    --pu-veja-mais-inset: auto 0.75rem 1.25rem auto !important;
+    --pu-veja-mais-padding: 0.8em 1.2em !important;
+}
+
+================================
+
+wx.qq.com
+wx2.qq.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+wxwidgets.org
+
+INVERT
+img[src$="header-logo.png"]
+
+================================
+
+wyborcza.pl
+wyborcza.biz
+
+INVERT
+#wH_username_wrap img
+.account-cap--logo
+.cap-navigation--back
+.cap-vignette--logo-image
+.header-cap-holder a img
+.nmk_avatar-icon
+.partners-list-item
+.partners-list-item-text
+.podcast-player-control ::after
+.podcast-player-time-progress
+.return-back img
+.wyborcza-logo
+a[title="Aplikacja wyborcza.pl"]
+img.logo
+.button svg
+.btn.pull-right.dismiss
+.slider_nekrologi p::before
+img[src*="WYBORCZA-NEKROLOGI.png"]
+
+================================
+
+wysokieobcasy.pl
+
+INVERT
+.vin-img-link-pic.vin-local-img-link-pic
+
+================================
+
+x-kom.pl
+*.x-kom.pl
+
+INVERT
+a[href="/"] img
+a[href="https://x-kom.pl"] img
+a[href="https://www.x-kom.pl"] img
+a[href="/"] svg
+a[href="https://x-kom.pl"] svg
+a[href="https://www.x-kom.pl"] svg
+div[title*="panel"] svg
+img[alt="Menu"]
+img[alt*="Logo"]
+img[src*="Logo_strefy_marek"]
+img[src*="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iM"]
+img[src*="data:image/svg+xml;base64,PHN2ZyB4bWxucz0ia"]
+.geex a img
+a[href="https://geex.x-kom.pl/"] img
+img[alt="Geex logotyp"]
+div[class*="parts__TabWrapper"] svg
+button svg:not(.swiper-navigation-icon)
+div[class*="parts__IconContainer"] svg *
+div[class*="QRCodeWrapper"] span img
+div[class*="BrandWrapper"] a span img
+div[class*="Hamburger"] svg
+div[class*="TileContainer"] ul li a span svg
+div[class*="PriceWrapper"] button
+div[class*="LoginMenu"] svg
+
+CSS
+[class*="parts__SlideContainer"] picture,
+.ePVVIv {
+    filter: brightness(0.8);
+}
+.promo-img img,
+.small-img-wrapper img,
+.xlp [class*="xwidget_carousel"] img,
+.xlp .category-box img {
+    mix-blend-mode: normal !important;
+}
+
+IGNORE INLINE STYLE
+div[class*="parts__IconContainer"] svg *
+
+IGNORE IMAGE ANALYSIS
+.xlp .img-technologia-section
+.xlp .img-kids-section
+.xlp .img-you-section
+.xlp .img-dom-section
+.xlp .img-lego-section
+
+================================
+
+xbox.com
+
+CSS
+ump-modals {
+    z-index: -1 !important;
+}
+
+================================
+
+xcite.com
+
+INVERT
+li.xc-product-slider-item__actions-bar__express.xcf.xcf--Rocket3-012222
+li.xc-product-slider-item__actions-bar__express.xcf.xcf--express-delivery
+li.xc-product-slider-item__actions-bar__pickup.xcf.xcf--bag
+li.xc-product-slider-item__actions-bar__secret-deal.xcf.xcf--secret-deal
+div > a.xc-product-slider-item__name
+div.titleFyler > span.weeklyTitle
+
+CSS
+div.algolia-instant-results-wrapper {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
+xda-developers.com
+
+INVERT
+.hb-trigger
+
+CSS
+body.tag {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+xfree86.org
+
+INVERT
+img[src*=".png"]
+
+================================
+
+xiph.org
+
+INVERT
+img[src$="fish_xiph_org.png"]
+
+================================
+
+xpather.com
+
+CSS
+body,
+.content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.xpathonline_selected {
+    background-color: ${rgb(255, 242, 160)};
+}
+#xpathonline_output li span:hover {
+    background-color: ${rgb(255, 180, 180)} !important;
+}
+
+================================
+
+y.qq.com
+
+INVERT
+.popup_guide__logo
+.qqmusic_logo
+
+================================
+
+yadi.sk
+
+INVERT
+span.logo.burger-sidebar__logo
+span.logo.burger-sidebar__sidebar-logo
+
+================================
+
+yahoo.com
+
+CSS
+#atomic .Bg\(\$weatherCardBackground\) {
+    background: rgba(var(--rgb-black),.54);
+}
+body {
+    background-color: transparent !important;
+}
+
+================================
+
+yami.com
+
+INVERT
+.category__item__left--active > .category-item__image
+.category__list__item
+img[alt="Yami logo"]
+span[class="cat-txt"]
+
+CSS
+.bff-item__img,
+.bff-item__imgbox--wrapper,
+.cms-component-search-category_keywordItemImg__kTVCV,
+.itemCard_grayBg__pZfD4 {
+    mix-blend-mode: unset !important;
+}
+.cms-component-pc-shortcut-S2_itemHead__Y8ll3 {
+    background-color: ${black} !important;
+}
+.cms-component-slide_swiperSlide__8TzRv [data-darkreader-inline-color] {
+    color: ${white} !important;
+}
+
+IGNORE INLINE STYLE
+.box_title[data-font-color]
+.box_row[data-font-color]
+
+================================
+
+yamicsoft.com
+
+CSS
+.slider-wrapper .slide-secound-detail,
+.slider-wrapper .slide-secound-title {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+yandex.*/internet
+
+INVERT
+a[href="/internet"]
+
+================================
+
+yandex.*/maps
+yandex.*/web-maps
+
+INVERT
+.content-panel-header__logo path[d^="M39.64 22.32"]
+.whats-here-preview__control-search-icon
+.close-button._color_black._circle
+.business-social-links-view__icon
+.social-share-view_discovery-small
+.social-share-view_discovery-large
+.orgpage-social-links-view__icon
+.promo-button__promo-image-container
+.orgpage-photos-view__empty
+.map-container > ymaps > ymaps > canvas
+
+CSS
+span[class$="business-reactions-view__icon"],
+div[class$="business-reactions-view__counter"],
+span[class$="business-reactions-view__icon _dislike"] {
+    color: ${#aba8a8} !important;
+}
+
+================================
+
+yandex.*/pogoda
+
+INVERT
+.maps-widget-nowcast__map-link
+.weather-maps__map > ymaps > ymaps > ymaps > ymaps
+.color-scale__line
+.weather-table__wind-direction > .icon_wind
+.icon_color_black
+
+================================
+
+yandex.*/support
+
+INVERT
+.header2__logo
+
+================================
+
+yandex.eu/showcaptcha
+
+CSS
+.AdvancedCaptcha-SilhouetteTask {
+    background-color: teal !important;
+}
+
+================================
+
+yandex.ru/blog/narod-karta
+
+INVERT
+.y-header_club__logo
+.y-header_club__service
+
+================================
+
+yandex.ru/q
+
+INVERT
+header a[href="/q/"] svg
+
+================================
+
+yelp.com
+
+INVERT
+#logo:not(.homepage-hero_logo)
+img[src$="40x40_food_v2.svg"]
+.gm-style img[role="presentation"]:not([src*="v="])
+
+================================
+
+yeniakit.com.tr
+
+CSS
+.photo-news-detail-cover .article-header > .image {
+    z-index: 0 !important;
+}
+.photo-news-detail-cover .article-header > .black-shadow {
+    z-index: 1 !important;
+}
+.photo-news-detail-cover .article-header > .social-box,
+.photo-news-detail-cover .article-header > .category {
+    z-index: 2 !important;
+}
+
+================================
+
+yettel.rs
+
+INVERT
+.header-container
+
+================================
+
+yle.fi
+
+INVERT
+[class*="AreenaHeader"]
+[class*="TheEndIsDelight__Svg"]
+
+IGNORE IMAGE ANALYSIS
+.yle-header figure.yle-header-logo
+
+================================
+
+yougetsignal.com
+
+INVERT
+img[src^="img/"]
+
+================================
+
+youla.ru
+
+INVERT
+section[data-test-component="HeaderActionMenu"] a > svg > path:nth-child(2n+2)
+#map-1 canvas
+
+================================
+
+youmath.it
+*.youmath.it
+
+INVERT
+.ltximg
+
+================================
+
+youtube.com
+
+INVERT
+#tube-mount .b img
+#ytd-player + .efyt-control-bar > button
+
+CSS
+#search-icon-legacy.ytd-searchbox {
+    border: 1px solid var(--ytd-searchbox-legacy-border-color) !important;
+}
+html:not(.style-scope) {
+    --accent-color: ${#ff4081} !important;
+    --disabled-text-color: ${#9b9b9b} !important;
+    --divider-color: ${#dbdbdb} !important;
+    --error-color: ${#dd2c00} !important;
+    --primary-background-color: ${#ffffff} !important;
+    --primary-color: ${#3f51b5} !important;
+    --primary-text-color: ${#212121} !important;
+    --t5978da8d584b8fe9: ${rgba(255, 255, 255, 0.9)} !important;
+    --ta889dfda9605a358: ${rgba(255, 255, 255, 0.9)} !important;
+    --yt-alert-background: ${hsla(0, 0%, 93.3%, .4)} !important;
+    --yt-app-background: ${hsl(0, 0%, 100%)} !important;
+    --yt-border-color: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-button-active-color: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-channel-header-background: ${hsl(0, 0%, 98%)} !important;
+    --yt-chat-bubble-other-background-color: ${#F9F9F9} !important;
+    --yt-chat-bubble-other-border-color: ${#CCCCCC} !important;
+    --yt-chat-bubble-self-background-color: ${#EDEDED} !important;
+    --yt-chat-bubble-self-border-color: ${#CCCCCC} !important;
+    --yt-commentbox-border-active: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-commentbox-border-inactive: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-copyright-text: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-dialog-background: ${hsl(0, 0%, 100%)} !important;
+    --yt-emoji-picker-search-background-color: ${hsla(0, 0%, 100%, .6)} !important;
+    --yt-emoji-picker-search-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --yt-emoji-picker-search-placeholder-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-expand-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-featured-channel-title-text-color: ${hsla(0, 0%, 0%, .54)} !important;
+    --yt-formatted-string-deemphasize-color: ${hsl(0, 0%, 53.3%)} !important;
+    --yt-guide-background: ${hsl(0, 0%, 96%)} !important;
+    --yt-guide-entry-text-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --yt-hovered-text-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --yt-icon-active-color: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-icon-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --yt-icon-disabled-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-icon-hover-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --yt-item-section-header-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-live-chat-action-panel-background-color: ${hsla(0, 0%, 93.3%, .4)} !important;
+    --yt-live-chat-action-panel-background-color-transparent: ${hsla(0, 0%, 97%, .8)} !important;
+    --yt-live-chat-background-color: ${hsl(0, 0%, 100%)} !important;
+    --yt-live-chat-disabled-icon-button-color: ${hsla(0, 0%, 6.7%, .2)} !important;
+    --yt-live-chat-picker-button-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --yt-live-chat-primary-text-color: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-live-chat-secondary-background-color: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-live-chat-secondary-text-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-live-chat-tertiary-text-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --yt-live-chat-text-input-field-suggestion-background-color: ${hsl(0, 0%, 100%)} !important;
+    --yt-live-chat-text-input-field-suggestion-background-color-hover: ${#eee} !important;
+    --yt-live-chat-text-input-field-suggestion-text-color: ${#666} !important;
+    --yt-live-chat-text-input-field-suggestion-text-color-hover: ${#333} !important;
+    --yt-live-chat-vem-background-color: ${hsl(0, 0, 93.3%)} !important;
+    --yt-main-app-background: ${hsl(0, 0%, 98%)} !important;
+    --yt-main-app-background-tmp: ${hsl(0, 0%, 100%)} !important;
+    --yt-material-searchbox-active: ${hsl(0, 0%, 100%)} !important;
+    --yt-material-searchbox-active-shadow: ${hsla(0, 0%, 0%, .26)} !important;
+    --yt-material-searchbox-inactive: ${hsla(0, 0%, 93.3%, .6)} !important;
+    --yt-material-searchbox-inactive-shadow: ${hsla(0, 0%, 53.3%, .2)} !important;
+    --yt-material-searchbox-inset: ${hsla(0, 0%, 0%, .04)} !important;
+    --yt-menu-focus-background-color: ${hsla(0, 0%, 6.7%, .2)} !important;
+    --yt-menu-hover-backgound-color: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-paper-button-ink-color: ${hsl(0, 0%, 53.3%)} !important;
+    --yt-placeholder-text: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-placeholder-text-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-playlist-background-header: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-playlist-background-item: ${hsla(0, 0%, 93.3%, .6)} !important;
+    --yt-playlist-message-text: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-playlist-message-text-hover: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-playlist-title-text: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-primary-color: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-primary-disabled-button-text-color: ${hsl(0, 0%, 100%)} !important;
+    --yt-primary-text-color: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-searchbox-background: ${hsl(0, 0%, 100%)} !important;
+    --yt-secondary-text-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --yt-sidebar-background: ${hsl(0, 0%, 98%)} !important;
+    --yt-simple-menu-header-background: ${hsl(0, 0%, 93.3%)} !important;
+    --yt-spec-10-percent-layer: ${rgba(0, 0, 0, 0.10)} !important;
+    --yt-spec-badge-chip-background: ${rgba(0, 0, 0, 0.05)} !important;
+    --yt-spec-brand-background-primary: ${rgba(255, 255, 255, 0.98)} !important;
+    --yt-spec-brand-background-secondary: ${rgba(255, 255, 255, 0.95)} !important;
+    --yt-spec-brand-background-solid: ${#FFFFFF} !important;
+    --yt-spec-brand-icon-active: #{rgb(255, 0, 0)} !important;
+    --yt-spec-brand-icon-inactive: ${#606060} !important;
+    --yt-spec-brand-subscribe-button-background: ${#FF0000} !important;
+    --yt-spec-brand-text-button-focus-outline: ${rgba(204, 0, 0, 0.30)} !important;
+    --yt-spec-button-chip-background-hover: ${rgba(0, 0, 0, 0.10)} !important;
+    --yt-spec-call-to-action: ${#065FD4} !important;
+    --yt-spec-call-to-action-button-focus-outline: ${rgba(6, 95, 212, 0.30)} !important;
+    --yt-spec-call-to-action-inverse: ${#3EA6FF} !important;
+    --yt-spec-error-background: ${#1F1F1F} !important;
+    --yt-spec-feed-background-a: ${#F9F9F9} !important;
+    --yt-spec-feed-background-b: ${#F3F3F3} !important;
+    --yt-spec-feed-background-c: ${#EDEDED} !important;
+    --yt-spec-filled-button-focus-outline: ${rgba(0, 0, 0, 0.60)} !important;
+    --yt-spec-filled-button-text: ${#FFFFFF} !important;
+    --yt-spec-general-background-a: ${white} !important;
+    --yt-spec-general-background-b: ${#f1f1f1} !important;
+    --yt-spec-general-background-c: ${#e9e9e9} !important;
+    --yt-spec-icon-active-other: ${#606060} !important;
+    --yt-spec-icon-disabled: ${#CCCCCC} !important;
+    --yt-spec-icon-inactive: ${#909090} !important;
+    --yt-spec-inactive-text-button-focus-outline: ${#CCCCCC} !important;
+    --yt-spec-selected-nav-text: ${#CC0000} !important;
+    --yt-spec-suggested-action: ${#F2F8FF} !important;
+    --yt-spec-text-disabled: ${#909090} !important;
+    --yt-spec-text-primary: ${#0A0A0A} !important;
+    --yt-spec-text-primary-inverse: ${#FFFFFF} !important;
+    --yt-spec-text-secondary: ${#606060} !important;
+    --yt-spec-themed-blue: ${#065FD4} !important;
+    --yt-spec-themed-green: ${#107516} !important;
+    --yt-spec-touch-response: ${#000000} !important;
+    --yt-spec-wordmark-text: ${#282828} !important;
+    --yt-std-body-300: ${hsla(0, 0%, 0%, .54)} !important;
+    --yt-std-surface-200: ${hsl(0, 0%, 98%)} !important;
+    --yt-std-surface-300: ${hsl(0, 0%, 96%)} !important;
+    --yt-std-surface-400: ${hsl(0, 0%, 93%)} !important;
+    --yt-swatch-icon-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --yt-swatch-input-text: ${hsl(0, 0%, 6.7%)} !important;
+    --yt-swatch-primary: ${hsl(0, 0%, 100%)} !important;
+    --yt-swatch-primary-darker: ${rgb(230, 230, 230)} !important;
+    --yt-swatch-text: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --yt-swatch-textbox-bg: ${rgb(255, 255, 255)} !important;
+    --yt-tertiary-text-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --yt-thumbnail-placeholder-color: ${hsl(0, 0%, 89%)} !important;
+    --yt-transcript-background: ${hsl(0, 0%, 100%)} !important;
+    --yt-video-secondary-info-description-background: ${hsla(0, 0%, 93.3%, .6)} !important;
+    --ytd-backstage-attachment-background-color: ${hsl(0, 0%, 100%)} !important;
+    --ytd-backstage-attachment-icon-hover-color: ${hsla(0, 0%, 0%, .74)} !important;
+    --ytd-backstage-cancel-background-color: ${hsl(0, 0%, 100%)} !important;
+    --ytd-backstage-cancel-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --ytd-backstage-creationbox-background-color: ${hsl(0, 0%, 98%)} !important;
+    --ytd-backstage-creationbox-background-color-focus: ${hsl(0, 0%, 96%)} !important;
+    --ytd-backstage-creationbox-disabled-button-color: ${hsla(0, 0%, 0%, .04)} !important;
+    --ytd-backstage-creationbox-disabled-button-text-color: ${hsl(0, 0%, 100%)} !important;
+    --ytd-backstage-creationbox-inactive-color: ${hsla(0, 0%, 0%, .26)} !important;
+    --ytd-backstage-creationbox-input-text-color: ${hsla(0, 0%, 0%, .87)} !important;
+    --ytd-backstage-creationbox-text-color: ${hsla(0, 0%, 0%, .54)} !important;
+    --ytd-backstage-image-alert-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-backstage-metadata-text-color: ${hsl(0, 0%, 53.3%)} !important;
+    --ytd-backstage-video-link-background-color: ${hsla(0, 0%, 93.3%, .4)} !important;
+    --ytd-badge-disabled-color: ${hsla(0, 0%, 53.3%, .4)} !important;
+    --ytd-collection-badge-color: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --ytd-comment-text-color: ${hsl(0, 0%, 6.7%)} !important;
+    --ytd-macro-markers-list-item-background-color: ${rgba(0, 0, 0, 0.05)} !important;
+    --ytd-moderation-icon-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-moderation-icon-hover-color: ${hsl(0, 0%, 6.7%)} !important;
+    --ytd-moderation-panel-background: ${hsla(0, 0%, 93.3%, .6)} !important;
+    --ytd-moderation-panel-comment-metadata-text: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-moderation-panel-comment-text: ${hsl(0, 0%, 6.7%)} !important;
+    --ytd-moderation-panel-hover: ${hsla(0, 0%, 93.3%, .8)} !important;
+    --ytd-offer-background-color: ${hsla(0, 0%, 93.3%, .4)} !important;
+    --ytd-owner-badge-color: ${hsla(0, 0%, 6.7%, .4)} !important;
+    --ytd-searchbox-border-color: ${hsla(0, 0%, 53.3%, .2)} !important;
+    --ytd-searchbox-legacy-border-color: ${#ccc} !important;
+    --ytd-searchbox-legacy-border-shadow-color: ${#eee} !important;
+    --ytd-searchbox-legacy-button-border-color: ${#d3d3d3} !important;
+    --ytd-searchbox-legacy-button-color: ${#f8f8f8} !important;
+    --ytd-searchbox-legacy-button-focus-color: ${#e9e9e9} !important;
+    --ytd-searchbox-legacy-button-hover-border-color: ${#c6c6c6} !important;
+    --ytd-searchbox-legacy-button-hover-color: ${#f0f0f0} !important;
+    --ytd-searchbox-legacy-button-icon-color: ${#333} !important;
+    --ytd-shopping-product-info: ${hsla(0, 0%, 6.7%, .8)} !important;
+    --ytd-simple-badge-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-sponsorships-background-color-focus: ${hsla(0, 0%, 93.3%, .4)} !important;
+    --ytd-transcript-cue-hover-background-color: ${hsl(0, 0%, 93.3%)} !important;
+    --ytd-transcript-toolbar-background-color: ${hsl(0, 0%, 93.3%)} !important;
+    --ytd-transcript-toolbar-text: ${hsl(0, 0%, 6.7%)} !important;
+    --ytd-vat-notice-text: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-video-game-watch-card-logo-color: ${hsl(0, 0%, 6.7%)} !important;
+    --ytd-video-publish-date-color: ${hsla(0, 0%, 6.7%, .6)} !important;
+    --ytd-watch-card-album-header-background: ${hsl(0, 0%, 100%)} !important;
+    --ytd-watch-card-secondary-text-color: ${hsl(0, 0%, 53.3%)} !important;
+    --ytd-watch-split-pane-sidebar-background-color: ${hsl(0, 0%, 98%)} !important;
+}
+.ytp-hover-progress-light {
+    background-color: rgba(255,255,255,.5) !important;
+}
+.ytp-progress-list {
+    background-color: rgba(255,255,255,.2) !important;
+}
+.ytp-volume-slider-handle {
+    background-color: white !important;
+}
+.ytp-volume-slider-handle::before {
+    background-color: white !important;
+}
+.ytp-volume-slider-handle::after {
+    background-color: rgba(255,255,255,.2) !important;
+}
+button[aria-pressed="true"] > yt-icon:not(#guide-icon.ytd-app):not(#guide-icon.ytd-masthead),
+[id$="-replies"].ytd-comment-replies-renderer > .ytd-button-renderer > paper-button,
+[id$="-replies"].ytd-comment-replies-renderer > .ytd-button-renderer > paper-button  > yt-icon {
+    color: var(--yt-spec-call-to-action) !important;
+    fill: var(--yt-spec-call-to-action) !important;
+}
+.ytp-menuitem-toggle-checkbox {
+    background: rgba(255, 255, 255, 0.3) !important;
+}
+.ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
+    background: #f00 !important;
+}
+.ytp-menuitem-toggle-checkbox::after {
+    background-color: #bdbdbd !important;
+}
+.ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox::after {
+    background-color: white !important;
+}
+#date yt-formatted-string.ytd-video-primary-info-renderer,
+.yt-view-count-renderer {
+    color: var(--yt-spec-text-secondary) !important;
+}
+.ytp-contextmenu .ytp-menuitem .ytp-menuitem-toggle-checkbox {
+    background: none !important;
+}
+.ytp-contextmenu .ytp-menuitem[aria-checked="true"] .ytp-menuitem-toggle-checkbox {
+    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" fill="white"/></svg>') !important;
+}
+paper-button.ytd-subscribe-button-renderer[subscribed] {
+    background-color: var(--yt-spec-10-percent-layer) !important;
+}
+.badge-style-type-live-now.ytd-badge-supported-renderer {
+    border: 1px solid rgb(255, 78, 69) !important;
+}
+.ytp-load-progress {
+    background: rgba(255,255,255,0.3) !important;
+}
+yt-chip-cloud-chip-renderer[chip-style="STYLE_DEFAULT"] {
+    background-color: rgba(255,255,255,0.05);
+}
+yt-chip-cloud-chip-renderer[chip-style="STYLE_DEFAULT"].iron-selected {
+    background-color: rgba(255,255,255,0.2);
+}
+paper-item[aria-selected="true"] {
+    background-color: rgba(255,255,255,0.2) !important;
+}
+iron-input.paper-input > input.paper-input,
+.input-content.paper-input-container > label,
+.input-content.paper-input-container > .paper-input-label {
+    color: var(--paper-input-container-shared-input-style_-_color) !important;
+}
+ytd-compact-autoplay-renderer,
+ytd-video-primary-info-renderer,
+#sections.ytd-guide-renderer > .ytd-guide-renderer:not(first-child),
+ytd-video-secondary-info-renderer,
+#placeholder-area.ytd-comment-simplebox-renderer {
+    border-bottom-color: var(--yt-spec-10-percent-layer) !important;
+}
+ytd-guide-collapsible-section-entry-renderer.ytd-guide-section-renderer:not(:first-child),
+ytd-metadata-row-header-renderer[has-divider-line] {
+    border-top-color: var(--yt-spec-10-percent-layer) !important;
+}
+ytd-guide-entry-renderer[active] .guide-icon.ytd-guide-entry-renderer {
+    fill: ${black} !important;
+}
+#hearted.ytd-creator-heart-renderer {
+    fill: var(--yt-spec-static-brand-red) !important;
+}
+#hearted-border.ytd-creator-heart-renderer {
+    fill: ${white} !important;
+}
+.guide-entry-badge.ytd-guide-entry-renderer {
+    fill: var(--yt-spec-static-brand-red) !important;
+}
+#endpoint.yt-simple-endpoint.ytd-guide-entry-renderer:hover,
+#endpoint.yt-simple-endpoint.ytd-guide-entry-renderer:focus {
+    background-color: var(--yt-spec-badge-chip-background) !important;
+}
+.ytp-cards-button-icon .ytp-svg-shadow {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.ytp-doubletap-ui-legacy[data-side="back"] .ytp-doubletap-base-arrow {
+    border-right-color: var(--darkreader-neutral-color) !important;
+}
+.ytp-doubletap-ui-legacy[data-side="forward"] .ytp-doubletap-base-arrow {
+    border-left-color: var(--darkreader-neutral-color) !important;
+}
+.yt-spec-button-shape-next--mono.yt-spec-button-shape-next--tonal {
+    background-color: ${lightgray} !important;
+}
+.page-header-banner-image {
+    background-image: var(--yt-channel-banner) !important;
+}
+tp-yt-paper-menu-button {
+    background-color: transparent !important;
+}
+#paid-comment-background.ytd-comment-view-model {
+    background-color: transparent !important;
+}
+svg[id^="yt-ringo2"] :not([id^="youtube-paths"]) path:nth-child(1) {
+    fill: #ff0033 !important;
+}
+ytd-horizontal-card-list-renderer.ytd-structured-description-content-renderer:not(:first-child),
+ytd-metadata-row-container-renderer.ytd-structured-description-content-renderer:not(:first-child),
+ytd-structured-description-content-renderer[inline-structured-description] ytd-horizontal-card-list-renderer.ytd-structured-description-content-renderer,
+ytd-structured-description-content-renderer[inline-structured-description] ytd-error-corrections-section-renderer.ytd-structured-description-content-renderer,
+ytd-structured-description-content-renderer[inline-structured-description] ytd-video-description-infocards-section-renderer.ytd-structured-description-content-renderer {
+    border-top: 2px solid #888 !important;
+}
+.yt-spec-touch-feedback-shape__hover-effect,
+.ytd-rich-item-renderer-highlight {
+    background: ${rgb(221, 228, 235)} !important;
+}
+.yt-lockup-metadata-view-model__title {
+    color: ${rgb(16, 20, 25)} !important;
+}
+.yt-lockup-metadata-view-model__metadata {
+    color: ${rgb(79, 100, 122)} !important;
+}
+.ytd-rich-item-renderer-highlight[style*="box-shadow"][style*="0px 0px 0px 10px"] {
+    box-shadow: ${rgb(221, 228, 235)} 0px 0px 0px 10px !important;
+}
+ytd-watch-metadata[description-collapsed][enable-color-sampling] #description.ytd-watch-metadata:hover {
+    background: ${rgb(240, 247, 255)} !important;
+}
+ytd-watch-metadata[description-collapsed] #description.ytd-watch-metadata:hover {
+    background: ${rgb(255, 242, 240)} !important;
+}
+.ytdVolumeControlsNativeSlider::-webkit-slider-thumb {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.ytdVolumeControlsNativeSlider::-moz-range-thumb {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.ytp-delhi-modern.ytp-delhi-modern-icons .delhi-fast-follow-autonav-toggle .ytp-autonav-toggle-button[aria-checked=true] {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.ytLockupMetadataViewModelTitle[style*="color"] {
+    color: ${rgb(32, 32, 32)} !important;
+}
+.ytLockupMetadataViewModelMetadata[style*="color"] {
+    color: ${rgb(88, 88, 88)} !important;
+}
+[style*="--ytd-macro-markers-list-item-background-color"] {
+    --ytd-macro-markers-list-item-background-color: ${rgba(0, 0, 0, 0.05)} !important;
+}
+
+IGNORE INLINE STYLE
+yt-live-chat-ticker-paid-message-item-renderer *
+yt-live-chat-ticker-sponsor-item-renderer *
+#ytd-player + .efyt-control-bar > button path
+
+================================
+
+yscec.yonsei.ac.kr
+
+INVERT
+iframe
+#page-sidebar
+
+================================
+
+yume.wiki
+
+CSS
+.spoiler {
+    background-color: ${black} !important;
+    color: ${black} !important;
+}
+
+================================
+
+yuque.com
+
+INVERT
+.lake-math-content-preview-img > img
+.lake-math-container > img
+div[data-lake-card="mindmap"] > div > div > div
+
+================================
+
+zacznijzyc.net
+
+INVERT
+.logo_container
+
+================================
+
+zadania.info
+
+INVERT
+img.latex__math-inline
+img.math
+img.math-display
+
+================================
+
+zdic.net
+
+INVERT
+li a img
+.kxtimg
+.zipic img
+.zx img
+
+CSS
+.nr-box-header {
+    background-image: none !important;
+}
+
+================================
+
+zdw.krakow.pl
+
+CSS
+#kw-alert p,
+#kw-alert a {
+    color: initial !important;
+}
+
+================================
+
+zed.dev
+
+CSS
+.text-transparent {
+    color: var(--tw-gradient-from) !important;
+}
+
+================================
+
+zegna.com
+
+IGNORE INLINE STYLE
+.menu__logo svg
+
+================================
+
+zendesk.com
+
+CSS
+.zendesk-editor--rich-text-container {
+    background-image: none !important;
+}
+
+================================
+
+zenn.dev
+
+INVERT
+a[class^="AppHeader_homeLink"]
+
+CSS
+:root {
+    --c-bg-base: var(--darkreader-bg--c-bg-base) !important;
+    --c-bg-emoji: var(--darkreader-bg--c-bg-base);
+    --c-bg-neutral: var(--darkreader-bg--c-bg-neutral) !important;
+    --c-bg-primary-lighter: var(--darkreader-bg--c-bg-primary-lighter) !important;
+}
+
+================================
+
+zeptovm.com
+
+INVERT
+.logo
+
+================================
+
+zerohedge.com
+*.zerohedge.com
+
+INVERT
+header img
+
+================================
+
+zerossl.com
+
+INVERT
+.logo
+
+================================
+
+zfoh.ch
+
+INVERT
+main header img
+.partners a img
+.s43 a img
+
+================================
+
+zfsbootmenu.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
+zhihu.com
+
+INVERT
+img[eeimg="1"]
+
+CSS
+div.css-vurnku > div > div.css-1bi2006 {
+    background-color: ${darkgray} !important;
+}
+div.css-vurnku button {
+    color: ${darkblue} !important;
+}
+div.css-vurnku button svg {
+    fill: ${darkblue} !important;
+}
+div.Popover-content .Menu {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+zhihuishu.com
+
+INVERT
+img[class="kfformula"]
+
+================================
+
+zhixue.com
+
+INVERT
+.analysis_html_new [src]
+.hd2
+.hd3
+.ml15 [src]
+.subject-info [src]
+.subject-result [src]
+div.analysis-content [src]
+div.mt5
+#sideToolbar
+
+================================
+
+zi.tools
+
+INVERT
+button.ant-switch
+:not([aria-checked="true"]) > .ant-switch-inner
+img[src="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/home_svg/zi-tools.svg"]
+img[src^="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/icon_svg/"]
+img[src^="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/swjz/"]
+
+CSS
+[style*="color: rgba(0, 0, 0, 0)"] {
+    color: rgb(0 0 0 / 0) !important;
+}
+svg {
+    fill: currentColor;
+}
+
+================================
+
+zillow.com
+
+CSS
+#breakdown-panel .pie-chart svg g text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+zippyshare.com
+
+INVERT
+img#browse
+
+CSS
+.inner_main > table {
+    background-image: none !important;
+}
+
+================================
+
+zlidc.net
+
+INVERT
+#nav-logo
+
+================================
+
+znanium.com
+
+INVERT
+.bookreadimgs
+
+================================
+
+zohranfornyc.com
+
+INVERT
+.bg-background > .mb-4
+
+CSS
+.bg-\[url\(\/static\/images\/clipping\.svg\)\] {
+    background-image: none !important;
+}
+
+================================
+
+zonatmo.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
+zorin.com
+
+INVERT
+.logotype
+.social
+img[alt="GOG logo"]
+img[alt="Windows to Zorin OS"]
+
+================================
+
+zotero.org
+
+INVERT
+.brand
+
+================================
+
+zrzutka.pl
+
+INVERT
+.navbar-logo
+.rounded-circle
+
+================================
+
+zybooks.com
+learn.zybooks.com
+
+CSS
+.image-content-resource img,
+.zyimage {
+    background-color: var(--darkreader-neutral-text) !important;
+}


### PR DESCRIPTION
Scales the curated dark-mode registry without hand-writing each site. Parses a Dark Reader fix-config snapshot and resolves every `${color}` token through gjoa's **exact WCAG luminance flip** (engine-identical), emitting `override:active` + corrected CSS (DR's invert-then-correct model). **Print-by-default** so nothing ships unvalidated; `--write` merges after a human eyeball. `--selftest` proves the flip. Live registry untouched.