### PR TITLE
ci(windows): force LF line endings so patches apply (#53)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# gjoa is authored on Linux/macOS — everything is LF. Force LF on checkout on
+# every platform so the Windows CI build never gets CRLF: CRLF breaks `git apply`
+# of our LF patches (patch context mismatch → "patch does not apply") and would
+# feed CRLF line endings into the Firefox build. Binary files (icons, archives)
+# are auto-detected by `text=auto` and left untouched.
+* text=auto eol=lf
+
+# Belt-and-suspenders for the files that MUST stay LF for the build to work.
+*.patch  text eol=lf
+*.bjs    text eol=lf
+*.sh     text eol=lf

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,6 +17,16 @@ jobs:
       run:
         shell: bash
     steps:
+      # Windows git defaults to autocrlf=true, which rewrites LF→CRLF on checkout.
+      # That breaks `git apply` of our LF patches (context mismatch) and feeds CRLF
+      # into the build. Force LF BEFORE checkout so both the gjoa repo and (later)
+      # the tar-extracted engine source stay LF. .gitattributes (eol=lf) is the
+      # committed belt; this covers engine/, which has no .gitattributes of ours.
+      - name: Force LF line endings (Windows git defaults to autocrlf)
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@v4
 
       - name: Install bun


### PR DESCRIPTION
Windows import got all the way to patch-apply, then failed: `patch does not apply` on browser/components/moz.build. Root cause: Windows git `autocrlf=true` rewrites our LF patches + source to CRLF on checkout → `git apply` context mismatch. Fix: committed `.gitattributes` (`* text=auto eol=lf`) + `core.autocrlf=false` before checkout (covers tar-extracted engine/). Linux/macOS unaffected.