### PR TITLE
feat(preflight): Gate K — engine-currency (Phase 0)

### DIFF
--- a/tools/prep/import.bjs
+++ b/tools/prep/import.bjs
@@ -7,7 +7,8 @@
             [gjoa.tools.prep.mozconfig :refer [mozconfig!]]
             [gjoa.tools.prep.overlay :refer [overlay]]
             [gjoa.tools.prep.patches :refer [patches]]
-            [gjoa.tools.prep.log :refer [log]]))
+            [gjoa.tools.prep.log :refer [log]]
+            [fs :refer [writeFileSync]]))
 (define-mode strict)
 
 ;; Seven sequential phases. Each is idempotent, so re-running `bun run import`
@@ -33,5 +34,11 @@
 
   (.step log "phase 7/7 — generating build fingerprint")
   (js/await (fingerprint!))
+
+  ;; Stamp import completion (written LAST so its mtime is the true completion
+  ;; time). preflight Gate K refuses to build if any source tree (src/gjoa/,
+  ;; patches/, tools/prep/) is newer than this stamp — i.e. you edited source
+  ;; but forgot to re-import, so engine/ (the actual compile input) is stale.
+  (writeFileSync "engine/.gjoa-import-stamp" "gjoa engine import stamp\n")
 
   (.ok log "import complete")))

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -310,6 +310,33 @@
             (.trim (or (.-out r) "digest mismatch"))
             "if you refreshed the bundle from a pinned uBO commit, update the SHA-256 in verify-scriptlet-resources.sh AND scriptlet-resources.PROVENANCE.md"))))))
 
+;; ── Gate K: engine/ reflects current source (import-currency) ───────────────
+;; The compile input is engine/ (gitignored), which only mirrors src/gjoa/ +
+;; patches/ + the import tooling AFTER `bun run import`. Every stale-engine
+;; catastrophe — e.g. the 2026-06-14 build that compiled a 3-week-old tree, ran
+;; green, and silently dropped every recent change — is this gate's failure
+;; mode. `import` stamps engine/.gjoa-import-stamp at completion; if any source
+;; tree is newer than that stamp, engine/ is stale and must be re-imported.
+(def IMPORT-STAMP :- String (join ENGINE-DIR ".gjoa-import-stamp"))
+(defn gateK [] :- Any
+  (if (not (existsSync IMPORT-STAMP))
+    (fail "K" "engine/ reflects current source (import-currency)"
+      "no engine/.gjoa-import-stamp — engine/ is unimported (or predates this gate)"
+      "run `bun run import` to (re)build engine/ from src/gjoa/ + patches/")
+    (let [stamp-r (sh (str "stat -c %Y '" IMPORT-STAMP "'") {})
+          newest-r (sh "find src/gjoa patches tools/prep -type f -printf '%T@\\n' 2>/dev/null | sort -rn | head -1" {})
+          stamp-out (.trim (or (.-out stamp-r) ""))
+          newest-out (.trim (or (.-out newest-r) ""))]
+      (if (or (not (.-ok stamp-r)) (not (.-ok newest-r)) (= stamp-out "") (= newest-out ""))
+        (warn "K" "engine/ reflects current source (import-currency)"
+          "could not determine source/stamp mtimes — skipping (non-fatal)")
+        (if (> (parseInt newest-out 10) (parseInt stamp-out 10))
+          (fail "K" "engine/ reflects current source (import-currency)"
+            "src/gjoa/, patches/, or tools/prep/ changed since the last `bun run import`"
+            "run `bun run import` — the build compiles engine/, not src/, so un-imported edits silently vanish from the binary")
+          (pass "K" "engine/ reflects current source (import-currency)"
+            "no src/patches/tooling edits since the last import"))))))
+
 ;; ── Run + render ──────────────────────────────────────────────────────────
 (defn main! [] :- Any
   (.log console (bold "gjoa preflight"))
@@ -318,7 +345,7 @@
 
   (let [gates [["A" gateA] ["B" gateB] ["C" gateC] ["D" gateD]
                ["E" gateE] ["F" gateF] ["G" gateG] ["H" gateH]
-               ["I" gateI] ["J" gateJ]]]
+               ["I" gateI] ["J" gateJ] ["K" gateK]]]
     (doseq [gate gates]
       (let [fn (aget gate 1)]
         (try (fn)


### PR DESCRIPTION
Refuse to build if `engine/` (the compile input) is stale vs `src/gjoa/` + `patches/` + `tools/prep/`. `import` stamps `engine/.gjoa-import-stamp`; Gate K fails if any source tree is newer. Kills the stale-engine failure class (the 2026-06-14 3-week-stale build). Tested: 11/11 GREEN on a current tree; `✗ K` when source is newer. ~40 lines, no new architecture.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784491892&installation_id=141311834&pr_number=70&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F70&signature=f4ca17d70ba50b9c675ef90c6cb1c808015149c4507e1ac336b815ec9853b318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->