### PR TITLE
feat(preflight): Phase 2 — Gate L surface contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ builds (which is the actual goal):
 - G — `nix eval` succeeds (catches eval-time rejections before compile)
 - H — diff since last working build reviewed for prereqs
 - I — chrome bundles aligned across loader / `jar.mn` / `chrome-bake.ts`
+- J — scriptlet bundle integrity (`scriptlet-resources.json` matches pinned SHA-256)
+- K — engine-currency (refuse build if `src/gjoa/`/`patches/`/`tools/prep/` is newer than the last `bun run import` — kills the stale-`engine/` class). Gate A also WARNs on patch line-offset drift (early `.rej` warning).
+- L — surface contracts (a patch/overlay's declared `# depends-on:` upstream symbols still resolve in `engine/` — catches a Rust path move / field removal / JS prop deletion *before* the compile)
 
 ### Postmortem on any unexpected rebuild
 

--- a/patches/0009-dark-mode-engine-color-inversion.patch
+++ b/patches/0009-dark-mode-engine-color-inversion.patch
@@ -9,6 +9,8 @@
 #     - dom/chrome-webidl/BrowsingContext.webidl
 #     - docshell/base/BrowsingContext.h
 #     - docshell/base/BrowsingContext.cpp
+#   depends-on:
+#     - rust-path crate::computed_value_flags::ComputedValueFlags
 #
 Engine-level dark mode: luminance-invert resolved absolute colors at
 style-resolution time (the performant successor to the compositor filter:invert).

--- a/patches/0010-dark-mode-island-scrim.patch
+++ b/patches/0010-dark-mode-island-scrim.patch
@@ -4,6 +4,8 @@
 #     - servo/components/style/properties/computed_value_flags.rs
 #     - servo/components/style/style_adjuster.rs
 #     - layout/painting/nsDisplayList.cpp
+#   depends-on:
+#     - rust-field GeckoBackground.background_image | accessor=clone_background_image
 #
 gjoa dark mode — image-backed "island" detection + dark scrim (sibling to 0009).
 

--- a/tools/prep/symbol-resolve.bjs
+++ b/tools/prep/symbol-resolve.bjs
@@ -1,0 +1,172 @@
+#lang beagle/js
+;; Symbol resolver for Gate L (surface contracts). Given a declared upstream
+;; dependency a gjoa patch/overlay relies on, verify it still RESOLVES in the
+;; patched engine/ tree — cheap (rg/fs class), no build. Each resolver returns
+;; {:verdict "resolved"|"not-found"|"ambiguous" :detail "..."}.
+;;   resolved  — the symbol is present/reachable (green)
+;;   not-found — moved / deleted / field gone (RED — the build will break)
+;;   ambiguous — cfg-gated / deep-glob / missing objdir (warn, never a false green)
+;; Design: private-docs/research-fork-currency-gate-l.md (Gate L v1).
+(ns gjoa.tools.prep.symbol-resolve
+  (:require [fs :refer [existsSync readFileSync]]
+            [path :refer [join dirname]]
+            [child_process :refer [execSync]]))
+(define-mode strict)
+(declare-extern [process Error] Any)
+
+(def REPO :- String (.cwd process))
+(def ENGINE :- String (join REPO "engine"))
+(js/export (def STYLE-ROOT :- String (join ENGINE "servo" "components" "style")))
+
+(defn slurp [f :- String] :- String
+  (if (existsSync f) (readFileSync f "utf8") ""))
+
+(defn sh [cmd :- String] :- String
+  (try (.toString (execSync cmd {:encoding "utf8" :stdio ["ignore" "pipe" "ignore"]}))
+    (catch Error _e "")))
+
+(defn rel [f :- String] :- String (.replace f (str ENGINE "/") ""))
+
+;; ── rust-path ──────────────────────────────────────────────────────────────
+;; Walk the module chain from the crate root (lib.rs), honoring `#[path = ...]`
+;; attributes — load-bearing: lib.rs maps `computed_value_flags` to
+;; properties/computed_value_flags.rs, which a naive a::b::c -> a/b/c.rs resolver
+;; gets wrong. Returns the resolved module file path, or nil if the chain breaks.
+(defn resolve-module-file [crate-root :- String mods :- Any] :- Any
+  (loop [file (join crate-root "lib.rs")
+         dir crate-root
+         i 0]
+    (if (>= i (.-length mods))
+      file
+      (let [seg (aget mods i)
+            text (slurp file)
+            pm (.exec (RegExp. (str "#\\[path\\s*=\\s*\"([^\"]+)\"\\]\\s*(?:pub\\s+)?mod\\s+" seg "\\b")) text)]
+        (cond
+          pm
+          (let [nf (join dir (aget pm 1))]
+            (recur nf (dirname nf) (+ i 1)))
+          (existsSync (join dir (str seg ".rs")))
+          (recur (join dir (str seg ".rs")) (join dir seg) (+ i 1))
+          (existsSync (join dir seg "mod.rs"))
+          (recur (join dir seg "mod.rs") (join dir seg) (+ i 1))
+          :else nil)))))
+
+(defn item-defined? [file :- String item :- String] :- Bool
+  (let [text (slurp file)]
+    (or (.test (RegExp. (str "(?:pub\\s+)?(?:struct|enum|fn|const|type|trait|static)\\s+" item "\\b")) text)
+        (.test (RegExp. (str "bitflags!\\s*\\{[\\s\\S]*?(?:pub\\s+)?struct\\s+" item "\\b")) text)
+        (.test (RegExp. (str "pub\\s+use\\s+[^;]*\\b" item "\\b")) text))))
+
+(defn has-pub-glob? [file :- String] :- Bool
+  (.test (RegExp. "pub\\s+use\\s+[^;]*::\\*\\s*;") (slurp file)))
+
+(js/export (defn resolve-rust-path [crate-root :- String sym :- String] :- Any
+  (let [clean (.replace sym (RegExp. "^crate::") "")
+        segs (.split clean "::")
+        upper-idx (.findIndex segs (fn [s :- String] :- Bool (.test (RegExp. "^[A-Z]") s)))
+        n (.-length segs)
+        mods (if (= upper-idx -1) (.slice segs 0 (- n 1)) (.slice segs 0 upper-idx))
+        item (if (= upper-idx -1) (aget segs (- n 1)) (aget segs upper-idx))
+        file (resolve-module-file crate-root mods)]
+    (cond
+      (not file) {:verdict "not-found" :detail (str "module chain broke (no `mod " (.join mods "::") "`)")}
+      (item-defined? file item) {:verdict "resolved" :detail (str item " defined in " (rel file))}
+      (has-pub-glob? file) {:verdict "ambiguous" :detail (str item " not a direct pub item; module has a `pub use ::*` glob — can't prove")}
+      :else {:verdict "not-found" :detail (str item " not defined/re-exported in " (rel file))}))))
+
+;; ── rust-field ─────────────────────────────────────────────────────────────
+;; Generated Gecko style-struct longhands live ONLY in the objdir artifact
+;; obj-*/.../style-*/out/properties.rs. Modern API is clone_<longhand>(); assert
+;; the accessor (or a bare field) exists there.
+(defn objdir-properties [] :- String
+  (.trim (sh (str "ls -t " ENGINE "/obj-*/x86_64-unknown-linux-gnu/release/build/style-*/out/properties.rs 2>/dev/null | head -1"))))
+
+(js/export (defn resolve-rust-field [field :- String accessor :- String] :- Any
+  (let [gen (objdir-properties)]
+    (if (= gen "")
+      {:verdict "ambiguous" :detail "objdir properties.rs absent (no prior build) — can't verify generated bindings"}
+      (let [text (slurp gen)
+            has-acc (if (and accessor (not= accessor "")) (.test (RegExp. (str "fn\\s+" accessor "\\b")) text) false)
+            has-field (.test (RegExp. (str "\\b" field "\\b")) text)]
+        (if (or has-acc has-field)
+          {:verdict "resolved" :detail (str (if has-acc (str "accessor " accessor "()") (str "field " field)) " present in generated properties.rs")}
+          {:verdict "not-found" :detail (str "neither field `" field "` nor accessor `" accessor "()` in generated bindings")}))))))
+
+;; ── js-prop ────────────────────────────────────────────────────────────────
+;; A property on an exported object literal (e.g. AboutNewTab.newTabURL). Find
+;; `export const Mod = {`, brace-match the body, assert get/set/prop inside.
+;; Optionally assert >=1 non-definition reader exists under must-read (the
+;; override is still CONSULTED, not orphaned like FF152's silently-ignored
+;; newTabURL). Brace match is not string/comment-aware (v1 limitation).
+(defn match-object-body [text :- String mod :- String] :- Any
+  (let [m (.exec (RegExp. (str "export\\s+(?:const|let|var)\\s+" mod "\\s*=\\s*\\{")) text)]
+    (if (not m)
+      nil
+      (let [start (+ (.-index m) (.-length (aget m 0)) -1)
+            len (.-length text)]
+        (loop [i (+ start 1) depth 1]
+          (if (>= i len)
+            (.slice text (+ start 1) i)
+            (let [ch (.charAt text i)
+                  nd (cond (= ch "{") (+ depth 1) (= ch "}") (- depth 1) :else depth)]
+              (if (= nd 0)
+                (.slice text (+ start 1) i)
+                (recur (+ i 1) nd)))))))))
+
+(js/export (defn resolve-js-prop [rel-path :- String mod :- String prop :- String must-read :- String] :- Any
+  (let [file (join ENGINE rel-path)
+        text (slurp file)]
+    (if (= text "")
+      {:verdict "not-found" :detail (str rel-path " not found")}
+      (let [body (match-object-body text mod)]
+        (if (not body)
+          {:verdict "not-found" :detail (str mod " is no longer an exported object literal in " rel-path)}
+          (let [present (.test (RegExp. (str "(?:get|set)\\s+" prop "\\s*\\(|\\b" prop "\\s*[:(]")) body)]
+            (if (not present)
+              {:verdict "not-found" :detail (str prop " not a member of " mod " (deleted/renamed)")}
+              (if (and must-read (not= must-read ""))
+                (let [readers (.trim (sh (str "rg -l --no-messages '\\." prop "\\b' " (join ENGINE must-read) " 2>/dev/null | head -1")))]
+                  (if (= readers "")
+                    {:verdict "not-found" :detail (str prop " exists but is ORPHANED — no reader under " must-read " (override silently ignored, like FF152 newTabURL)")}
+                    {:verdict "resolved" :detail (str prop " present + read under " must-read)}))
+                {:verdict "resolved" :detail (str prop " present on " mod)})))))))))
+
+;; ── contract parsing + dispatch ─────────────────────────────────────────────
+;; A `depends-on` entry is any comment line `(# | ;;) - <kind> <symbol> [@ path]
+;; [| accessor=X] [must-be-read-by: Y]`. The kind keyword IS the marker, so no
+;; block delimiter is needed — works in both patch headers and overlay comments.
+(defn parse-dep-entry [kind :- String rest :- String] :- Any
+  (let [at-m (.exec (RegExp. "@\\s*(\\S+)") rest)
+        acc-m (.exec (RegExp. "accessor=(\\S+)") rest)
+        read-m (.exec (RegExp. "must-be-read-by:\\s*(\\S+)") rest)
+        sym (.trim (aget (.split rest (RegExp. "\\s*[@|]\\s*|\\s*must-be-read-by:")) 0))]
+    {:kind kind :symbol sym
+     :at (if at-m (aget at-m 1) nil)
+     :accessor (if acc-m (aget acc-m 1) nil)
+     :mustRead (if read-m (aget read-m 1) nil)}))
+
+(js/export (defn parse-depends-on [text :- String] :- Any
+  (let [out []
+        re (RegExp. "(?:#|;;)\\s*-\\s*(rust-path|rust-field|rust-method|cpp-member|webidl-attr|js-prop)\\s+(.+?)\\s*$" "gm")]
+    (doseq [m (.matchAll text re)]
+      (.push out (parse-dep-entry (.trim (aget m 1)) (.trim (aget m 2)))))
+    out)))
+
+;; Parse a patch/overlay text's declared dependencies and resolve each against
+;; engine/. Returns [{:kind :symbol :verdict :detail}].
+(js/export (defn check-contract [text :- String] :- Any
+  (let [entries (parse-depends-on text)
+        out []]
+    (doseq [e entries]
+      (let [kind (.-kind e)
+            sym (.-symbol e)
+            r (cond
+                (= kind "rust-path") (resolve-rust-path STYLE-ROOT sym)
+                (= kind "rust-field")
+                (resolve-rust-field (or (aget (.split sym ".") 1) sym) (or (.-accessor e) ""))
+                (= kind "js-prop")
+                (let [parts (.split sym ".")]
+                  (resolve-js-prop (or (.-at e) "") (aget parts 0) (or (aget parts 1) "") (or (.-mustRead e) "")))
+                :else {:verdict "ambiguous" :detail (str kind " not yet resolved (coverage backlog)")})]
+        (.push out {:kind kind :symbol sym :verdict (.-verdict r) :detail (.-detail r)})))
+    out)))

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -11,7 +11,8 @@
 (ns gjoa.tools.scripts.preflight
   (:require [fs :refer [existsSync readFileSync readdirSync]]
             [child_process :refer [execSync]]
-            [path :refer [join]]))
+            [path :refer [join basename]]
+            [gjoa.tools.prep.symbol-resolve :refer [check-contract]]))
 (define-mode strict)
 (declare-extern [process console JSON parseInt Array String] Any)
 
@@ -352,6 +353,44 @@
           (pass "K" "engine/ reflects current source (import-currency)"
             "no src/patches/tooling edits since the last import"))))))
 
+;; ── Gate L: surface contracts (declared upstream deps still resolve) ────────
+;; A patch/overlay DEPENDS ON upstream symbols it references but does not patch
+;; (a Rust path, a generated style-struct accessor, a JS object property). git
+;; apply (Gate A) is blind to these — they're added tokens, not context — so a
+;; MOVE/REMOVAL passes apply and dies 26 min into the compile (ComputedValueFlags
+;; module move; background_image field removal) or ships a silent no-op
+;; (FF152 deleting AboutNewTab.newTabURL). A `# depends-on:` / `;; @gjoa-depends-on`
+;; block declares those anchors; Gate L resolves each against engine/, RED before
+;; the build if one vanished. Design: private-docs/research-fork-currency-gate-l.md.
+(def OVERLAY-FILES :- Any
+  [(join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "GjoaLoader.bjs")])
+(defn gateL [] :- Any
+  (let [patch-files (.map (.filter (readdirSync PATCHES-DIR) (fn [p :- String] :- Bool (.endsWith p ".patch")))
+                          (fn [p :- String] :- String (join PATCHES-DIR p)))
+        files (.concat patch-files (.filter OVERLAY-FILES (fn [f :- String] :- Bool (existsSync f))))
+        not-found []
+        ambiguous []
+        resolved []]
+    (doseq [f files]
+      (doseq [r (check-contract (readFileSync f "utf8"))]
+        (cond
+          (= (.-verdict r) "not-found")
+          (.push not-found (str (basename f) ": " (.-kind r) " `" (.-symbol r) "` — " (.-detail r)))
+          (= (.-verdict r) "ambiguous")
+          (.push ambiguous (str (basename f) ": " (.-symbol r)))
+          :else (.push resolved (.-symbol r)))))
+    (cond
+      (> (.-length not-found) 0)
+      (fail "L" "surface contracts (declared upstream deps resolve)"
+        (str (.-length not-found) " declared dependency(ies) no longer resolve")
+        (str "the upstream anchor moved/was removed — regenerate the patch/overlay against current upstream:\n    " (.join not-found "\n    ")))
+      (> (.-length ambiguous) 0)
+      (warn "L" "surface contracts (declared upstream deps resolve)"
+        (str (.-length resolved) " resolved, " (.-length ambiguous) " ambiguous (cfg/glob/no-objdir — can't prove): " (.join ambiguous ", ")))
+      :else
+      (pass "L" "surface contracts (declared upstream deps resolve)"
+        (str (.-length resolved) " declared upstream dependencies resolve")))))
+
 ;; ── Run + render ──────────────────────────────────────────────────────────
 (defn main! [] :- Any
   (.log console (bold "gjoa preflight"))
@@ -360,7 +399,7 @@
 
   (let [gates [["A" gateA] ["B" gateB] ["C" gateC] ["D" gateD]
                ["E" gateE] ["F" gateF] ["G" gateG] ["H" gateH]
-               ["I" gateI] ["J" gateJ] ["K" gateK]]]
+               ["I" gateI] ["J" gateJ] ["K" gateK] ["L" gateL]]]
     (doseq [gate gates]
       (let [fn (aget gate 1)]
         (try (fn)


### PR DESCRIPTION
Gate L resolves each patch/overlay's declared `# depends-on:` upstream symbols against engine/ — RED before the build if a Rust path moved, a generated field/accessor was removed, or a JS prop was deleted. Resolver core (rust-path #[path]-aware walk / rust-field objdir / js-prop object-literal) in symbol-resolve.bjs. Tested: 12/12 GREEN; regression flips to crisp RED naming the symbol. Would have caught all 3 ledger failures pre-build. Fork-currency Phase 2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784495576&installation_id=141311834&pr_number=72&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F72&signature=10286ca2e640686a9c4f2298a14883bab26c3921aa6ec7bc7b13f517df3b680c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->