### PR TITLE
feat(tools): Phase 4 (part) — seam-cost scorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "security:bump": "bun run tools:compile && bun .beagle-tools/gjoa/tools/security/bump.js",
     "status": "bun run tools:compile && bun .beagle-tools/gjoa/tools/scripts/status.js",
     "preflight": "bun run tools:compile && bun .beagle-tools/gjoa/tools/scripts/preflight.js",
+    "cost": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/patch-cost.js",
     "check": "BEAGLE_PURITY=error ../beagle/bin/beagle check --profile 3 src/gjoa/chrome/bjs tools tests",
     "test": "bun run check && bun run tools:compile && bun test .beagle-tools/gjoa/tests/branding.test.js",
     "test:chrome:ensure": "bun run tools:compile && bun .beagle-tools/gjoa/tools/chrome-bundle/ensure-installed.js",

--- a/tools/prep/patch-cost.bjs
+++ b/tools/prep/patch-cost.bjs
@@ -1,0 +1,66 @@
+#lang beagle/js
+;; Phase 4 (fork-currency roadmap) — seam-cost scorer. Turns the lane doctrine
+;; into a NUMBER: each patch's expected rebases-broken-per-year ~= its seam-tier
+;; cadence (rung) x the upstream churn under the files it touches (measured from
+;; mozilla-central git history). Ranks patches by fragility so demotion effort
+;; targets the costliest carriers first. Run: `bun run cost`.
+(ns gjoa.tools.prep.patch-cost
+  (:require [fs :refer [readdirSync readFileSync]]
+            [path :refer [join]]
+            [child_process :refer [execSync]]))
+(define-mode strict)
+(declare-extern [process console parseInt Error] Any)
+
+(def REPO :- String (.cwd process))
+(def PATCHES-DIR :- String (join REPO "patches"))
+;; mozilla-central full clone (the churn oracle). /reference per code/CLAUDE.md.
+(def FF :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
+
+(defn sh [cmd :- String] :- String
+  (try (.toString (execSync cmd {:encoding "utf8" :stdio ["ignore" "pipe" "ignore"]}))
+    (catch Error _e "")))
+
+;; churn = commits touching <file> in mozilla-central over the last year.
+(defn churn [file :- String] :- Number
+  (parseInt (.trim (sh (str "git -C " FF " log --oneline --since='1 year ago' -- '" file "' 2>/dev/null | wc -l"))) 10))
+
+(defn touches [text :- String] :- Any
+  (let [out []]
+    (doseq [m (.matchAll text (RegExp. "^#     - (\\S+)\\s*$" "gm"))]
+      (.push out (aget m 1)))
+    out))
+
+;; rung_base — seam-tier cadence multiplier, inferred from the highest-cadence
+;; file kind the patch touches. Native C++/Rust/WebIDL source conflicts per
+;; release (3.0); a .sys.mjs in-place patch per major version (0.5); build-wiring
+;; (moz.build / jar.mn) ~never (0.05).
+(defn rung-base [files :- Any] :- Number
+  (cond
+    (.some files (fn [f :- String] :- Bool (.test (RegExp. "\\.(rs|cpp|cc|h|webidl)$") f))) 3.0
+    (.some files (fn [f :- String] :- Bool (.test (RegExp. "\\.(mjs|js)$") f))) 0.5
+    :else 0.05))
+
+(defn rung-name [rb :- Number] :- String
+  (cond (= rb 3.0) "native-src" (= rb 0.5) "sys.mjs" :else "build"))
+
+(defn score-patch [name :- String] :- Any
+  (let [text (readFileSync (join PATCHES-DIR name) "utf8")
+        files (touches text)
+        rb (rung-base files)
+        total-churn (.reduce files (fn [acc :- Number f :- String] :- Number (+ acc (churn f))) 0)]
+    {:name name :rung rb :churn total-churn :score (* rb total-churn) :nfiles (.-length files)}))
+
+(defn main! [] :- Any
+  (let [names (.sort (.filter (readdirSync PATCHES-DIR) (fn [p :- String] :- Bool (.endsWith p ".patch"))))
+        rows (.sort (.map names score-patch) (fn [a :- Any b :- Any] :- Number (- (.-score b) (.-score a))))]
+    (.log console "patch seam-cost  =  rung x upstream-churn  (~expected rebases/yr; higher = demote first)\n")
+    (doseq [r rows]
+      (.log console (str "  " (.padStart (.toFixed (.-score r) 1) 7)
+                         "   " (.padEnd (rung-name (.-rung r)) 11)
+                         " churn=" (.padEnd (str (.-churn r)) 4)
+                         " files=" (.padEnd (str (.-nfiles r)) 3)
+                         " " (.-name r))))
+    (.log console "")))
+
+(when (.-main (js/import-meta))
+  (main!))


### PR DESCRIPTION
`bun run cost` ranks patches by expected rebases/yr = rung × upstream-churn (real mozilla-central history from ~/code/reference/firefox). 0009+0008 are the fragile carriers; 0001 (high moz.build churn but robust 1-liner) correctly scores low. Remaining Phase 4: demotion detection (needs fram blast-radius) + externs hardening (delicate). Fork-currency Phase 4 (part).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784496087&installation_id=141311834&pr_number=73&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F73&signature=2e87220c38d655c9e08a1b14a355bf546213d7dac6c04e51240411e66e2eb213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->