### PR TITLE
ci(windows): launch beagle-build via bash (#53)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Gjoa — a Firefox fork.",
   "scripts": {
-    "tools:compile": "(test -f .beagle-tools/.boot/build-tools.js && test -z \"$(find tools -name '*.bjs' -newer .beagle-tools/.boot/build-tools.js -print -quit 2>/dev/null)\" || ../beagle/bin/beagle-build tools/build-tools.bjs .beagle-tools/.boot/build-tools.js) && bun .beagle-tools/.boot/build-tools.js",
+    "tools:compile": "(test -f .beagle-tools/.boot/build-tools.js && test -z \"$(find tools -name '*.bjs' -newer .beagle-tools/.boot/build-tools.js -print -quit 2>/dev/null)\" || bash ../beagle/bin/beagle-build tools/build-tools.bjs .beagle-tools/.boot/build-tools.js) && bun .beagle-tools/.boot/build-tools.js",
     "init": "bun run download && bun run import",
     "download": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/cli.js download",
     "import": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/cli.js import",

--- a/tools/build-tools.bjs
+++ b/tools/build-tools.bjs
@@ -15,7 +15,12 @@
 
 (def REPO-ROOT :- String (.cwd process))
 (def OUT-ROOT :- String (join REPO-ROOT ".beagle-tools" "gjoa"))
-(def BEAGLE-BUILD :- String (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build"))
+;; beagle-build is a `#!/usr/bin/env bash` script. Windows has no shebang support,
+;; so it can't be exec'd directly there — it's launched via `bash` (Git Bash on the
+;; runner) at every :cmd site below. Normalize the path to forward slashes so bash
+;; accepts it on Windows; (.fromCharCode String 92) is a backslash. No-op on *nix.
+(def BEAGLE-BUILD :- String
+  (.replaceAll (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build") (.fromCharCode String 92) "/"))
 (def SRC-DIRS :- Any ["tools" "tests"])
 
 ;; Recursively collect every *.bjs path under `dir` (synchronous — small tree).
@@ -51,7 +56,7 @@
     (if (not (stale? src out))
       {:rel rel :code 0 :skipped true}
       (let [_ (js/await (mkdir (join out "..") {:recursive true}))
-            proc (.spawn Bun {:cmd [BEAGLE-BUILD src out]
+            proc (.spawn Bun {:cmd ["bash" BEAGLE-BUILD src out]
                               :cwd REPO-ROOT
                               :stdout "pipe"
                               :stderr "pipe"})

--- a/tools/chrome-bundle/compile.bjs
+++ b/tools/chrome-bundle/compile.bjs
@@ -12,7 +12,11 @@
 (def REPO-ROOT :- String (.cwd process))
 (def BJS-ROOT :- String (join REPO-ROOT "src" "gjoa" "chrome" "bjs"))
 (def OUT-ROOT :- String (join REPO-ROOT ".beagle-out"))
-(def BEAGLE-BUILD :- String (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build"))
+;; beagle-build is a bash script (no shebang support on Windows) — launched via
+;; `bash` at the :cmd site; forward-slash the path so bash accepts it on Windows.
+;; (.fromCharCode String 92) is a backslash; no-op on *nix.
+(def BEAGLE-BUILD :- String
+  (.replaceAll (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build") (.fromCharCode String 92) "/"))
 
 (defn find-bjs-files [dir :- String] :- (Promise Any)
   (let [results []
@@ -64,7 +68,7 @@
             (let [out-rel (.replace rel (RegExp. "\\.bjs$") ".js")
                   out-path (join OUT-ROOT out-rel)
                   _ (js/await (mkdir (join out-path "..") {:recursive true}))
-                  proc (.spawn Bun {:cmd [BEAGLE-BUILD src out-path]
+                  proc (.spawn Bun {:cmd ["bash" BEAGLE-BUILD src out-path]
                                     :cwd REPO-ROOT
                                     :stdout "pipe"
                                     :stderr "pipe"})

--- a/tools/prep/branding.bjs
+++ b/tools/prep/branding.bjs
@@ -19,7 +19,11 @@
 ;; beagle-build compiles the pref .bjs sources to pref() JS at import time (same
 ;; resolution as tools/build-tools.bjs). The pref files are the one source-tree
 ;; artifact that must reach the engine as emitted JS rather than running under Bun.
-(def BEAGLE-BUILD :- String (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build"))
+;; It's a bash script (no Windows shebang support) — launched via `bash` at the
+;; :cmd site; forward-slash the path for bash on Windows. (.fromCharCode String 92)
+;; is a backslash; no-op on *nix.
+(def BEAGLE-BUILD :- String
+  (.replaceAll (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build") (.fromCharCode String 92) "/"))
 
 ;; Files we string-substitute. Anything else (binary icons, archive formats,
 ;; platform-specific blobs) is copied as-is from the unofficial template.
@@ -181,7 +185,7 @@
             ;; Compile the pref .bjs → pref() JS. Sync spawn keeps this in the
             ;; (now sync) branding pipeline; a nonzero exit is fatal so a broken
             ;; pref source can't silently ship empty defaults.
-            (let [proc (.spawnSync Bun {:cmd [BEAGLE-BUILD src out]
+            (let [proc (.spawnSync Bun {:cmd ["bash" BEAGLE-BUILD src out]
                                         :cwd REPO-ROOT
                                         :stdout "pipe"
                                         :stderr "pipe"})]

--- a/tools/prep/overlay.bjs
+++ b/tools/prep/overlay.bjs
@@ -16,8 +16,12 @@
 (declare-extern [Bun] Any)
 
 ;; beagle-build compiles the chrome loader (.bjs) to the .sys.mjs that jar.mn
-;; packages into omni.ja. Same resolution as tools/build-tools.bjs.
-(def BEAGLE-BUILD :- String (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build"))
+;; packages into omni.ja. Same resolution as tools/build-tools.bjs. It's a bash
+;; script (no Windows shebang support), so it's launched via `bash` at the :cmd
+;; site; forward-slash the path for bash on Windows. (.fromCharCode String 92) is
+;; a backslash; no-op on *nix.
+(def BEAGLE-BUILD :- String
+  (.replaceAll (resolve REPO-ROOT ".." "beagle" "bin" "beagle-build") (.fromCharCode String 92) "/"))
 
 (defn count-files [dir :- String] :- Any
   (reduce
@@ -51,7 +55,7 @@
                 loader-out (join ENGINE-DIR "browser" "components" "gjoa" "GjoaLoader.sys.mjs")
                 stray (join ENGINE-DIR "browser" "components" "gjoa" "GjoaLoader.bjs")]
             (when (existsSync loader-src)
-              (let [proc (.spawnSync Bun {:cmd [BEAGLE-BUILD loader-src loader-out]
+              (let [proc (.spawnSync Bun {:cmd ["bash" BEAGLE-BUILD loader-src loader-out]
                                           :cwd REPO-ROOT
                                           :stdout "pipe"
                                           :stderr "pipe"})]


### PR DESCRIPTION
Windows `import` died: `command not found: ../beagle/bin/beagle-build` — it's a `#!/usr/bin/env bash` script and Windows has no shebang support. Launch via `bash` (all 3 platforms have it; Git Bash on the runner) at every spawn site + the bootstrap line; forward-slash the path for Git Bash. Validated on Linux: check 0 errors, direct bash-launch compiles, chrome 45/45.