### PR TITLE
ci(windows): --enable-bootstrap auto-fetches toolchains (#53)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,6 +104,10 @@ jobs:
           ac_add_options --with-distribution-id=org.gjoa
           ac_add_options --with-app-name=gjoa
           ac_add_options --with-app-basename=Gjoa
+          # Auto-fetch missing Mozilla toolchains (Windows App SDK, nasm, clang,
+          # …) instead of hand-installing each one — bootstrap_path() in
+          # build/moz.configure/bootstrap.configure pulls them on demand.
+          ac_add_options --enable-bootstrap
           ac_add_options --without-wasm-sandboxed-libraries
           ac_add_options --disable-updater
           ac_add_options --disable-tests


### PR DESCRIPTION
Configure failed on missing Windows App SDK. It's fetched via bootstrap_path() when --enable-bootstrap is set. One mozconfig line → mach auto-fetches WinAppSDK + future missing toolchains, ending the manual whack-a-mole.