### PR TITLE
refactor(hygiene): guard!/quiet! macros, convert firefox dir (#54 batch 1)

### DIFF
--- a/src/gjoa/chrome/bjs/firefox/observers.bjs
+++ b/src/gjoa/chrome/bjs/firefox/observers.bjs
@@ -1,25 +1,20 @@
 #lang beagle/js
-(ns gjoa.firefox.observers)
+(ns gjoa.firefox.observers
+  (:require [gjoa.macros :refer [guard! quiet!]]))
 (define-mode strict)
 
 (declare-extern [Services console] Any)
 
 (js/export (defn on [topic :- String handler :- Any] :- Any
   (let [observer {:observe (fn [subject _topic data]
-                    (try
-                      (handler subject data)
-                      (catch Any e
-                        (.error console (str "gjoa obs handler " topic ":") e))))}]
-    (try
-      (.addObserver (.-obs Services) observer topic)
-      (catch Any _e nil))
+                    (guard! (str "gjoa obs handler " topic ":")
+                      (handler subject data)))}]
+    (quiet! nil
+      (.addObserver (.-obs Services) observer topic))
     (fn []
-      (try
-        (.removeObserver (.-obs Services) observer topic)
-        (catch Any _e nil))))))
+      (quiet! nil
+        (.removeObserver (.-obs Services) observer topic))))))
 
 (js/export (defn notify [topic :- String subject :- Any data :- Any] :- Any
-  (try
-    (.notifyObservers (.-obs Services) subject topic data)
-    (catch Any e
-      (.error console (str "gjoa obs notify " topic ":") e)))))
+  (guard! (str "gjoa obs notify " topic ":")
+    (.notifyObservers (.-obs Services) subject topic data))))

--- a/src/gjoa/chrome/bjs/firefox/prefs.bjs
+++ b/src/gjoa/chrome/bjs/firefox/prefs.bjs
@@ -1,7 +1,8 @@
 #lang beagle/js
 (ns gjoa.firefox.prefs
   (:require [gjoa.macros :refer [pref-bool pref-int pref-str
-                                 set-pref-bool! set-pref-int! set-pref-str!]]))
+                                 set-pref-bool! set-pref-int! set-pref-str!
+                                 guard! quiet!]]))
 (define-mode strict)
 
 (declare-extern [Services ChromeUtils console] Any)
@@ -26,40 +27,36 @@
 
 (js/export (defn migrate-legacy-prefs [] :- Any
   (let [root (.-prefs Services)]
-    (try
+    (quiet! nil
       (let [children (.getChildList (.getBranch root "pfx.") "" {})]
         (.forEach children (fn [suffix]
           (let [old-name (str "pfx." suffix)
                 new-name (str "gjoa." suffix)]
-            (try
+            (quiet! nil
               (when (not (.prefHasUserValue root new-name))
                 (let [type (.getPrefType root old-name)]
                   (cond
                     (= type 128) (.setBoolPref root new-name (.getBoolPref root old-name))
                     (= type 64)  (.setIntPref root new-name (.getIntPref root old-name))
                     (= type 32)  (.setStringPref root new-name (.getStringPref root old-name))
-                    :else nil)))
-              (catch Any _e nil))))))
-      (catch Any _e nil)))))
+                    :else nil))))))))))))
 
 (js/export (defn ensure-vertical-tabs-default [] :- Any
   (let [prefs (.-prefs Services)]
-    (try
+    (quiet! nil
       (when (not (.prefHasUserValue prefs "sidebar.verticalTabs"))
-        (.setBoolPref prefs "sidebar.verticalTabs" true))
-      (catch Any _e nil)))))
+        (.setBoolPref prefs "sidebar.verticalTabs" true))))))
 
 (js/export (defn migrate-toolbar-defaults [] :- Any
   (let [version (pref-int "gjoa.migration.toolbar" 0)]
     (when (< version 1)
-      (try
+      (guard! "gjoa: toolbar migration failed"
         (let [cui-mod (.importESModule ChromeUtils
                         "resource:///modules/CustomizableUI.sys.mjs")
               cui (.-CustomizableUI cui-mod)
               stripped ["fxa-toolbar-menu-button" "firefox-view-button" "alltabs-button"]]
           (.forEach stripped (fn [id]
-            (try (.removeWidgetFromArea cui id)
-                 (catch Any _e nil))))
+            (quiet! nil (.removeWidgetFromArea cui id))))
           (.removeValue (.-xulStore Services)
             "chrome://browser/content/browser.xhtml"
             "toolbar-menubar"
@@ -69,26 +66,19 @@
             "toolbar-menubar"
             "autohide"
             "false")
-          (set-pref-int! "gjoa.migration.toolbar" 1))
-        (catch Any e
-          (.error console "gjoa: toolbar migration failed" e)))))))
+          (set-pref-int! "gjoa.migration.toolbar" 1)))))))
 
 (js/export (defn apply-menubar-default [doc :- Any] :- Any
-  (try
+  (quiet! nil
     (let [mb (.getElementById doc "toolbar-menubar")]
-      (when mb (.setAttribute mb "autohide" "false")))
-    (catch Any _e nil))))
+      (when mb (.setAttribute mb "autohide" "false"))))))
 
 (js/export (defn observe [name :- String handler :- Any] :- Any
   (let [observer {:observe (fn [_subject _topic data]
-                    (try
-                      (handler data)
-                      (catch Any e
-                        (.error console (str "gjoa prefs observer " name ":") e))))}]
-    (try
-      (.addObserver (.-prefs Services) name observer)
-      (catch Any _e nil))
+                    (guard! (str "gjoa prefs observer " name ":")
+                      (handler data)))}]
+    (quiet! nil
+      (.addObserver (.-prefs Services) name observer))
     (fn []
-      (try
-        (.removeObserver (.-prefs Services) name observer)
-        (catch Any _e nil))))))
+      (quiet! nil
+        (.removeObserver (.-prefs Services) name observer))))))

--- a/src/gjoa/chrome/bjs/macros.bjs
+++ b/src/gjoa/chrome/bjs/macros.bjs
@@ -104,3 +104,15 @@
   `(.querySelector ,el ,sel))
 (defmacro qa [el sel]
   `(.querySelectorAll ,el ,sel))
+;; ---- error handling ----
+;; guard!: run body, log+swallow any throw. quiet!: run body, swallow silently
+;; and return `fallback`. Both expand to primitives (try/do/catch) — `console`
+;; resolves at the USE SITE (non-hygienic syntax-quote; see the mi/sep note
+;; above), so the calling fn must have `console` in scope. The wrapping fn stays
+;; effectful — keep its `!` (E019).
+(defmacro guard! [label & body]
+  `(try (do ,@body)
+        (catch Any _e (.error console ,label _e))))
+(defmacro quiet! [fallback & body]
+  `(try (do ,@body)
+        (catch Any _e ,fallback)))


### PR DESCRIPTION
First slice of the #54 hygiene plan (macro-utilization).

- **macros.bjs**: `guard!`/`quiet!` — try/catch wrappers (log+swallow / silent+fallback), expanding to primitives.
- **firefox/prefs.bjs** (9 sites), **firefox/observers.bjs** (4 sites): converted to the macros, behavior-preserving.
- **security/index.bjs**: stale 'rebuild next Sunday' string fixed (Sunday rule rescinded).

Validated: `beagle check` 0 errors (115 files), fast integration lane **57 pass / 0 fail**.

Deferred to batch 2: `last-of` + its tabs call sites; `guard!`/`quiet!` propagation to dark-mode/blocking/loader; the §2 shared-helper extractions. Riskier §5 items (decompositions) stay deliberate.