### PR TITLE
ci: free GitHub-hosted by default, Blacksmith as opt-in 'fast' toggle

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,11 +2,20 @@ name: Linux build (x86_64)
 
 on:
   workflow_dispatch:
+    inputs:
+      fast:
+        description: "Use the Blacksmith fast runner (paid) instead of free GitHub-hosted"
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      fast:
+        type: boolean
+        default: false
 
 jobs:
   build:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ inputs.fast && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
     timeout-minutes: 300
     env:
       FF_VERSION: "152.0"
@@ -17,6 +26,7 @@ jobs:
       # build stalled 34 min then SIGTERM (143) — disk exhaustion. Reclaim ~25GB
       # of preinstalled toolchains we don't use before anything else.
       - name: Free disk space
+        if: ${{ !inputs.fast }}
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
@@ -46,6 +56,7 @@ jobs:
             mercurial pkg-config nodejs
 
       - name: Maximize build space
+        if: ${{ !inputs.fast }}
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -135,7 +146,7 @@ jobs:
 
       - name: Build
         working-directory: engine
-        run: ./mach build -j$(nproc)
+        run: ./mach build -j${{ inputs.fast && '16' || '2' }}
 
       # Dark-mode contrast verification — runs the WCAG-AA harness against the
       # freshly-built binary in a clean xvfb env (the agent shell can't launch the

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,7 +2,16 @@ name: macOS build (Apple Silicon)
 
 on:
   workflow_dispatch:
+    inputs:
+      fast:
+        description: "Use the Blacksmith fast runner (paid) instead of free GitHub-hosted"
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      fast:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -11,7 +20,7 @@ jobs:
     # macos-26 image ships Xcode 26.0-26.4 but DEFAULTS to 26.2, whose SDK lacks
     # `prf` (verified: 26.0-26.3 fail to compile it, 26.4 succeeds) — so the
     # "Select newest Xcode" step below is required on this runner.
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: ${{ inputs.fast && 'blacksmith-6vcpu-macos-26' || 'macos-26' }}
     timeout-minutes: 300
     env:
       FF_VERSION: "152.0"
@@ -22,6 +31,7 @@ jobs:
       # ASAuthorization `prf` API FF 152's dom/webauthn references (26.0-26.3
       # fail to compile it; 26.4 compiles). Select the newest installed Xcode.
       - name: Select newest Xcode (needs SDK 26.4+ for webauthn prf)
+        if: ${{ inputs.fast }}
         run: |
           NEWEST=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
           echo "selecting $NEWEST"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,11 +11,20 @@ name: Windows build (x86_64)
 # zen-browser/.github/workflows/windows-release-build.yml + configs/windows/mozconfig.
 on:
   workflow_dispatch:
+    inputs:
+      fast:
+        description: "Use the Blacksmith fast runner (paid) instead of free GitHub-hosted"
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      fast:
+        type: boolean
+        default: false
 
 jobs:
   build:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ inputs.fast && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
     timeout-minutes: 360
     env:
       FF_VERSION: "152.0"
@@ -23,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space
+        if: ${{ !inputs.fast }}
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
@@ -50,6 +60,7 @@ jobs:
             pkg-config nodejs
 
       - name: Maximize build space
+        if: ${{ !inputs.fast }}
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
@@ -203,7 +214,7 @@ jobs:
           # Headless: fxc2 runs under wine with the NULL display driver selected in
           # Setup (~/.wine), so no X server is needed — its window/OLE init is a
           # no-op and the shader compile proceeds.
-          ./mach build -j$(nproc)
+          ./mach build -j${{ inputs.fast && '16' || '2' }}
 
       - name: Package
         working-directory: engine


### PR DESCRIPTION
Default builds go back to free GitHub-hosted (the proven pre-Blacksmith config: -j2 + disk/swap hacks). `fast=true` opts into Blacksmith for ~5x speed when you want it. Releases default to free. Both paths are already-shipped configs (v0.3.1 = GitHub, v0.3.2 = Blacksmith); actionlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784490191&installation_id=141311834&pr_number=69&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F69&signature=239ec6033679e7e57417ca933f48edf00291329858e5b7a87e91c8849b04c81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->