### PR TITLE
ci: tag-driven release pipeline (build 3 platforms + draft release)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Custom self-hosted runner labels (Blacksmith) so actionlint doesn't flag them
+# as unknown. These are real, proven runners — see BUILD-LEDGER (Blacksmith
+# migration: Linux/Windows 16vcpu ~5x, macOS 6vcpu+xcode-select-26.4 ~3x).
+self-hosted-runner:
+  labels:
+    - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-6vcpu-macos-26

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,6 +2,7 @@ name: Linux build (x86_64)
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,6 +2,7 @@ name: macOS build (Apple Silicon)
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,6 +11,7 @@ name: Windows build (x86_64)
 # zen-browser/.github/workflows/windows-release-build.yml + configs/windows/mozconfig.
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+# Tag-driven release pipeline. Push a version tag and this builds all three
+# platforms (on Blacksmith) and assembles a DRAFT GitHub release with the binaries
+# attached, named gjoa-<version>-<platform>.<ext>. The draft is deliberate: a human
+# writes the release notes and clicks Publish — CI never publishes on its own.
+#
+#   git tag v0.3.3 && git push origin v0.3.3
+#
+# The three build-*.yml workflows are reused (workflow_call), so the build steps
+# stay defined in exactly one place.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  linux:
+    uses: ./.github/workflows/build-linux.yml
+  macos:
+    uses: ./.github/workflows/build-macos.yml
+  windows:
+    uses: ./.github/workflows/build-windows.yml
+
+  release:
+    needs: [linux, macos, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Assemble release assets
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          echo "version: $VER"
+          mkdir -p release
+          find artifacts/gjoa-linux-x86_64   -name '*.tar.xz'   -exec cp {} "release/gjoa-${VER}-linux-x86_64.tar.xz" \;
+          find artifacts/gjoa-macos-arm64     -name '*.dmg'      -exec cp {} "release/gjoa-${VER}-macos-arm64.dmg" \;
+          find artifacts/gjoa-windows-x86_64  -name '*.win64.zip' -exec cp {} "release/gjoa-${VER}-windows-x86_64.zip" \;
+          echo "=== assembled ==="
+          ls -la release/
+          # Fail loudly if any platform asset is missing or trivially small.
+          n=$(find release -type f | wc -l)
+          small=$(find release -type f -size -1M | wc -l)
+          if [ "$n" -ne 3 ] || [ "$small" -ne 0 ]; then
+            echo "::error::expected 3 non-trivial assets, got $n ($small under 1MB)"; exit 1
+          fi
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: "_Draft assembled by CI. Replace this with hand-written release notes, then publish._"
+          files: release/*
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Push a `v*` tag → builds all 3 on Blacksmith → assembles a **draft** release with renamed binaries attached → human writes notes + publishes. Validated without a paid build (actionlint clean; rename logic tested against real v0.3.2 artifacts). Dormant until a real tag is pushed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784484509&installation_id=141311834&pr_number=68&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F68&signature=4c46b2737bf600628e8ea5cec481cea05ca6796e740a7f35f5c362530fb49219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->