### PR TITLE
chore(bump): Firefox 152.0 → 152.0.1 (security)

### DIFF
--- a/configs/firefox-152.0.1.sha256
+++ b/configs/firefox-152.0.1.sha256
@@ -1,0 +1,14 @@
+# Pinned SHA-256 of the Firefox source tarball for FF_VERSION 152.0.1.
+#
+# This is an in-repo trust anchor (committed, reviewed) that is INDEPENDENT of
+# the live SHA256SUMS Mozilla serves from the same origin as the tarball. The
+# download/verify path asserts the live checksum against THIS pinned value, so
+# an origin/TLS compromise that serves a backdoored tarball + matching
+# SHA256SUMS still fails verification (the attacker cannot change this file).
+#
+# Format is `sha256sum -c` compatible: `<hash>  <path-as-listed-in-SHA256SUMS>`.
+# To bump FF_VERSION: add a configs/firefox-<version>.sha256 with the value from
+# https://archive.mozilla.org/pub/firefox/releases/<version>/SHA256SUMS, after
+# verifying that file's GPG signature (SHA256SUMS.asc) against Mozilla's
+# release-signing key fingerprint 14F26682D0916CDD81E37B6D61B7B526D98F0353.
+bff037bd04f0df25a330daa7133bea6eee5a02b7ce39da30581580271502f15e  source/firefox-152.0.1.source.tar.xz

--- a/gjoa.json
+++ b/gjoa.json
@@ -4,12 +4,12 @@
   "binaryName": "gjoa",
   "appId": "gjoa",
   "vendor": "tompassarelli",
-  "displayVersion": "0.3.2",
+  "displayVersion": "0.3.3",
   "license": "MPL-2.0",
   "github": "tompassarelli/gjoa",
   "firefox": {
-    "version": "152.0",
-    "candidate": "152.0",
+    "version": "152.0.1",
+    "candidate": "152.0.1",
     "candidateBuild": 1
   },
   "branding": {

--- a/patches/0001-browser-components-mozbuild-include-gjoa.patch
+++ b/patches/0001-browser-components-mozbuild-include-gjoa.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 151.0.1
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - browser/components/moz.build
 #

--- a/patches/0002-browser-glue-import-gjoa-loader.patch
+++ b/patches/0002-browser-glue-import-gjoa-loader.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 151.0.1
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - browser/components/BrowserGlue.sys.mjs
 #

--- a/patches/0007-enable-sqlite-fts5.patch
+++ b/patches/0007-enable-sqlite-fts5.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 151.0.1
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - third_party/sqlite3/src/moz.build
 #

--- a/patches/0008-content-classifier-cosmetic-filtering.patch
+++ b/patches/0008-content-classifier-cosmetic-filtering.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 152.0
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - Cargo.lock
 #     - toolkit/components/content-classifier/ContentClassifierService.cpp

--- a/patches/0009-dark-mode-engine-color-inversion.patch
+++ b/patches/0009-dark-mode-engine-color-inversion.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 152.0
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - servo/components/style/values/specified/color.rs
 #     - servo/components/style/device/gecko.rs

--- a/patches/0010-dark-mode-island-scrim.patch
+++ b/patches/0010-dark-mode-island-scrim.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 152.0
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - servo/components/style/properties/computed_value_flags.rs
 #     - servo/components/style/style_adjuster.rs

--- a/patches/0011-newtab-redirector-gjoa.patch
+++ b/patches/0011-newtab-redirector-gjoa.patch
@@ -1,5 +1,5 @@
 # gjoa-patch:
-#   baseline-firefox: 152.0
+#   baseline-firefox: 152.0.1
 #   touches:
 #     - browser/components/newtab/AboutNewTabRedirector.sys.mjs
 #


### PR DESCRIPTION
Security point release. Phase-3 forecast: 152.0.1 delta is fully disjoint from gjoa's surface — zero patch conflicts, all apply unchanged. Pinned + hash-matched source. Ships as v0.3.3.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784497008&installation_id=141311834&pr_number=74&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F74&signature=d9c557ef90b41ee238d3a4758a123beb3cb367cf843d60e6d699022a0384aa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->