### PR TITLE
ci(windows): install nasm before mach build (#53)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -143,11 +143,21 @@ jobs:
             throw "MozillaBuild install failed"
           }
 
+      # mach build needs nasm (assembler for AV1/FFVPX/JPEG/VPX) — the runner
+      # doesn't ship it and MozillaBuild doesn't put it on mach's PATH. Install
+      # via chocolatey and add it to PATH for the Build step.
+      - name: Install nasm
+        shell: pwsh
+        run: |
+          choco install nasm -y --no-progress
+          "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Build
         working-directory: engine
         run: |
           export MOZBUILD_STATE_PATH="$HOME/.mozbuild"
           export MOZILLABUILD="C:\\mozilla-build"
+          export PATH="/c/Program Files/NASM:$PATH"
           ./mach build
 
       - name: Package


### PR DESCRIPTION
MozillaBuild install works now; configure fails on missing nasm (AV1/JPEG/VPX assembler). Install via chocolatey + PATH.