### PR TITLE
ci(windows): beagle checkout from HEAD, exclude con.clj (#53)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,14 +49,16 @@ jobs:
       # beagle has runtime/src/{dd,mk,pp}/con.clj — `con` is a Windows RESERVED
       # device name (NUL/PRN/AUX-class), so the OS itself can't create the file and
       # a normal checkout dies (exit 128, "invalid path"). They're test fixtures
-      # beagle-build doesn't need. Clone without a working tree, drop those 3 paths
-      # from the index, then materialize EVERYTHING ELSE via checkout-index.
+      # beagle-build doesn't need. Clone with NO working tree (which also leaves the
+      # index empty), then check out everything EXCEPT those 3 paths straight from
+      # HEAD via :(exclude) pathspecs — git never tries to write the reserved names.
       - name: Checkout beagle (sibling compiler)
         run: |
           git clone --no-checkout --depth 1 https://github.com/tompassarelli/beagle.git ../beagle
-          git -C ../beagle rm --cached -q --ignore-unmatch \
-            runtime/src/dd/con.clj runtime/src/mk/con.clj runtime/src/pp/con.clj
-          git -C ../beagle checkout-index -a -f
+          git -C ../beagle checkout HEAD -- . \
+            ':(exclude)runtime/src/dd/con.clj' \
+            ':(exclude)runtime/src/mk/con.clj' \
+            ':(exclude)runtime/src/pp/con.clj'
           test -f ../beagle/bin/beagle-build || { echo "beagle-build missing"; exit 1; }
           test -d ../beagle/beagle-lib || { echo "beagle-lib missing"; exit 1; }
           echo "beagle checked out: $(find ../beagle -name '*.rkt' | wc -l) .rkt, $(ls ../beagle/bin | wc -l) bin entries"


### PR DESCRIPTION
Third time's the charm. `clone --no-checkout` leaves the index empty (verified: 0 files), so `rm --cached`+`checkout-index` had nothing to write. Now `git checkout HEAD -- . ':(exclude)…con.clj'` reads from HEAD. Verified locally: beagle-build+beagle-lib+151 .rkt present, con.clj absent.