### PR TITLE
refactor(hygiene): last-of macro + conversions (#54 batch 2)

### DIFF
--- a/src/gjoa/chrome/bjs/macros.bjs
+++ b/src/gjoa/chrome/bjs/macros.bjs
@@ -116,3 +116,8 @@
 (defmacro quiet! [fallback & body]
   `(try (do ,@body)
         (catch Any _e ,fallback)))
+;; ---- array ----
+;; last element without the hand-rolled `(- (.-length x) 1)` off-by-one math.
+;; Evaluates the array once (so it's also safe on a side-effecting expression).
+(defmacro last-of [arr]
+  `(let [_a ,arr] (aget _a (- (.-length _a) 1))))

--- a/src/gjoa/chrome/bjs/tabs/drag.bjs
+++ b/src/gjoa/chrome/bjs/tabs/drag.bjs
@@ -1,6 +1,6 @@
 #lang beagle/js
 (ns gjoa.tabs.drag
-  (:require [gjoa.macros :refer [q qa xul-new attr! on! onc! bool has? rmattr! css! tabs! toggle! undef-or]]))
+  (:require [gjoa.macros :refer [q qa xul-new attr! on! onc! bool has? rmattr! css! tabs! toggle! undef-or last-of]]))
 (define-mode strict)
 
 (declare-extern [document gBrowser Math Set Array requestAnimationFrame INDENT create-logger! state row-of selection moving-tabs all-rows data-of! is-horizontal level-of level-of-row subtree-rows tab-by-id tree-data!] Any)
@@ -75,7 +75,7 @@
 (defn find-last-tab-in-group-or-before! [group :- Any] :- Any
   (let [subtree-tabs (tabs-of (.slice (subtree-rows group) 1))]
     (if (.-length subtree-tabs)
-      (aget subtree-tabs (- (.-length subtree-tabs) 1))
+      (last-of subtree-tabs)
       (find-closest-tab-before! group))))
 (js/export (defn make-drag! [deps :- Any] :- Any
   (let [clear-selection (.-clearSelection deps)
@@ -162,7 +162,7 @@
 
                   :else
                   (let [st (subtree-rows target-row)]
-                    (.after (aget st (- (.-length st) 1)) ind)))
+                    (.after (last-of st) ind)))
                 (set! (.-marginInlineStart (.-style ind))
                       (str (+ (* (if (= position "child") (+ lvl 1) lvl)
                                   INDENT)

--- a/src/gjoa/chrome/bjs/tabs/events.bjs
+++ b/src/gjoa/chrome/bjs/tabs/events.bjs
@@ -1,6 +1,6 @@
 #lang beagle/js
 (ns gjoa.tabs.events
-  (:require [gjoa.macros :refer [q on! bool rmattr! undef-or toggle! tabs!]]))
+  (:require [gjoa.macros :refer [q on! bool rmattr! undef-or toggle! tabs! last-of]]))
 (define-mode strict)
 
 (declare-extern [Services gBrowser console Math Object create-logger! CLOSED-MEMORY SPACE-ATTR all-rows group-by-id is-horizontal level-of parent-of-tab pin-tab-id read-pinned-id subtree-rows tab-by-id tab-url tree-data! pop-saved-by-url pop-saved-for-tab closed-tabs moving-tabs row-of saved-tab-queue state tree-of] Any)
@@ -118,7 +118,7 @@
                 (let [prev-row (.get row-of prev-sib-tab)]
                   (if (and prev-row (not= prev-row row))
                     (let [st (subtree-rows prev-row)
-                          anchor (aget st (- (.-length st) 1))]
+                          anchor (last-of st)]
                       (if (not= (.-nextElementSibling anchor) row)
                         (do (.after anchor row) true)
                         false))
@@ -143,11 +143,11 @@
     (cond
       (and sib-row same-parent)
       (let [st (subtree-rows sib-row)]
-        (.after (aget st (- (.-length st) 1)) row))
+        (.after (last-of st) row))
 
       (and prev-sibling-id parent-row)
       (let [st (subtree-rows parent-row)]
-        (.after (aget st (- (.-length st) 1)) row))
+        (.after (last-of st) row))
 
       (and prev-sibling-id (not parent-row))
       (.insertBefore (.-panel state) row (.-spacer state))

--- a/src/gjoa/chrome/bjs/tabs/index.bjs
+++ b/src/gjoa/chrome/bjs/tabs/index.bjs
@@ -1,6 +1,6 @@
 #lang beagle/js
 (ns gjoa.tabs.index
-  (:require [gjoa.macros :refer [q by-id xul-new xul-id attr! pref-bool on! on1! has? bool rmattr! tabs!]]))
+  (:require [gjoa.macros :refer [q by-id xul-new xul-id attr! pref-bool on! on1! has? bool rmattr! tabs! last-of]]))
 (define-mode strict)
 
 ;; Browser globals
@@ -479,7 +479,7 @@
                       (fn []
                         (let [visible (.filter (all-rows) #(not (.-hidden %)))]
                           (when (> (.-length visible) 0)
-                            (.activateVim vim-api (aget visible (- (.-length visible) 1)))))))
+                            (.activateVim vim-api (last-of visible))))))
 
                     ;; Spacer right-click -> panel context menu
                     (on! (.-spacer state) "contextmenu"


### PR DESCRIPTION
Completes the macro layer (guard!/quiet!/last-of) from the hygiene audit. Adds `last-of` + converts the 6 clean off-by-one sites in tabs/{events,drag,index}.bjs. Countdown loops correctly left alone. `beagle check` 0/48.

Closes the #54 macro-utilization headline. Remaining plan items (guard! propagation to dark-mode/blocking/loader, shared-helper extractions, the big fn decompositions) are documented optional polish, not blockers.