### PR TITLE
ci(windows): wine under Xvfb (#53)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,6 +45,7 @@ jobs:
             nasm yasm unzip zip \
             python3 python3-pip \
             aria2 msitools p7zip-full cabextract dos2unix \
+            xvfb mesa-utils libgl1-mesa-dri \
             pkg-config nodejs
 
       - name: Maximize build space
@@ -156,6 +157,11 @@ jobs:
         run: |
           export MOZBUILD_STATE_PATH="$HOME/.mozbuild"
           [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env" || true
+          # wine needs an X display to run the VS tools during cross-compile (else
+          # "explorer process failed to start" → compilation fails). Start a virtual
+          # framebuffer (zen .github/workflows/src/release-build.sh:22-26).
+          Xvfb :2 -nolisten tcp -noreset -screen 0 1024x768x24 &
+          export DISPLAY=:2
           ./mach build -j2
 
       - name: Package


### PR DESCRIPTION
Configure completes; the compile's wine-run VS tools fail with 'explorer process failed to start' — wine needs an X display. Add xvfb + DISPLAY before mach build (zen's release-build.sh pattern).