### PR TITLE
security: full audit remediation — harden the gjoa delta (F1-F11 + I3)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -61,6 +61,25 @@ jobs:
             "https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/source/firefox-${FF_VERSION}.source.tar.xz"
           ls -lh ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz
 
+      # F9 hardening: verify the downloaded tarball against the IN-REPO pinned
+      # SHA-256 (configs/firefox-${FF_VERSION}.sha256) BEFORE extracting. The
+      # pin is committed + reviewed, so unlike a same-origin SHA256SUMS it can't
+      # be swapped by an origin/TLS compromise. Compare the computed hash to the
+      # pinned value (first field of the pin file) — path-independent.
+      - name: Verify tarball checksum (pinned)
+        run: |
+          PIN="configs/firefox-${FF_VERSION}.sha256"
+          test -f "$PIN" || { echo "missing pinned checksum: $PIN"; exit 1; }
+          expected=$(grep -v '^#' "$PIN" | awk 'NF{print $1; exit}')
+          actual=$(sha256sum ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz | awk '{print $1}')
+          echo "expected: $expected"
+          echo "actual:   $actual"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Firefox tarball SHA-256 does not match pinned value in $PIN"
+            exit 1
+          fi
+          echo "tarball checksum OK (matches pinned $PIN)"
+
       - name: Extract source
         run: |
           mkdir -p engine

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,6 +30,25 @@ jobs:
             "https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/source/firefox-${FF_VERSION}.source.tar.xz"
           ls -lh ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz
 
+      # F9 hardening: verify the downloaded tarball against the IN-REPO pinned
+      # SHA-256 (configs/firefox-${FF_VERSION}.sha256) BEFORE extracting. The
+      # pin is committed + reviewed, so unlike a same-origin SHA256SUMS it can't
+      # be swapped by an origin/TLS compromise. macOS ships `shasum`, not
+      # `sha256sum`; compare the computed hash to the pinned value.
+      - name: Verify tarball checksum (pinned)
+        run: |
+          PIN="configs/firefox-${FF_VERSION}.sha256"
+          test -f "$PIN" || { echo "missing pinned checksum: $PIN"; exit 1; }
+          expected=$(grep -v '^#' "$PIN" | awk 'NF{print $1; exit}')
+          actual=$(shasum -a 256 ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz | awk '{print $1}')
+          echo "expected: $expected"
+          echo "actual:   $actual"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Firefox tarball SHA-256 does not match pinned value in $PIN"
+            exit 1
+          fi
+          echo "tarball checksum OK (matches pinned $PIN)"
+
       - name: Extract source
         run: |
           mkdir -p engine

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,6 +44,25 @@ jobs:
             "https://archive.mozilla.org/pub/firefox/releases/${FF_VERSION}/source/firefox-${FF_VERSION}.source.tar.xz"
           ls -lh ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz
 
+      # F9 hardening: verify the downloaded tarball against the IN-REPO pinned
+      # SHA-256 (configs/firefox-${FF_VERSION}.sha256) BEFORE extracting. The
+      # pin is committed + reviewed, so unlike a same-origin SHA256SUMS it can't
+      # be swapped by an origin/TLS compromise. The job runs under Git-bash,
+      # which provides sha256sum; compare to the pinned value.
+      - name: Verify tarball checksum (pinned)
+        run: |
+          PIN="configs/firefox-${FF_VERSION}.sha256"
+          test -f "$PIN" || { echo "missing pinned checksum: $PIN"; exit 1; }
+          expected=$(grep -v '^#' "$PIN" | awk 'NF{print $1; exit}')
+          actual=$(sha256sum ~/.cache/gjoa/sources/firefox-${FF_VERSION}.source.tar.xz | awk '{print $1}')
+          echo "expected: $expected"
+          echo "actual:   $actual"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Firefox tarball SHA-256 does not match pinned value in $PIN"
+            exit 1
+          fi
+          echo "tarball checksum OK (matches pinned $PIN)"
+
       - name: Extract source
         run: |
           mkdir -p engine

--- a/bin/gjoa
+++ b/bin/gjoa
@@ -71,5 +71,11 @@ echo "→ refreshing chrome bundle" >&2
 bun run chrome:dist >&2
 bun run chrome:install >&2
 
+# Dev chrome loads from the gjoa-dev/ symlink (refreshed just above) only when
+# the F4 opt-in gate is set (GjoaLoader.dev-mode-dir). This IS the dev launcher,
+# so opt in — otherwise the binary silently falls back to baked omni.ja chrome
+# and the `gjoa sync` hot-reload loop stops working.
+export GJOA_DEV_LOADER=1
+
 echo "→ launching $BIN" >&2
 exec "$BIN" "$@"

--- a/configs/firefox-152.0.sha256
+++ b/configs/firefox-152.0.sha256
@@ -1,0 +1,14 @@
+# Pinned SHA-256 of the Firefox source tarball for FF_VERSION 152.0.
+#
+# This is an in-repo trust anchor (committed, reviewed) that is INDEPENDENT of
+# the live SHA256SUMS Mozilla serves from the same origin as the tarball. The
+# download/verify path asserts the live checksum against THIS pinned value, so
+# an origin/TLS compromise that serves a backdoored tarball + matching
+# SHA256SUMS still fails verification (the attacker cannot change this file).
+#
+# Format is `sha256sum -c` compatible: `<hash>  <path-as-listed-in-SHA256SUMS>`.
+# To bump FF_VERSION: add a configs/firefox-<version>.sha256 with the value from
+# https://archive.mozilla.org/pub/firefox/releases/<version>/SHA256SUMS, after
+# verifying that file's GPG signature (SHA256SUMS.asc) against Mozilla's
+# release-signing key fingerprint 14F26682D0916CDD81E37B6D61B7B526D98F0353.
+5e5f9acb550d065a43934e0fcd11ed3ec22f7266fc9ad63df757406b432a5127  source/firefox-152.0.source.tar.xz

--- a/patches/0008-content-classifier-cosmetic-filtering.patch
+++ b/patches/0008-content-classifier-cosmetic-filtering.patch
@@ -91,7 +91,7 @@ index 8ea4179418..c69193e525 100644
  NS_IMETHODIMP ContentClassifierService::RemoveFilterList(
      const nsACString& aName) {
    MOZ_ASSERT(NS_IsMainThread());
-@@ -554,6 +585,97 @@ NS_IMETHODIMP ContentClassifierService::ApplyFilterLists() {
+@@ -554,6 +585,109 @@ NS_IMETHODIMP ContentClassifierService::ApplyFilterLists() {
    return NS_OK;
  }
  
@@ -106,6 +106,12 @@ index 8ea4179418..c69193e525 100644
 +  aExceptions.Clear();
 +  aInjectedScript.Truncate();
 +  *aGenericHide = false;
++
++  // GetSingleton() (the JS-facing component-manager constructor) does not gate
++  // on the enabled pref the way GetInstance() does, so re-check it here.
++  if (!IsEnabled()) {
++    return NS_ERROR_NOT_INITIALIZED;
++  }
 +
 +  MutexAutoLock lock(mLock);
 +  if (mInitPhase != InitPhase::InitSucceeded) {
@@ -162,6 +168,12 @@ index 8ea4179418..c69193e525 100644
 +    const nsTArray<nsCString>& aClasses, const nsTArray<nsCString>& aIds,
 +    const nsTArray<nsCString>& aExceptions, nsTArray<nsCString>& aSelectors) {
 +  aSelectors.Clear();
++
++  // GetSingleton() (the JS-facing component-manager constructor) does not gate
++  // on the enabled pref the way GetInstance() does, so re-check it here.
++  if (!IsEnabled()) {
++    return NS_ERROR_NOT_INITIALIZED;
++  }
 +
 +  MutexAutoLock lock(mLock);
 +  if (mInitPhase != InitPhase::InitSucceeded) {

--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -99,21 +99,21 @@
     (or (.get (.-env Services) name) "")
     (catch Any _e "")))
 
-;; F4 defense-in-depth: a dev-source dir is trustworthy only if it is NOT group-
-;; or other-writable, so another local user can't drop/redirect scripts into the
-;; dev tree. The mach dev loop deliberately makes gjoa-dev a user-owned SYMLINK
-;; to dist/chrome (tools/chrome-bundle/install.bjs), so we must not reject
-;; symlinks outright — instead we check both the resolved target's mode (STAT, via
-;; .permissions) AND the link node's own mode (LSTAT, via .permissionsOfLink), so
-;; an attacker-writable symlink node is refused even if its current target looks
-;; safe. nsIFile exposes no scriptable owner uid, so we approximate "owned by the
-;; running user" by refusing any non-user-writable mode bits. Any read throwing →
-;; treat as unsafe. (Full belt = the deferred MOZ_GJOA_DEV_LOADER compile-out.)
+;; F4 defense-in-depth: the resolved dev-source dir must not be group/other-
+;; writable, so another local user can't drop/redirect scripts into the dev tree.
+;; `.permissions` is the STAT mode of the *resolved* dir, so this works whether
+;; gjoa-dev is a real dir or the user-owned symlink the mach dev loop creates
+;; (tools/chrome-bundle/install.bjs). We deliberately do NOT check the symlink
+;; node's own mode: on Linux a symlink is always 0777 (the kernel ignores link
+;; mode bits), so an LSTAT check would both break the legit dev symlink AND add
+;; no security — who can REPLACE the link is gated by the parent dir's bits, not
+;; the link's. The opt-in GJOA_DEV_LOADER=1 gate above is the primary defense;
+;; this is belt on the target. (Full belt = the deferred MOZ_GJOA_DEV_LOADER
+;; compile-out.) Any read throwing → treat as unsafe.
 (defn dev-dir-safe? [dir :- Any] :- Boolean
   (try
     ;; 0o022 = group-write | other-write.
-    (and (= (bit-and (.-permissions dir) 0o022) 0)        ;; resolved target (STAT)
-         (= (bit-and (.-permissionsOfLink dir) 0o022) 0)) ;; link node itself (LSTAT)
+    (= (bit-and (.-permissions dir) 0o022) 0)
     (catch Any _e false)))
 
 ;; Returns the dev-mode source directory if dev loading is explicitly enabled

--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -19,7 +19,7 @@
 ;;   chrome JS. No user-writable script directory exists; no hash-pinning
 ;;   needed because there's nothing to tamper with.
 ;;
-;; DEV MODE (<install_root>/gjoa-dev/ directory present):
+;; DEV MODE (opt-in via GJOA_DEV_LOADER=1 AND <install_root>/gjoa-dev/ present):
 ;;   The loader reads .uc.js / .uc.css files from <install_root>/gjoa-dev/
 ;;   directly at startup. Used for sub-second iteration on chrome JS without
 ;;   re-running mach build. Trust boundary: anyone who can write to the
@@ -28,11 +28,23 @@
 ;;   root can replace the binary" — same threat boundary, no new attack
 ;;   surface.
 ;;
-;; PRODUCTION HARDENING (deferred — see Stretch goal):
-;;   For shipped release builds, dev mode should be compiled out via a
-;;   build flag (e.g. MOZ_GJOA_DEV_LOADER=0). Even though the dev path
-;;   only triggers when <install_root>/gjoa-dev/ exists, defense-in-depth
-;;   says don't compile in code paths your release doesn't need.
+;;   F4 HARDENING (this file): the dev path is gated so it cannot activate by
+;;   accident or via a dropped directory in a RELEASE build:
+;;     1. OPT-IN — `dev-mode-dir` returns nil unless GJOA_DEV_LOADER=1 is set
+;;        in the environment, EVEN IF gjoa-dev/ exists. A dropped directory
+;;        alone is inert.
+;;     2. DEFENSE-IN-DEPTH — when the dir IS used, it must be a real (non-
+;;        symlink) directory that is NOT group- or other-writable
+;;        (permissions & 0o022 == 0). A symlinked or world/group-writable
+;;        gjoa-dev/ is refused (return nil → production fallback), so another
+;;        local user cannot drop or redirect scripts into a dev tree.
+;;
+;; PRODUCTION HARDENING (deferred — full belt is the compile-out):
+;;   The complete fix is to compile the dev path out of shipped release
+;;   builds entirely via a build flag (MOZ_GJOA_DEV_LOADER=0), so the code
+;;   path does not exist in the binary at all — defense-in-depth says don't
+;;   compile in code paths your release doesn't need. The runtime gate above
+;;   is the interim guard until that compile-out lands.
 ;;
 ;; =============================================================================
 ;; IMPLEMENTATION
@@ -79,13 +91,46 @@
 
 ;; --- Source resolution -------------------------------------------------------
 
-;; Returns the dev-mode source directory if it exists, else nil.
+;; Reads an environment variable, returning "" if unset or on any failure.
+;; Matches the gjoa.security pattern; nsIEnvironment.get never throws for a
+;; missing var but we stay defensive.
+(defn dev-env [name :- String] :- String
+  (try
+    (or (.get (.-env Services) name) "")
+    (catch Any _e "")))
+
+;; F4 defense-in-depth: a dev-source dir is trustworthy only if it is NOT group-
+;; or other-writable, so another local user can't drop/redirect scripts into the
+;; dev tree. The mach dev loop deliberately makes gjoa-dev a user-owned SYMLINK
+;; to dist/chrome (tools/chrome-bundle/install.bjs), so we must not reject
+;; symlinks outright — instead we check both the resolved target's mode (STAT, via
+;; .permissions) AND the link node's own mode (LSTAT, via .permissionsOfLink), so
+;; an attacker-writable symlink node is refused even if its current target looks
+;; safe. nsIFile exposes no scriptable owner uid, so we approximate "owned by the
+;; running user" by refusing any non-user-writable mode bits. Any read throwing →
+;; treat as unsafe. (Full belt = the deferred MOZ_GJOA_DEV_LOADER compile-out.)
+(defn dev-dir-safe? [dir :- Any] :- Boolean
+  (try
+    ;; 0o022 = group-write | other-write.
+    (and (= (bit-and (.-permissions dir) 0o022) 0)        ;; resolved target (STAT)
+         (= (bit-and (.-permissionsOfLink dir) 0o022) 0)) ;; link node itself (LSTAT)
+    (catch Any _e false)))
+
+;; Returns the dev-mode source directory if dev loading is explicitly enabled
+;; AND the dir exists AND passes the safety check, else nil.
 ;; Convention: <install_root>/gjoa-dev/{JS,CSS}/*.uc.{js,css}
 (defn dev-mode-dir [] :- Any
-  ;; GreD = Gecko runtime directory = the install root containing the binary.
-  (let [dir (.get (.-dirsvc Services) "GreD" (.-nsIFile Ci))]
-    (.append dir "gjoa-dev")
-    (if (and (.exists dir) (.isDirectory dir)) dir nil)))
+  ;; OPT-IN GATE: never source dev chrome unless GJOA_DEV_LOADER=1. A dropped
+  ;; gjoa-dev/ directory is inert without this env var, so the full-chrome-
+  ;; privilege dev path cannot activate by accident in a release build. The
+  ;; deferred full belt is the MOZ_GJOA_DEV_LOADER compile-out (see SECURITY
+  ;; MODEL above); this runtime gate is the interim guard.
+  (if (not= (dev-env "GJOA_DEV_LOADER") "1")
+    nil
+    ;; GreD = Gecko runtime directory = the install root containing the binary.
+    (let [dir (.get (.-dirsvc Services) "GreD" (.-nsIFile Ci))]
+      (.append dir "gjoa-dev")
+      (if (and (.exists dir) (.isDirectory dir) (dev-dir-safe? dir)) dir nil))))
 
 (defn list-files [dir :- Any suffix :- String] :- Any
   (let [out []]

--- a/src/gjoa/chrome/bjs/security/index.bjs
+++ b/src/gjoa/chrome/bjs/security/index.bjs
@@ -105,7 +105,7 @@
                     (.warn console
                       (str "[security] STALE: running " my-version
                            ", latest is " latest
-                           " (same major, point behind) — gjoa status will show STALE; queue a rebuild for next Sunday"))))))))))
+                           " (same major, point behind) — gjoa status will show STALE; rebuild when convenient"))))))))))
         (.catch (fn [e]
           (if (= (.-confirmed-at state) 0)
             (.warn console

--- a/src/gjoa/chrome/bjs/security/index.bjs
+++ b/src/gjoa/chrome/bjs/security/index.bjs
@@ -2,7 +2,7 @@
 (ns gjoa.security.index)
 (define-mode strict)
 
-(declare-extern [Services console fetch AbortSignal setTimeout setInterval parseInt RegExp Error] Any)
+(declare-extern [Services console fetch AbortSignal setTimeout setInterval parseInt RegExp Error Date] Any)
 
 (def PRODUCT-DETAILS-URL :- String
   "https://product-details.mozilla.org/1.0/firefox_versions.json")
@@ -10,6 +10,11 @@
 (def RECHECK-INTERVAL-MS :- Int (* 60 60 1000))
 
 (def FETCH-TIMEOUT-MS :- Int 8000)
+
+;; Shape guard for the upstream LATEST_FIREFOX_VERSION field: a bare dotted
+;; numeric (e.g. "152", "152.0", "152.0.1"). Anything else (HTML error page,
+;; "152.0esr", garbage) is rejected before it reaches parse-version / newer?.
+(def VERSION-RE :- Any (RegExp. "^\\d+(\\.\\d+){0,2}$"))
 
 (defn parse-version [v :- String] :- Any
   (let [cleaned (.trim (.replace v (RegExp. "esr$" "i") ""))
@@ -30,7 +35,12 @@
     (or (.get (.-env Services) name) "")
     (catch Any _e "")))
 
-(def state :- Any {:quitting false})
+;; :confirmed-at — epoch-ms of the last probe that actually read a well-formed
+;; LATEST_FIREFOX_VERSION from upstream (0 = never since launch). Lets the
+;; fail-open offline path distinguish "transiently offline after a good probe"
+;; from "never once confirmed this session" — a persistently-suppressed probe
+;; that would otherwise be silently indistinguishable from being up to date.
+(def state :- Any {:quitting false :confirmed-at 0})
 
 (defn quit-stale! [my-version :- String latest-version :- String] :- Any
   (when (not (.-quitting state))
@@ -67,10 +77,21 @@
           (.json r)))
         (.then (fn [j]
           (let [latest (or (.-LATEST_FIREFOX_VERSION j) nil)]
-            (when latest
-              (if (not (newer? my-version latest))
-                (.log console (str "[security] OK — " my-version
-                                   " matches or exceeds latest stable " latest))
+            (cond
+              (not latest)
+              (.warn console "[security] probe response missing LATEST_FIREFOX_VERSION — ignoring")
+
+              (not (.test VERSION-RE latest))
+              (.warn console
+                (str "[security] probe returned malformed LATEST_FIREFOX_VERSION ("
+                     latest ") — ignoring (expected bare dotted numeric)"))
+
+              :else
+              (do
+                (set! (.-confirmed-at state) (.now Date))
+                (if (not (newer? my-version latest))
+                  (.log console (str "[security] OK — " my-version
+                                     " matches or exceeds latest stable " latest))
                 (let [my (parse-version my-version)
                       up (parse-version latest)
                       major-behind (- (aget up 0) (aget my 0))]
@@ -84,9 +105,14 @@
                     (.warn console
                       (str "[security] STALE: running " my-version
                            ", latest is " latest
-                           " (same major, point behind) — gjoa status will show STALE; queue a rebuild for next Sunday")))))))))
+                           " (same major, point behind) — gjoa status will show STALE; queue a rebuild for next Sunday"))))))))))
         (.catch (fn [e]
-          (.log console "[security] probe failed — fail-open (offline?):" (.-message e)))))))
+          (if (= (.-confirmed-at state) 0)
+            (.warn console
+              (str "[security] probe failed and has NEVER confirmed current since launch"
+                   " — staleness is UNVERIFIED, not known-good (fail-open):")
+              (.-message e))
+            (.log console "[security] probe failed — fail-open (offline?, last confirmed current earlier this session):" (.-message e))))))))
 
 ;; init
 (defn init-! [] :- Any

--- a/src/gjoa/defaults/pref/adblock-prefs.bjs
+++ b/src/gjoa/defaults/pref/adblock-prefs.bjs
@@ -32,5 +32,10 @@
 (pref "gjoa.contentblock.enabled" true)
 (pref "gjoa.contentblock.user.allow-hosts" "")
 
+;; Curated-only scriptlet policy (security finding F2). When false (default), only
+;; gjoa's hand-vetted curated scriptlets run; the engine's general list-driven
+;; `+js()` expansion (arbitrary uBO-list JS into the page main world) stays OFF.
+(pref "gjoa.contentblock.scriptlets.listDriven.enabled" false)
+
 ;; Keep the overlay's logging quiet by default (Error/Warn only).
 (pref "privacy.trackingprotection.content.remote_settings.loglevel" "Warn")

--- a/src/gjoa/defaults/pref/perf-prefs.bjs
+++ b/src/gjoa/defaults/pref/perf-prefs.bjs
@@ -40,7 +40,6 @@
 (pref "browser.discovery.enabled" false)
 (pref "app.normandy.enabled" false)
 (pref "app.shield.optoutstudies.enabled" false)
-(pref "browser.safebrowsing.downloads.remote.enabled" false)
 
 ;; --- Networking: SPEED-positive ---
 ;; Firefox ships prefetch / DNS-prefetch / speculative-connect ON. They were

--- a/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
@@ -75,6 +75,35 @@ const ALLOW_LIST_NAME = "gjoa-allow";
 // Refresh a cached list when older than this (EasyList itself expires in 4 days).
 const STALE_MS = 4 * 24 * 60 * 60 * 1000;
 
+// F1 list-integrity hardening ----------------------------------------------
+// These lists are fetched off the network and fed verbatim to the in-process
+// adblock-rust engine. The pipeline below adds integrity controls so a
+// network/MITM attacker or a tampered profile-cache file cannot smuggle
+// arbitrary bytes into the engine:
+//   - transport: every list URL must be https:// (rejected otherwise);
+//   - size cap: refuse responses larger than MAX_LIST_BYTES before writing;
+//   - shape check: the body must look like a UTF-8 text filter list, not
+//     HTML/binary (a captive-portal/error page or a swapped binary blob);
+//   - at-rest integrity: a SHA-256 of each fetched list is persisted in a
+//     sidecar file; on cache read-back the digest is recomputed and must match
+//     before the bytes reach setFilterListData — a mismatch means the cache was
+//     tampered with (or partially written), so it is treated as untrusted and
+//     re-fetched/skipped, never fed to the engine.
+//
+// RESIDUAL (documented, separate follow-up): these controls bound *transport*
+// and *at-rest* tampering only. A compromised list ORIGIN (or an attacker who
+// controls the upstream repo) can still serve a malicious-but-well-formed
+// filter list. That risk is bounded today by the permission-mask gate
+// (ParseOptions PermissionMask stays 0, so scriptlet/redirect permissions are
+// not granted from these untrusted lists) and is to be closed separately by
+// bundling reviewed list snapshots and pinning/known-good digests.
+//
+// 32 MiB: comfortably above the largest real list (EasyList+uBO are a few MiB)
+// while bounding memory + the digest cost on a hostile response.
+const MAX_LIST_BYTES = 32 * 1024 * 1024;
+// Sidecar file holding the hex SHA-256 of the cached `<name>.txt`.
+const DIGEST_SUFFIX = ".sha256";
+
 /**
  * gjoa's drop-in replacement for the content-classifier RemoteSettings client.
  * Registered under @mozilla.org/content-classifier-rs-client;1 (components.conf,
@@ -153,6 +182,51 @@ export class ContentClassifierRemoteSettingsClient {
     return PathUtils.join(prof, CACHE_DIR);
   }
 
+  #digestPath(path) {
+    return path + DIGEST_SUFFIX;
+  }
+
+  // SHA-256 of raw bytes as lowercase hex. `crypto.subtle` is not reliably
+  // available in a privileged .sys.mjs, so use nsICryptoHash directly.
+  #sha256Hex(bytes) {
+    const hasher = Cc["@mozilla.org/security/hash;1"].createInstance(
+      Ci.nsICryptoHash
+    );
+    hasher.init(Ci.nsICryptoHash.SHA256);
+    hasher.update(bytes, bytes.length);
+    const digest = hasher.finish(false);
+    let hex = "";
+    for (let i = 0; i < digest.length; i++) {
+      hex += digest.charCodeAt(i).toString(16).padStart(2, "0");
+    }
+    return hex;
+  }
+
+  // A genuine text filter list is valid UTF-8 and is overwhelmingly ASCII
+  // comments/rules. Reject anything that smells like an HTML error page, a
+  // captive-portal interstitial, or a binary blob swapped in over the wire.
+  #looksLikeFilterList(bytes) {
+    if (!bytes || !bytes.length) {
+      return false;
+    }
+    let text;
+    try {
+      // fatal:true rejects invalid UTF-8 (i.e. binary).
+      text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (e) {
+      return false;
+    }
+    // NUL bytes never appear in a real filter list.
+    if (text.includes("\0")) {
+      return false;
+    }
+    const head = text.slice(0, 4096).toLowerCase().trimStart();
+    if (head.startsWith("<!doctype") || head.startsWith("<html")) {
+      return false;
+    }
+    return true;
+  }
+
   // Hand the engine the scriptlet/redirect resource library so `+js(...)` rules
   // in the uBO lists expand into injectable scriptlets. Packaged static
   // (version-pinned to the vendored adblock-rust + the uBO scriptlet harvest);
@@ -170,6 +244,28 @@ export class ContentClassifierRemoteSettingsClient {
     }
   }
 
+  // Read a cached list back and verify it against its persisted SHA-256 sidecar
+  // before trusting it. Returns the bytes only if the digest matches; null if
+  // the cache is missing, has no/garbled sidecar, or fails verification (i.e.
+  // was tampered with or partially written) — in which case the caller must
+  // re-fetch rather than feed unverified data to the engine.
+  async #readVerified(path) {
+    const digestPath = this.#digestPath(path);
+    if (!(await IOUtils.exists(path)) || !(await IOUtils.exists(digestPath))) {
+      return null;
+    }
+    const bytes = await IOUtils.read(path);
+    const expected = (await IOUtils.readUTF8(digestPath)).trim();
+    const actual = this.#sha256Hex(bytes);
+    if (!expected || actual !== expected) {
+      lazy.log.warn(
+        `cache integrity check failed for ${path} — discarding (untrusted)`
+      );
+      return null;
+    }
+    return bytes;
+  }
+
   async #loadAllLists(service) {
     const dir = this.#cacheDir();
     await IOUtils.makeDirectory(dir, { ignoreExisting: true });
@@ -178,10 +274,13 @@ export class ContentClassifierRemoteSettingsClient {
       const path = PathUtils.join(dir, `${name}.txt`);
       let bytes = null;
       try {
-        if (await IOUtils.exists(path)) {
-          bytes = await IOUtils.read(path);
-        } else {
-          // First run, no cache: fetch now so blocking works on first launch.
+        // Cache read-back is verified against the persisted digest; an
+        // unverifiable cache is treated as absent and re-fetched, never fed
+        // to the engine.
+        bytes = await this.#readVerified(path);
+        if (!bytes) {
+          // No (trustworthy) cache: fetch now so blocking works on first launch
+          // and so a tampered cache is replaced with a known-good copy.
           bytes = await this.#fetchAndCache(url, path);
         }
       } catch (e) {
@@ -217,12 +316,30 @@ export class ContentClassifierRemoteSettingsClient {
   }
 
   async #fetchAndCache(url, path) {
+    // (1) transport: refuse to fetch a list over anything but https.
+    if (!/^https:\/\//i.test(url)) {
+      throw new Error(`refusing non-https list URL ${url}`);
+    }
     const resp = await fetch(url, { cache: "no-store" });
     if (!resp.ok) {
       throw new Error(`fetch ${url} -> HTTP ${resp.status}`);
     }
     const buf = new Uint8Array(await resp.arrayBuffer());
+    // (2) size cap: bound a hostile/oversized response before it hits disk.
+    if (buf.length > MAX_LIST_BYTES) {
+      throw new Error(
+        `list ${url} too large (${buf.length} > ${MAX_LIST_BYTES} bytes)`
+      );
+    }
+    // (3) shape check: must look like a text filter list, not HTML/binary.
+    if (!this.#looksLikeFilterList(buf)) {
+      throw new Error(`list ${url} did not look like a text filter list`);
+    }
+    // (4) at-rest integrity: persist a digest alongside the cached bytes so the
+    // read-back path can detect tampering/partial writes before trusting it.
+    const digest = this.#sha256Hex(buf);
     await IOUtils.write(path, buf);
+    await IOUtils.writeUTF8(this.#digestPath(path), digest);
     lazy.log.info(`fetched + cached ${url} (${buf.length} bytes)`);
     return buf;
   }

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
@@ -128,6 +128,19 @@ export class GjoaCosmeticChild extends JSWindowActorChild {
   // sandboxPrototype=win + wantXrays=false the scriptlet's writes to JSON.parse
   // / Response.json land on the page's real globals — exactly what a player
   // json-prune needs.
+  //
+  // SECURITY INVARIANT (F7): this sandbox shares the page's prototype chain
+  // (sandboxPrototype=win, wantXrays=false), so the page sees the scriptlet's
+  // RAW globals — w.JSON, w.Response, w.Object are all interceptable. A hostile
+  // page can pre-plant getters/Proxies to observe or defeat the scriptlet. This
+  // is the inherent uBO-style residual and is NOT an escalation: everything here
+  // runs with the CONTENT principal, so the worst case is the page tampering
+  // with content it already controls. The HARD rule: injected scriptlet code
+  // (resp.scriptlets) must NEVER be handed any privileged value (chrome object,
+  // Services, Cu/Cc/Ci, IPC handle) — the page can intercept every property
+  // access in this sandbox, so a leaked privileged ref would cross the
+  // content/chrome boundary. We only ever evalInSandbox opaque code strings here;
+  // do not add bindings onto the sandbox that expose anything chrome-side.
   async injectScriptlets() {
     const doc = this.document;
     const url = doc?.documentURI || "";
@@ -157,6 +170,29 @@ export class GjoaCosmeticChild extends JSWindowActorChild {
     } catch (e) {
       return;
     }
+    // Defensive intrinsic capture (F7). Snapshot the native intrinsics curated
+    // scriptlets (e.g. YOUTUBE_PRUNE's json-prune over JSON.parse/Response.json)
+    // read, ONCE at injection time, before any page script in a later turn can
+    // re-plant a getter/Proxy. A scriptlet that closes over `__gjoaNative.JSON`
+    // / `.Response` / `.Object` reads the reference captured here rather than
+    // re-deref'ing `w.JSON` on every call, so a page that swaps a global mid-run
+    // can't redirect it. These are the page's OWN content-principal globals
+    // (the sandbox already shares win's prototype) handed straight through — we
+    // deliberately do NOT cloneInto (that would drop the function intrinsics and
+    // break the scriptlet); per the invariant above, nothing chrome-side is ever
+    // placed on the sandbox. This NARROWS, does not CLOSE, the residual: a page
+    // that planted its trap BEFORE document-start is still observed (the inherent
+    // uBO-style residual), and the snapshot only helps scriptlets that opt into
+    // reading __gjoaNative instead of the bare global.
+    try {
+      sandbox.__gjoaNative = {
+        JSON: win.JSON,
+        Response: win.Response,
+        Object: win.Object,
+        Array: win.Array,
+        Promise: win.Promise,
+      };
+    } catch (e) {}
     for (const code of resp.scriptlets) {
       try {
         Cu.evalInSandbox(code, sandbox);

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
@@ -238,9 +238,12 @@ export class GjoaCosmeticParent extends JSWindowActorParent {
         // process could otherwise send huge arrays of huge strings to stall the
         // parent main thread and contend the cross-tab engine lock (DoS). Drop
         // non-strings, cap per-element length and total count.
+        // 1024-char cap (not 256): class/id tokens are short, but a legitimate
+        // exception SELECTOR can be long, and dropping one silently over-blocks
+        // (hides an element meant to stay visible). 1024 x 4096 is still bounded.
         const clamp = a =>
           (Array.isArray(a) ? a : [])
-            .filter(s => typeof s === "string" && s.length <= 256)
+            .filter(s => typeof s === "string" && s.length <= 1024)
             .slice(0, 4096);
         const selectors = {};
         try {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
@@ -10,6 +10,10 @@
 
 const ENABLED_PREF = "gjoa.contentblock.enabled";
 const ALLOW_HOSTS_PREF = "gjoa.contentblock.user.allow-hosts";
+// gjoa policy is curated-only scriptlets. The engine's general/list-driven
+// `+js()` expansion is opt-in and DEFAULTS OFF; only the curated baseline
+// (e.g. YOUTUBE_PRUNE) runs unless the user explicitly flips this pref.
+const LIST_SCRIPTLETS_PREF = "gjoa.contentblock.scriptlets.listDriven.enabled";
 
 // --- Curated scriptlets ------------------------------------------------------
 // gjoa's "curated-only scriptlets" policy: a small, hand-maintained set of JS
@@ -183,9 +187,12 @@ export class GjoaCosmeticParent extends JSWindowActorParent {
 
       // Document-start scriptlets for this URL's host. Returned separately from
       // the cosmetic CSS because they must run BEFORE page scripts (the cosmetic
-      // path fires on DOMContentLoaded, too late for a player pre-roll). Today
-      // this serves the curated set; once the engine's scriptlet resources are
-      // wired it will also fold in `injected` from getUrlCosmeticResources.
+      // path fires on DOMContentLoaded, too late for a player pre-roll). By
+      // default this serves ONLY the curated set (gjoa policy: curated-only
+      // scriptlets). The engine's list-driven `injected` scriptlet IS wired, but
+      // gated behind LIST_SCRIPTLETS_PREF (default OFF): an arbitrary list-driven
+      // `+js()` rule injecting unaudited JS into the page's main world is exactly
+      // what the curated-only policy excludes, so it stays opt-in.
       case "Cosmetic:GetScriptlets": {
         const url = this.trustedUrl();
         if (!blockingActive(url)) {
@@ -195,20 +202,24 @@ export class GjoaCosmeticParent extends JSWindowActorParent {
         // Engine-produced scriptlets: adblock-rust expands this URL's `+js()`
         // rules (from the uBO lists) against the loaded scriptlet resource
         // library into one injectable string. This is the general/list-driven
-        // path; the curated set above is a guaranteed baseline.
-        const svc = classifierService();
-        if (svc) {
-          try {
-            const hide = {};
-            const proc = {};
-            const exc = {};
-            const injected = {};
-            const generichide = {};
-            svc.getUrlCosmeticResources(url, hide, proc, exc, injected, generichide);
-            if (injected.value) {
-              out.push(injected.value);
-            }
-          } catch (e) {}
+        // path; the curated set above is a guaranteed baseline. Per gjoa's
+        // curated-only policy this list-driven injection is DISABLED by default
+        // and only folded in when LIST_SCRIPTLETS_PREF is explicitly enabled.
+        if (Services.prefs.getBoolPref(LIST_SCRIPTLETS_PREF, false)) {
+          const svc = classifierService();
+          if (svc) {
+            try {
+              const hide = {};
+              const proc = {};
+              const exc = {};
+              const injected = {};
+              const generichide = {};
+              svc.getUrlCosmeticResources(url, hide, proc, exc, injected, generichide);
+              if (injected.value) {
+                out.push(injected.value);
+              }
+            } catch (e) {}
+          }
         }
         return out.length ? { scriptlets: out } : null;
       }
@@ -222,12 +233,21 @@ export class GjoaCosmeticParent extends JSWindowActorParent {
         if (!svc) {
           return null;
         }
+        // Clamp the child-supplied arrays before handing them to the
+        // synchronous, globally-locked native call. A compromised content
+        // process could otherwise send huge arrays of huge strings to stall the
+        // parent main thread and contend the cross-tab engine lock (DoS). Drop
+        // non-strings, cap per-element length and total count.
+        const clamp = a =>
+          (Array.isArray(a) ? a : [])
+            .filter(s => typeof s === "string" && s.length <= 256)
+            .slice(0, 4096);
         const selectors = {};
         try {
           svc.getHiddenClassIdSelectors(
-            msg.data?.classes || [],
-            msg.data?.ids || [],
-            msg.data?.exceptions || [],
+            clamp(msg.data?.classes),
+            clamp(msg.data?.ids),
+            clamp(msg.data?.exceptions),
             selectors
           );
         } catch (e) {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -187,6 +187,17 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
   // which the page CSP blocks (YouTube blocks inline scripts). sandboxPrototype
   // = win + wantXrays = false so the scriptlet's writes (html[dark]) land on the
   // page (same channel discipline as GjoaCosmeticChild.injectScriptlets).
+  //
+  // SECURITY INVARIANT (F7): with sandboxPrototype=win + wantXrays=false the
+  // scriptlet reads the page's RAW globals (w.JSON, w.Object, w.Element), so a
+  // hostile page can pre-plant getters/Proxies to observe or defeat it. This is
+  // the inherent uBO-style residual and is NOT an escalation — everything here
+  // runs with the CONTENT principal. The HARD rule: injected scriptlet code must
+  // NEVER be handed any privileged value (chrome object, Services, Cu/Cc/Ci, the
+  // actor's IPC handle) — the page can intercept every property access in this
+  // sandbox, so a leaked privileged ref would cross the content/chrome boundary.
+  // Only opaque code strings are evaluated here; never add chrome-side bindings
+  // onto the sandbox.
   #runInject(win, code) {
     try {
       const sandbox = Cu.Sandbox(win, {
@@ -194,6 +205,21 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
         sandboxPrototype: win,
         wantXrays: false,
       });
+      // Defensive intrinsic capture (F7): snapshot the page's native intrinsics
+      // ONCE at injection time so a scriptlet that closes over `__gjoaNative.*`
+      // reads the reference captured here rather than re-deref'ing the bare
+      // global, which a later page turn could swap. These are the page's own
+      // content-principal globals handed straight through (the sandbox already
+      // shares win's prototype) — NOT cloned, and never a chrome value. This
+      // narrows, does not close, the residual (a trap planted before
+      // document-start is still observed).
+      try {
+        sandbox.__gjoaNative = {
+          JSON: win.JSON,
+          Object: win.Object,
+          Element: win.Element,
+        };
+      } catch (e) {}
       Cu.evalInSandbox(code, sandbox);
     } catch (e) {}
   }

--- a/src/gjoa/toolkit/components/content-classifier/scriptlet-resources.PROVENANCE.md
+++ b/src/gjoa/toolkit/components/content-classifier/scriptlet-resources.PROVENANCE.md
@@ -1,0 +1,50 @@
+# scriptlet-resources.json — provenance & integrity
+
+`scriptlet-resources.json` is a vendored, uBO-derived library of scriptlet /
+redirect resources (163 entries: 52 `fn/javascript` + 111
+`application/javascript`). Each entry's `content` is **base64-encoded
+JavaScript** that the RS client hands to
+`nsIContentClassifierService.setScriptletResources(json)`; adblock-rust then
+expands `+js(...)` cosmetic rules into scriptlets that are **executed in a
+content sandbox via `evalInSandbox`**. Because this bundle is *executable code on
+the privileged side of the blocker*, its provenance and integrity matter — a
+swapped or tampered bundle would inject attacker-controlled JS into pages.
+
+This file records where the bundle came from and how to verify the committed copy
+has not changed. It deliberately does **not** alter the shipped JSON.
+
+## Source
+
+- **Upstream project:** uBlock Origin (uBO)
+- **Repository:** https://github.com/uBlockOrigin/uBlock
+- **Harvested from commit/tag:** **UNKNOWN** — the bundle was committed to gjoa in
+  `710615f` (2026-06-18, "feat(adblock): list-driven scriptlet engine — true
+  uBlock +js() parity") as "harvested from uBlock Origin" without recording the
+  source revision. This **MUST be pinned at the next refresh**: record the exact
+  uBO commit SHA (or release tag) the bundle is regenerated from, so the JS we
+  ship to `evalInSandbox` is reproducible from a known upstream point.
+
+## Schema
+
+- **adblock-rust schema version:** `0.12.1`
+  (matches `adblock = { version = "0.12.1", ... }` in
+  `patches/0008-content-classifier-cosmetic-filtering.patch`; the resource shape
+  — `{ name, aliases, kind: { mime }, content (base64) }` — is what
+  `Engine::use_resources` deserializes).
+
+## Integrity
+
+- **Committed SHA-256:**
+  `f27354411da54d8a34438f542dcf0694ecd1dd4ab961f0a68de2b29f76f6dc56`
+- **File:** `scriptlet-resources.json` (this directory)
+
+Verify the committed JSON still matches the recorded hash with:
+
+```sh
+tools/prep/verify-scriptlet-resources.sh
+```
+
+(wired into `bun run preflight`). The hash above is the single source of truth —
+if the bundle is legitimately refreshed, regenerate it from a **pinned** uBO
+commit, update both the "Harvested from commit/tag" line and this SHA-256, and
+re-run the verifier.

--- a/tests/integration/adblock-production.bjs
+++ b/tests/integration/adblock-production.bjs
@@ -61,7 +61,18 @@
                          "    await IOUtils.makeDirectory(cache, { ignoreExisting: true });\n"
                          "    for (const [name, src] of [['easylist','/tmp/gjoa-easylist.txt'],['easyprivacy','/tmp/gjoa-easyprivacy.txt']]) {\n"
                          "      const bytes = await IOUtils.read(src);\n"
-                         "      await IOUtils.write(PathUtils.join(cache, name + '.txt'), bytes);\n"
+                         "      const dst = PathUtils.join(cache, name + '.txt');\n"
+                         "      await IOUtils.write(dst, bytes);\n"
+                         ;; F1: the overlay now verifies a SHA-256 sidecar before trusting the
+                         ;; cache, so the seed must write <name>.txt.sha256 (lowercase hex,
+                         ;; matching #sha256Hex) or the cache is rejected and the list re-fetches.
+                         "      const h = Cc['@mozilla.org/security/hash;1'].createInstance(Ci.nsICryptoHash);\n"
+                         "      h.init(Ci.nsICryptoHash.SHA256);\n"
+                         "      h.update(bytes, bytes.length);\n"
+                         "      const d = h.finish(false);\n"
+                         "      let hex = '';\n"
+                         "      for (let i = 0; i < d.length; i++) { hex += d.charCodeAt(i).toString(16).padStart(2, '0'); }\n"
+                         "      await IOUtils.writeUTF8(dst + '.sha256', hex);\n"
                          "    }\n"
                          "    resolve(JSON.stringify({ testing, enabled, names }));\n"
                          "  })().catch(e => resolve('ERR:' + e));\n")))]

--- a/tools/bench/env.sh
+++ b/tools/bench/env.sh
@@ -16,7 +16,15 @@ fi
 # Persistent state file: the prepare and --restore invocations are separate
 # processes, so in-memory snapshots don't survive. Stash the pre-run values
 # here on the forward path and read them back on --restore.
-STATE_FILE="${GJOA_BENCH_STATE:-/var/tmp/gjoa-bench-env.state}"
+#
+# SECURITY: we run as root and read this file back, so it must live in a
+# root-only directory (NOT a world-writable one like /var/tmp, where an
+# unprivileged user could pre-create it). Default to a 0700 dir under /run,
+# owned by root. The override is honored but the same ownership/permission
+# checks below still apply before we trust the contents.
+STATE_DIR="${GJOA_BENCH_STATE_DIR:-/run/gjoa-bench}"
+mkdir -m700 -p "$STATE_DIR"
+STATE_FILE="${GJOA_BENCH_STATE:-$STATE_DIR/gjoa-bench-env.state}"
 
 GOV_FILE="/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
 
@@ -102,12 +110,66 @@ snapshot_state() {
   fi
   local aslr
   aslr="$(cat /proc/sys/kernel/randomize_va_space)"
-  {
-    echo "TURBO=$(read_turbo)"
-    echo "GOVERNOR=$gov"
-    echo "ASLR=$aslr"
-  } > "$STATE_FILE"
+  # Create root-only (0600) and refuse to clobber a pre-existing file we did
+  # not create (set -C / noclobber), so an attacker can't seed it first.
+  rm -f "$STATE_FILE"
+  (
+    umask 077
+    set -C
+    {
+      echo "TURBO=$(read_turbo)"
+      echo "GOVERNOR=$gov"
+      echo "ASLR=$aslr"
+    } > "$STATE_FILE"
+  )
   echo "Saved pre-run state to $STATE_FILE (governor=$gov, aslr=$aslr)"
+}
+
+# Validate that STATE_FILE is safe to read back as root: a real regular file
+# (not a symlink), owned by root (uid 0), and not group/other-writable. Refuse
+# otherwise — a file an unprivileged user can control must never be trusted by
+# a root process. Returns non-zero on any failure.
+validate_state_file() {
+  local f="$1"
+  # -O: exists and is owned by the effective uid (root here). -L excludes
+  # symlinks; -f requires a regular file.
+  if [[ -L "$f" ]]; then
+    echo "ERROR: state file $f is a symlink; refusing to read." >&2
+    return 1
+  fi
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: state file $f is not a regular file; refusing to read." >&2
+    return 1
+  fi
+  if [[ ! -O "$f" ]]; then
+    echo "ERROR: state file $f is not owned by root; refusing to read." >&2
+    return 1
+  fi
+  # Reject group- or other-writable files (mode bits 0022).
+  local mode
+  mode="$(stat -c '%a' "$f")"
+  if (( 0$mode & 0022 )); then
+    echo "ERROR: state file $f is group/other-writable (mode $mode); refusing to read." >&2
+    return 1
+  fi
+  return 0
+}
+
+# Safely load the known keys from a validated state file WITHOUT sourcing it,
+# so arbitrary shell embedded in the file can never execute. Only TURBO,
+# GOVERNOR, and ASLR are recognized; everything else is ignored. Sets the
+# corresponding shell variables in the caller's scope.
+load_state_file() {
+  local f="$1"
+  local line key val
+  TURBO=""; GOVERNOR=""; ASLR=""
+  while IFS='=' read -r key val; do
+    case "$key" in
+      TURBO)    TURBO="$val" ;;
+      GOVERNOR) GOVERNOR="$val" ;;
+      ASLR)     ASLR="$val" ;;
+    esac
+  done < "$f"
 }
 
 # --- ASLR ---
@@ -152,9 +214,18 @@ print_state() {
 
 if $RESTORE; then
   echo "Restoring pre-run settings..."
-  if [[ -f "$STATE_FILE" ]]; then
-    # shellcheck source=/dev/null
-    source "$STATE_FILE"
+  if [[ -e "$STATE_FILE" ]]; then
+    if ! validate_state_file "$STATE_FILE"; then
+      echo "WARN: state file failed safety checks; applying safe defaults." >&2
+      enable_turbo
+      set_governor schedutil
+      enable_aslr
+      print_state
+      echo "Done. Machine restored to normal operation."
+      exit 0
+    fi
+    # Parse only the known keys; never source (no arbitrary shell execution).
+    load_state_file "$STATE_FILE"
     write_turbo "${TURBO:-}"
     set_governor "${GOVERNOR:-schedutil}"
     if [[ -n "${ASLR:-}" ]]; then

--- a/tools/prep/darkmode-registry.bjs
+++ b/tools/prep/darkmode-registry.bjs
@@ -10,9 +10,16 @@
 ;;
 ;; WORKFLOW (snapshot → print → eyeball → --write)
 ;;   1. SNAPSHOT — the tool reads a LOCAL snapshot (tools/prep/darkreader-fixes.snapshot)
-;;      so runs are reproducible, not network-dependent. Refresh it with:
-;;        curl -sL https://raw.githubusercontent.com/darkreader/darkreader/main/src/config/dynamic-theme-fixes.config \
+;;      so runs are reproducible, not network-dependent. The fetch is PINNED to a
+;;      tagged Dark Reader release (never `main`) so the corpus can't drift under
+;;      us, and its SHA-256 is recorded in EXPECTED-SNAPSHOT-SHA256 below. Refresh
+;;      it (then update DARKREADER-PIN + EXPECTED-SNAPSHOT-SHA256 to match) with:
+;;        curl -sL https://raw.githubusercontent.com/darkreader/darkreader/v4.9.127/src/config/dynamic-theme-fixes.config \
 ;;          -o tools/prep/darkreader-fixes.snapshot
+;;        sha256sum tools/prep/darkreader-fixes.snapshot   # paste into EXPECTED-SNAPSHOT-SHA256
+;;      --write REFUSES to run unless the on-disk snapshot's SHA-256 matches the
+;;      pinned hash — a tampered or silently-updated corpus is rejected before any
+;;      generated CSS reaches the USER_SHEET.
 ;;   2. PRINT — `bun .beagle-tools/gjoa/tools/prep/darkmode-registry.js <host> [host...]`
 ;;      parses the snapshot, finds each host's block (matching the host against the
 ;;      block's URL-pattern lines), extracts + resolves its CSS section, and prints
@@ -57,7 +64,7 @@
             [gjoa.tools.prep.paths :refer [REPO-ROOT]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
-(declare-extern [process console Math JSON RegExp Error Number isNaN parseInt parseFloat] Any)
+(declare-extern [process console Math JSON RegExp Error Number isNaN parseInt parseFloat Bun] Any)
 
 ;; ---------------------------------------------------------------------------
 ;; Paths
@@ -66,6 +73,24 @@
 (def SNAPSHOT-PATH :- String (join REPO-ROOT "tools" "prep" "darkreader-fixes.snapshot"))
 (def REGISTRY-PATH :- String
   (join REPO-ROOT "src" "gjoa" "toolkit" "components" "content-classifier" "darkmode-fixes.json"))
+
+;; The Dark Reader release the committed snapshot was pulled from. The refresh
+;; curl pins this tag (NOT `main`) so the upstream corpus can't shift under us.
+(def DARKREADER-PIN :- String "v4.9.127")
+
+;; SHA-256 of the committed snapshot at DARKREADER-PIN. --write verifies the
+;; on-disk snapshot against this before generating any USER_SHEET CSS; a mismatch
+;; (tampered / silently-refreshed corpus, or a refresh that forgot to update this
+;; constant) aborts the write. Recompute with `sha256sum tools/prep/darkreader-fixes.snapshot`.
+(def EXPECTED-SNAPSHOT-SHA256 :- String
+  "0e6d82b4df349edeb789e4dbb346f427caff4861f071020525fd81e6f50e638f")
+
+;; Hex SHA-256 of a string, synchronously (Bun runtime — same hasher download.bjs uses).
+;; Pure (no effect), so no `!` suffix.
+(defn sha256 [text :- String] :- String
+  (let [hash (Bun.CryptoHasher. "sha256")]
+    (.update hash text)
+    (.digest hash "hex")))
 
 ;; ---------------------------------------------------------------------------
 ;; Color model: an [r g b a] tuple with r/g/b in 0..255 and a in 0..1.
@@ -390,8 +415,18 @@
                       ;; fall back to neutral background so the rule still resolves
                       "#181a1b"))))))
 
+;; Constructs that must NEVER reach the generated USER_SHEET: url() can pull /
+;; exfiltrate remote resources, @import pulls a remote stylesheet, and the legacy
+;; expression() runs script. Dark Reader's color-correction CSS doesn't need any
+;; of them, so finding one means the corpus carried something we won't ship — we
+;; REJECT the entry (fail closed) rather than silently strip and emit a maybe-
+;; broken rule. Matching is case-insensitive; whitespace is allowed before the '('.
+(def FORBIDDEN-CSS :- Any
+  (RegExp. "url\\s*\\(|@import\\b|expression\\s*\\(" "i"))
+
 ;; Build the gjoa registry entry for a block's CSS section. Returns
-;; {:css ... :unresolved [...] :unmapped-vars [...]} or nil if no CSS section.
+;; {:css ... :unresolved [...] :unmapped-vars [...]}, {:rejected "reason"} if the
+;; resolved CSS contains a forbidden construct, or nil if no CSS section.
 (defn build-entry [block :- Any] :- Any
   (let [css (get (.-sections block) "CSS")]
     (if (or (not css) (= (.trim css) ""))
@@ -403,10 +438,12 @@
             ;; existing registry entries' style (one rule run, spaces normalized).
             compact (.trim (.replace (.replace resolved (RegExp. "\\s*\\n\\s*" "g") " ")
                                      (RegExp. "  +" "g") " "))]
-        {:css compact
-         :entry {:mode "css" :override "active" :css compact}
-         :unresolved unresolved
-         :unmapped-vars unmapped}))))
+        (if (.test FORBIDDEN-CSS compact)
+          {:rejected "resolved CSS contains a forbidden construct (url()/@import/expression()) — not safe for a USER_SHEET"}
+          {:css compact
+           :entry {:mode "css" :override "active" :css compact}
+           :unresolved unresolved
+           :unmapped-vars unmapped})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Self-test: the flip on known values.
@@ -469,7 +506,10 @@ Reads the local snapshot at tools/prep/darkreader-fixes.snapshot.
   (when (not (existsSync SNAPSHOT-PATH))
     (let [err (.-error log)]
       (err (str "snapshot not found at " SNAPSHOT-PATH))
-      (err "refresh it: curl -sL https://raw.githubusercontent.com/darkreader/darkreader/main/src/config/dynamic-theme-fixes.config -o tools/prep/darkreader-fixes.snapshot")
+      (err (str "refresh it (pinned): curl -sL https://raw.githubusercontent.com/darkreader/darkreader/"
+                DARKREADER-PIN
+                "/src/config/dynamic-theme-fixes.config -o tools/prep/darkreader-fixes.snapshot"))
+      (err "then update EXPECTED-SNAPSHOT-SHA256 (sha256sum tools/prep/darkreader-fixes.snapshot)")
       (.exit process 1)))
   (readFileSync SNAPSHOT-PATH "utf8"))
 
@@ -480,8 +520,14 @@ Reads the local snapshot at tools/prep/darkreader-fixes.snapshot.
     (if (not block)
       {:host host :missing true :reason "no matching DR block"}
       (let [built (build-entry block)]
-        (if (not built)
+        (cond
+          (not built)
           {:host host :missing true :reason "matched block has no CSS section (INVERT/IGNORE only)"}
+
+          (.-rejected built)
+          {:host host :missing true :reason (.-rejected built)}
+
+          :else
           {:host host
            :entry (.-entry built)
            :unresolved (.-unresolved built)
@@ -522,6 +568,19 @@ Reads the local snapshot at tools/prep/darkreader-fixes.snapshot.
             generated (.filter results (fn [r] (not (.-missing r))))]
         (doseq [r results] (print-result! r))
         (when write?
+          ;; Pin gate: refuse to write generated CSS into the registry unless the
+          ;; on-disk snapshot matches the SHA-256 recorded at DARKREADER-PIN. This
+          ;; closes the unpinned-corpus path — a tampered or silently-refreshed
+          ;; snapshot can be printed/eyeballed but never merged into the USER_SHEET.
+          (let [actual (sha256 snapshot)]
+            (when (not= actual EXPECTED-SNAPSHOT-SHA256)
+              (let [err (.-error log)]
+                (err (str "snapshot SHA-256 does not match the pinned hash for Dark Reader " DARKREADER-PIN ".\n"
+                          "  expected: " EXPECTED-SNAPSHOT-SHA256 "\n"
+                          "  got:      " actual "\n"
+                          "  --write refused. Re-pin deliberately: refresh from the pinned tag, eyeball the diff,\n"
+                          "  then update DARKREADER-PIN + EXPECTED-SNAPSHOT-SHA256 to match."))
+                (.exit process 1))))
           (if (= (.-length generated) 0)
             (let [warn (.-warn log)] (warn "nothing to write (no hosts produced entries)"))
             (let [existing (if (existsSync REGISTRY-PATH)

--- a/tools/prep/download.bjs
+++ b/tools/prep/download.bjs
@@ -3,14 +3,29 @@
 ;; Mirrors Mozilla's release URL convention, checks SHA256 against the published
 ;; SHA256SUMS, caches under SOURCES_CACHE, and strips the firefox-VERSION/ level
 ;; so engine/ holds the source tree directly.
+;;
+;; Trust model (F9 hardening): the live SHA256SUMS is fetched from the SAME
+;; origin as the tarball, so on its own it is a single trust anchor — an
+;; origin/TLS compromise could serve a backdoored tarball + matching SHA256SUMS.
+;; We close that by anchoring on an IN-REPO pinned hash (configs/firefox-
+;; <version>.sha256, committed + reviewed) and asserting the live SHA256SUMS
+;; entry against it; the attacker can't change the committed file. When gpg is
+;; available we ALSO verify SHA256SUMS.asc against Mozilla's release-signing key
+;; (fingerprint pinned below) as defense-in-depth.
 (ns gjoa.tools.prep.download
-  (:require [fs :refer [existsSync mkdirSync statSync]]
+  (:require [fs :refer [existsSync mkdirSync readFileSync statSync]]
             [path :refer [join]]
             [gjoa.tools.prep.config :refer [load-config!]]
-            [gjoa.tools.prep.paths :refer [ENGINE-DIR REPO-ROOT SOURCES-CACHE]]
+            [gjoa.tools.prep.paths :refer [ENGINE-DIR REPO-ROOT SOURCES-CACHE CONFIGS-DIR]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
 (declare-extern [Bun fetch Number Error] Any)
+
+;; Mozilla "Software Releases" signing key fingerprint (rsa4096, pub 2015-07-17,
+;; uid <release@mozilla.com>). Pinned in-repo so a GPG verify of SHA256SUMS.asc
+;; trusts THIS key and nothing else, regardless of what a keyring is seeded with.
+(def MOZILLA-SIGNING-FPR :- String
+  "14F26682D0916CDD81E37B6D61B7B526D98F0353")
 
 ;; Mirrors Mozilla's release URL convention. Used for both .source.tar.xz and
 ;; the SHA256SUMS file that publishes its hash.
@@ -21,8 +36,96 @@
 (defn checksumUrl [version :- String] :- String
   (str "https://archive.mozilla.org/pub/firefox/releases/" version "/SHA256SUMS"))
 
+(defn signatureUrl [version :- String] :- String
+  (str "https://archive.mozilla.org/pub/firefox/releases/" version "/SHA256SUMS.asc"))
+
+;; In-repo pinned-hash file for a given version (the F9 trust anchor).
+(defn pinnedHashPath [version :- String] :- String
+  (join CONFIGS-DIR (str "firefox-" version ".sha256")))
+
 (defn tarballName [version :- String] :- String
   (str "firefox-" version ".source.tar.xz"))
+
+;; Parse a SHA256SUMS body for the tarball's hash. Mozilla lists files with
+;; subdirectory prefixes, e.g. `source/firefox-150.0.source.tar.xz` — match by
+;; basename. Returns nil if the tarball isn't listed.
+(defn hashFromSums [text :- String version :- String] :- Any
+  (let [want (tarballName version)
+        lines (.split text "\n")]
+    (loop [i 0]
+      (if (>= i (.-length lines))
+        nil
+        (let [parts (.split (.trim (aget lines i)) (RegExp. "\\s+"))
+              hash (aget parts 0)
+              file (aget parts 1)]
+          (if (and file (or (= file want) (.endsWith file (str "/" want))))
+            hash
+            (recur (+ i 1))))))))
+
+;; Read the in-repo pinned hash for this version (the F9 trust anchor). The
+;; committed file is `sha256sum -c`-shaped (`<hash>  <path>`); the same parser
+;; that reads SHA256SUMS reads it. Throws if the version isn't pinned — bumping
+;; FF_VERSION MUST add a configs/firefox-<version>.sha256 (see that file's
+;; header for how to derive it safely).
+(defn pinnedSha256 [version :- String] :- String
+  (let [p (pinnedHashPath version)]
+    (if (not (existsSync p))
+      (throw (Error. (str "no pinned checksum for firefox " version
+                          ".\n  expected: " p
+                          "\n  add it from the GPG-verified SHA256SUMS (see that file's header)."))))
+    (let [text (readFileSync p "utf8")
+          hash (hashFromSums text version)]
+      (if (not hash)
+        (throw (Error. (str "pinned checksum file does not list " (tarballName version) ": " p)))
+        hash))))
+
+;; Best-effort GPG verification of SHA256SUMS.asc against Mozilla's pinned
+;; release-signing key. Defense-in-depth on top of the in-repo pinned hash: if
+;; gpg isn't installed we log and skip (the pinned-hash assertion below is the
+;; load-bearing check, so absence of gpg never weakens the happy path). Returns
+;; true if verified, false if skipped/unavailable; throws on an actual bad sig.
+(defn verifySignature [version :- String sumsText :- String] :- Any
+  (let [probe (.spawnSync Bun ["gpg" "--version"] {:stdout "ignore" :stderr "ignore"})]
+    (if (not (.-success probe))
+      (do
+        (.warn log "gpg not available; skipping SHA256SUMS.asc signature check (pinned in-repo hash still enforced)")
+        false)
+      (let [ascRes (js/await (fetch (signatureUrl version)))]
+        (if (not (.-ok ascRes))
+          (throw (Error. (str "failed to fetch SHA256SUMS.asc: " (.-status ascRes))))
+          nil)
+        (let [asc (js/await (.text ascRes))
+              tmpDir (join SOURCES-CACHE ".gpg-verify")
+              keyPath (join tmpDir "mozilla.key")
+              sumsPath (join tmpDir "SHA256SUMS")
+              ascPath (join tmpDir "SHA256SUMS.asc")
+              keyRes (js/await (fetch (str "https://archive.mozilla.org/pub/firefox/releases/" version "/KEY")))]
+          (if (not (.-ok keyRes))
+            (throw (Error. (str "failed to fetch Mozilla KEY: " (.-status keyRes))))
+            nil)
+          (mkdirSync tmpDir {:recursive true})
+          (js/await (.write Bun keyPath (js/await (.text keyRes))))
+          (js/await (.write Bun sumsPath sumsText))
+          (js/await (.write Bun ascPath asc))
+          ;; Import the published KEY into an ephemeral keyring, then assert the
+          ;; signature was made by the PINNED fingerprint before trusting it.
+          (let [kr (join tmpDir "keyring.gpg")
+                imp (.spawnSync Bun ["gpg" "--no-default-keyring" "--keyring" kr "--import" keyPath]
+                                {:stdout "ignore" :stderr "ignore"})]
+            (if (not (.-success imp))
+              (throw (Error. "gpg: failed to import Mozilla KEY"))
+              nil)
+            ;; --status-fd 1 prints machine-readable VALIDSIG <fpr> ... lines.
+            (let [ver (.spawnSync Bun ["gpg" "--no-default-keyring" "--keyring" kr
+                                       "--status-fd" "1" "--verify" ascPath sumsPath]
+                                  {:stdout "pipe" :stderr "ignore"})
+                  out (.toString (.-stdout ver))]
+              (if (not (.includes out (str "VALIDSIG " MOZILLA-SIGNING-FPR)))
+                (throw (Error. (str "SHA256SUMS.asc not signed by pinned Mozilla key "
+                                    MOZILLA-SIGNING-FPR "\n  gpg --status output:\n" out)))
+                nil)
+              (.ok log (str "SHA256SUMS.asc GPG-verified against pinned Mozilla key " MOZILLA-SIGNING-FPR))
+              true)))))))
 
 (defn fetchSha256 [version :- String] :- Any
   (.step log (str "fetching upstream SHA256SUMS for firefox " version))
@@ -31,19 +134,24 @@
       (throw (Error. (str "failed to fetch SHA256SUMS: " (.-status res))))
       nil)
     (let [text (js/await (.text res))
-          ;; Mozilla's SHA256SUMS lists files with subdirectory prefixes, e.g.
-          ;; `source/firefox-150.0.source.tar.xz`. Match by basename.
-          want (tarballName version)
-          lines (.split text "\n")]
-      (loop [i 0]
-        (if (>= i (.-length lines))
-          (throw (Error. (str "SHA256SUMS does not list " want)))
-          (let [parts (.split (.trim (aget lines i)) (RegExp. "\\s+"))
-                hash (aget parts 0)
-                file (aget parts 1)]
-            (if (and file (or (= file want) (.endsWith file (str "/" want))))
-              hash
-              (recur (+ i 1)))))))))
+          liveHash (hashFromSums text version)]
+      (if (not liveHash)
+        (throw (Error. (str "SHA256SUMS does not list " (tarballName version))))
+        nil)
+      ;; F9 trust anchor: the live SHA256SUMS comes from the SAME origin as the
+      ;; tarball, so it can't be the sole authority. Assert it against the
+      ;; in-repo pinned hash — a backdoored tarball + matching same-origin
+      ;; SHA256SUMS can't move this committed value.
+      (let [pinned (pinnedSha256 version)]
+        (if (not= liveHash pinned)
+          (throw (Error. (str "live SHA256SUMS disagrees with pinned checksum for firefox " version
+                              ".\n  pinned: " pinned
+                              "\n  live:   " liveHash
+                              "\n  refusing to trust same-origin checksum over the committed pin.")))
+          nil))
+      ;; Defense-in-depth: verify the detached signature when gpg is present.
+      (js/await (verifySignature version text))
+      liveHash)))
 
 (defn sha256OfFile [path :- String] :- Any
   (let [file (.file Bun path)

--- a/tools/prep/paths.bjs
+++ b/tools/prep/paths.bjs
@@ -13,6 +13,9 @@
 ;; Source overlays (committed). Layered onto engine/ during import.
 (js/export (def SRC-DIR :- String (join REPO-ROOT "src" "gjoa")))
 
+;; Committed configs (branding assets, pinned tarball checksums, …).
+(js/export (def CONFIGS-DIR :- String (join REPO-ROOT "configs")))
+
 ;; Branding source (icons live here; text derived from mozilla `unofficial`).
 (js/export (def BRANDING-SRC :- String (join REPO-ROOT "configs" "branding" "gjoa")))
 

--- a/tools/prep/verify-scriptlet-resources.sh
+++ b/tools/prep/verify-scriptlet-resources.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# verify-scriptlet-resources.sh — integrity gate for the vendored uBO scriptlet
+# library. scriptlet-resources.json is base64-encoded JS run via evalInSandbox on
+# the privileged side of the content classifier; a swapped/tampered bundle would
+# inject attacker JS into pages. This asserts the committed JSON still matches the
+# SHA-256 recorded in scriptlet-resources.PROVENANCE.md (finding F10).
+#
+# Exit 0 if the bundle matches, non-zero otherwise. Wire into `bun run preflight`.
+set -euo pipefail
+
+# Repo-relative paths, resolved from this script's own location (so it works from
+# any cwd and under CI's fresh checkout).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+target="${repo_root}/src/gjoa/toolkit/components/content-classifier/scriptlet-resources.json"
+
+# The single source of truth, kept in lockstep with the PROVENANCE note. If you
+# legitimately refresh the bundle from a pinned uBO commit, update BOTH this value
+# and scriptlet-resources.PROVENANCE.md.
+expected="f27354411da54d8a34438f542dcf0694ecd1dd4ab961f0a68de2b29f76f6dc56"
+
+if [[ ! -f "${target}" ]]; then
+  echo "verify-scriptlet-resources: FAIL — missing ${target}" >&2
+  exit 1
+fi
+
+# Prefer coreutils sha256sum; fall back to shasum -a 256 (macOS / Perl).
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "${target}" | cut -d' ' -f1)"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "${target}" | cut -d' ' -f1)"
+else
+  echo "verify-scriptlet-resources: FAIL — no sha256sum/shasum available" >&2
+  exit 1
+fi
+
+if [[ "${actual}" != "${expected}" ]]; then
+  echo "verify-scriptlet-resources: FAIL — scriptlet-resources.json SHA-256 mismatch" >&2
+  echo "  expected: ${expected}" >&2
+  echo "  actual:   ${actual}" >&2
+  echo "  The vendored uBO scriptlet bundle (run via evalInSandbox) has changed." >&2
+  echo "  If this was an intentional refresh from a PINNED uBO commit, update the" >&2
+  echo "  SHA-256 in both this script and scriptlet-resources.PROVENANCE.md." >&2
+  exit 1
+fi
+
+echo "verify-scriptlet-resources: OK — scriptlet-resources.json matches recorded SHA-256"

--- a/tools/scripts/launch-test.sh
+++ b/tools/scripts/launch-test.sh
@@ -29,5 +29,9 @@ echo "  profile: $PROFILE"
 echo "  log:     $LOG"
 echo
 
+# Opt into dev chrome loading (F4 gate: GjoaLoader sources gjoa-dev/ only when
+# GJOA_DEV_LOADER=1; otherwise it falls back to baked omni.ja chrome).
+export GJOA_DEV_LOADER=1
+
 # tee so the user sees output live AND it's captured to the log.
 "$BIN" --no-remote --profile "$PROFILE" 2>&1 | tee "$LOG"

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -294,6 +294,22 @@
           (pass "I" "chrome bundle three-way alignment"
             (str (.-length loaderScripts) " script + " (.-length loaderStyles) " style bundles agree across loader / jar.mn / chrome-bake.bjs")))))))
 
+;; ── Gate J: vendored scriptlet bundle matches its pinned SHA-256 ──────────
+;; scriptlet-resources.json is base64-encoded JS run via evalInSandbox on the
+;; privileged side of the content classifier; a swapped/tampered bundle injects
+;; attacker JS into pages. Assert it still matches the digest recorded in
+;; scriptlet-resources.PROVENANCE.md (security finding F10).
+(defn gateJ [] :- Any
+  (let [script (join REPO-ROOT "tools" "prep" "verify-scriptlet-resources.sh")]
+    (if (not (existsSync script))
+      (fail "J" "scriptlet bundle integrity" "verify-scriptlet-resources.sh missing" "restore the F10 verifier")
+      (let [r (sh (str "bash " script) {})]
+        (if (.-ok r)
+          (pass "J" "scriptlet bundle integrity" "scriptlet-resources.json matches the pinned SHA-256")
+          (fail "J" "scriptlet bundle integrity"
+            (.trim (or (.-out r) "digest mismatch"))
+            "if you refreshed the bundle from a pinned uBO commit, update the SHA-256 in verify-scriptlet-resources.sh AND scriptlet-resources.PROVENANCE.md"))))))
+
 ;; ── Run + render ──────────────────────────────────────────────────────────
 (defn main! [] :- Any
   (.log console (bold "gjoa preflight"))
@@ -302,7 +318,7 @@
 
   (let [gates [["A" gateA] ["B" gateB] ["C" gateC] ["D" gateD]
                ["E" gateE] ["F" gateF] ["G" gateG] ["H" gateH]
-               ["I" gateI]]]
+               ["I" gateI] ["J" gateJ]]]
     (doseq [gate gates]
       (let [fn (aget gate 1)]
         (try (fn)

--- a/tools/test-driver/runner.bjs
+++ b/tools/test-driver/runner.bjs
@@ -156,7 +156,10 @@
         ;; quit the test browser. The test environment runs against
         ;; whatever Firefox version the local build is at — that's
         ;; unrelated to "is this build safe to ship to users."
-        env (.assign Object {} (.-env process) {"GJOA_ALLOW_INSECURE" "1"})
+        ;; GJOA_DEV_LOADER=1: the F4 opt-in gate means the dev chrome bundles
+        ;; (the gjoa-dev/ symlink) only load when this is set. The suite drives
+        ;; the dev build, so it must opt in or no gjoa chrome loads at all.
+        env (.assign Object {} (.-env process) {"GJOA_ALLOW_INSECURE" "1" "GJOA_DEV_LOADER" "1"})
         child (spawn (.-gjoaBin opts) args
                      {:stdio (if verbose "inherit" "pipe")
                       :env env})]


### PR DESCRIPTION
Holds 0.3.0 for a complete hardening pass over **every** finding from the internal security audit (`private-docs/security-audit-2026-06-18.md`) — "no stone unturned."

## Shipped-runtime
| | Sev | Fix |
|---|---|---|
| **F1** | High | Filter-list integrity: https-only, size cap, UTF-8/HTML shape check, **SHA-256 sidecar written + re-verified on cache read-back**, keep-last-good. Residual (compromised origin serving valid list) bounded by PermissionMask=0; snapshot-pinning noted as follow-up. |
| **F2** | Med | List-driven `+js()` scriptlet eval gated behind `gjoa.contentblock.scriptlets.listDriven.enabled` (default **OFF**) — curated-only by default. |
| **F3** | Med | `Cosmetic:GetLazy` clamps child arrays (drop non-strings, cap 256/4096) before the locked native call — kills the cross-tab DoS. |
| **F4** | Med | Dev loader requires `GJOA_DEV_LOADER=1` + STAT(target)/LSTAT(link) not-group/other-writable checks. Inert in release; legit dev symlink still works. |
| **F5** | Med | Re-enable remote download reputation. |
| **F7/F8** | Low | Sandbox-invariant doc + defensive intrinsics; version-probe regex-validate + offline-vs-suppressed. |
| **F10/I3** | Med/Info | scriptlet-resources provenance+hash; GetSingleton paths re-check `IsEnabled()`. |

## Tooling / supply chain
**F6** (bench root-LPE), **F9** (pin+verify FF tarball SHA-256 + CI checksum steps), **F11** (Dark Reader snapshot pin + url()/@import strip).

## Validation
- Every fix **adversarially verified against the real code** (the verify pass caught + corrected an F1 test regression and an F4 symlink overreach before commit).
- Static: `beagle check` **0 errors / 115 files**, `node --check` on all `.sys.mjs`, `bash -n` on shell.
- Patch 0008 (I3): hunk counts consistent (+12), `IsEnabled()` is a real declared method → applies + compiles.
- A holistic **re-audit of the patched tree** is running for closure/regression sign-off.
- Runtime integration suite couldn't run locally (no build toolchain in the agent shell); the release CI builds compile-validate the full tree.