### PR TITLE
ci(windows): fxc2 native d3dcompiler + diagnostic (#53)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -159,6 +159,9 @@ jobs:
           # overriding moz.configure's check_prog which would pick the SDK fxc.exe
           # → builtin vkd3d → can't compile FF's HLSL.
           export FXC="$HOME/win-cross/fxc2/bin/fxc2.exe"
+          # Make wine load fxc2's BUNDLED native d3dcompiler_47.dll (sitting next to
+          # fxc2.exe) rather than its builtin vkd3d, which can't compile FF's HLSL.
+          export WINEDLLOVERRIDES="d3dcompiler_47=n"
           export MOZ_STUB_INSTALLER=1
           export MOZ_PKG_FORMAT=TAR
           export CROSS_BUILD=1
@@ -183,6 +186,26 @@ jobs:
         run: |
           [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env" || true
           rustup target add x86_64-pc-windows-msvc
+
+      # Ground-truth probe: the build runs fxc2 with WINEDEBUG=-all (clean log),
+      # which hides WHY fxc2 exits non-zero. Run it here verbosely so a failure is
+      # diagnosable from the same run. Never fails the job (set +e / true).
+      - name: Diagnose fxc2 under wine
+        working-directory: engine
+        run: |
+          set +e
+          export WINEPREFIX="$HOME/.wine"
+          export WINEDLLOVERRIDES="d3dcompiler_47=n"
+          W="$HOME/win-cross/wine/bin/wine"; F="$HOME/win-cross/fxc2/bin/fxc2.exe"
+          echo "=== files ==="; ls -l "$HOME/win-cross/fxc2/bin/"
+          file "$F" "$HOME/win-cross/fxc2/bin/d3dcompiler_47.dll" 2>/dev/null || true
+          echo "=== A: does fxc2 start at all? (no args) ==="
+          WINEDEBUG=fixme-all "$W" "$F" 2>&1 | head -25; echo "no-arg exit: $?"
+          echo "=== B: which d3dcompiler loads + module errors ==="
+          WINEDEBUG=+loaddll "$W" "$F" -nologo -Tvs_4_0_level_9_3 gfx/layers/d3d11/CompositorD3D11.hlsl -ELayerQuadVS -Fh/tmp/o.h 2>&1 | grep -iE "d3dcompiler|err:module|err:|cannot|Loaded" | head -40
+          echo "=== C: real compile output (default debug) ==="
+          WINEDEBUG=fixme-all "$W" "$F" -nologo -Tvs_4_0_level_9_3 gfx/layers/d3d11/CompositorD3D11.hlsl -ELayerQuadVS -Fh/tmp/o.h 2>&1 | head -30; echo "compile exit: $?"
+          true
 
       - name: Build
         working-directory: engine


### PR DESCRIPTION
Null driver fixed display; fxc2 still fails silently (WINEDEBUG=-all hid it). Force native d3dcompiler via WINEDLLOVERRIDES + add a verbose fxc2 probe to reveal ground truth.