### PR TITLE
feat(preflight): Phase 1 — fuzz/offset early-warning + DEP-3 provenance

### DIFF
--- a/tools/prep/patch-header.bjs
+++ b/tools/prep/patch-header.bjs
@@ -45,12 +45,21 @@
         (.add out (aget m 1))))
     (Array.from out)))
 
+;; DEP-3-style provenance (Debian patch convention): a patch that Mozilla has
+;; ABSORBED upstream carries `applied-upstream: <ref>` and should be DROPPED
+;; rather than carried forward toward the divergence cliff; `forwarded: <url>`
+;; records a submission (informational). check-all flags absorbed patches.
 (defn parseHeader [text :- String] :- Any
   (if (not (.startsWith text HEADER-TAG))
     ;; Header may be preceded by nothing, but must be at the very top of the file.
-    {:hasHeader false :declaredBaseline nil}
-    (let [m (.exec (RegExp. "^#\\s*baseline-firefox:\\s*(\\S+)\\s*$" "m") text)]
-      {:hasHeader true :declaredBaseline (if m (aget m 1) nil)})))
+    {:hasHeader false :declaredBaseline nil :appliedUpstream nil :forwarded nil}
+    (let [bm (.exec (RegExp. "^#\\s*baseline-firefox:\\s*(\\S+)\\s*$" "m") text)
+          am (.exec (RegExp. "^#\\s*applied-upstream:\\s*(\\S+)\\s*$" "m") text)
+          fm (.exec (RegExp. "^#\\s*forwarded:\\s*(\\S+)\\s*$" "m") text)]
+      {:hasHeader true
+       :declaredBaseline (if bm (aget bm 1) nil)
+       :appliedUpstream (if am (aget am 1) nil)
+       :forwarded (if fm (aget fm 1) nil)})))
 
 (defn formatHeader [baseline :- String touches :- Any] :- String
   (let [lines (.concat [HEADER-TAG
@@ -68,6 +77,8 @@
      :text text
      :hasHeader (.-hasHeader parsed)
      :declaredBaseline (.-declaredBaseline parsed)
+     :appliedUpstream (.-appliedUpstream parsed)
+     :forwarded (.-forwarded parsed)
      :touches touches}))
 
 (defn listPatches [] :- Any
@@ -100,6 +111,11 @@
             (not (.-declaredBaseline p))
             (do
               (.error console (str "[patch-header] " n ": header present but `baseline-firefox` not parseable"))
+              (recur (+ i 1) (+ problems 1)))
+
+            (.-appliedUpstream p)
+            (do
+              (.error console (str "[patch-header] " n ": applied-upstream (" (.-appliedUpstream p) ") — Mozilla absorbed this change; DROP this patch (rm patches/" n ") to avoid carrying redundant divergence-debt"))
               (recur (+ i 1) (+ problems 1)))
 
             (not= (.-declaredBaseline p) current)

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -83,16 +83,31 @@
             (do
               (sh (str "cd " tmp " && git init -q && git add -A && git -c user.email=t@t -c user.name=t commit -q -m baseline") {:timeout 60000})
               (let [patches (.sort (.filter (readdirSync PATCHES-DIR) (fn [p] (.endsWith p ".patch"))))
-                    failed []]
+                    failed []
+                    drifted []]
                 (doseq [p patches]
-                  (let [r (sh (str "cd " tmp " && git apply --check " (join PATCHES-DIR p)) {})]
-                    (when (not (.-ok r))
-                      (.push failed (str p ": " (.trim (or (aget (.split (.-out r) "\n") 0) "")))))))
-                (if (> (.-length failed) 0)
+                  (let [path (join PATCHES-DIR p)
+                        r (sh (str "cd " tmp " && git apply --check " path) {})]
+                    (if (not (.-ok r))
+                      (.push failed (str p ": " (.trim (or (aget (.split (.-out r) "\n") 0) ""))))
+                      ;; Applies clean via git apply — now detect line-offset DRIFT,
+                      ;; the early warning the .rej arrives a release after. GNU patch
+                      ;; reports "Hunk #N succeeded at M (offset L lines)" for drift
+                      ;; that git apply tolerates silently. Take the largest |offset|.
+                      (let [pr (sh (str "cd " tmp " && patch -p1 --dry-run --fuzz=0 --force -i " path " 2>&1 | grep -oiE 'offset -?[0-9]+' | grep -oE '[0-9]+' | sort -rn | head -1") {})
+                            off (parseInt (.trim (or (.-out pr) "")) 10)]
+                        (when (> off 0)
+                          (.push drifted (str p " (offset " off ")")))))))
+                (cond
+                  (> (.-length failed) 0)
                   (fail "A" "patches apply clean on fresh source"
                     (str (.-length failed) "/" (.-length patches) " patches fail")
                     (str "regenerate each failing patch via `git diff` in a fresh extract:\n    " (.join failed "\n    ")))
-                  (pass "A" "patches apply clean on fresh source" (str (.-length patches) "/" (.-length patches) " apply clean")))))))))))
+                  (> (.-length drifted) 0)
+                  (warn "A" "patches apply clean on fresh source"
+                    (str (.-length patches) "/" (.-length patches) " apply, but " (.-length drifted) " drifting on line-offset (early warning — regenerate before they .rej): " (.join drifted ", ")))
+                  :else
+                  (pass "A" "patches apply clean on fresh source" (str (.-length patches) "/" (.-length patches) " apply clean, no drift")))))))))))
 
 ;; ── Gate B: chrome registration uses a known-working pattern ──────────────
 (defn gateB [] :- Any


### PR DESCRIPTION
Gate A now WARNs on line-offset drift (caught 0002 at offset 1) — the early signal before a .rej. patch-header parses DEP-3 `applied-upstream:`/`forwarded:` and flags absorbed patches for dropping. Tested: synthetic offset-7, DEP-3 flag/revert, live Gate A warn. Fork-currency Phase 1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784493566&installation_id=141311834&pr_number=71&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F71&signature=5a606e2bd0124f51817bd52dd7218447be77a298e48ea32cf779e3bebaa14d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->