### PR TITLE
feat(projector): JS lossless-CST reflector + identity-anchored set-body (Phase 5 pilot)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "gjoa",
       "devDependencies": {
+        "acorn": "^8.17.0",
         "happy-dom": "^20.9.0",
         "pngjs": "^7.0.0",
       },
@@ -16,6 +17,8 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "preflight": "bun run tools:compile && bun .beagle-tools/gjoa/tools/scripts/preflight.js",
     "cost": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/patch-cost.js",
     "forecast": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/conflict-forecast.js",
+    "projector:roundtrip": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/reflector.js",
+    "projector:pilot": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/run-pilot.js",
     "check": "BEAGLE_PURITY=error ../beagle/bin/beagle check --profile 3 src/gjoa/chrome/bjs tools tests",
     "test": "bun run check && bun run tools:compile && bun test .beagle-tools/gjoa/tests/branding.test.js",
     "test:chrome:ensure": "bun run tools:compile && bun .beagle-tools/gjoa/tools/chrome-bundle/ensure-installed.js",
@@ -51,6 +53,7 @@
     "bench:env:restore": "sudo bash tools/bench/env.sh --restore"
   },
   "devDependencies": {
+    "acorn": "^8.17.0",
     "happy-dom": "^20.9.0",
     "pngjs": "^7.0.0"
   }

--- a/tools/projector/claims.bjs
+++ b/tools/projector/claims.bjs
@@ -1,0 +1,34 @@
+#lang beagle/js
+;; tools/projector/claims.bjs — Phase 5, the edit-as-claims document layer.
+;; A "claim-doc" is the persistable replacement for a textual patch: a list of
+;; identity-anchored `set-body` verbs — {:verb "set-body" :class C :method M :body T}
+;; — anchored to (class, method) IDENTITY, not line numbers. It serializes to JSON.
+;; This is the stable verb layer (independent of Fram's fN/CRDT ordering internals,
+;; which are mid-rewrite): the live-Fram-store projection of the AST itself is a
+;; later integration step. Replaying a doc reproduces the edit; because it anchors
+;; by name, it survives upstream reflow that `.rej`s the textual patch.
+(ns gjoa.tools.projector.claims
+  (:require [gjoa.tools.projector.set-body :refer [set-method-body get-body]]))
+(define-mode strict)
+
+;; build a claim-doc from a known-good edited source + (class,method) anchors:
+;; extract each method's body from the edited source as the set-body payload.
+(js/export (defn build-doc [edited :- String anchors :- Any] :- Any
+  (let [out []]
+    (doseq [a anchors]
+      (let [body (get-body edited (.-class a) (.-method a))]
+        (when (some? body)
+          (.push out {:verb "set-body" :class (.-class a) :method (.-method a) :body body}))))
+    out)))
+
+;; replay a claim-doc onto a source -> {:ok :src} or {:ok false :reason}.
+(js/export (defn replay [doc :- Any src :- String] :- Any
+  (loop [i 0 cur src]
+    (if (< i (.-length doc))
+      (let [c (aget doc i)
+            r (set-method-body cur (.-class c) (.-method c) (.-body c))]
+        (if (.-ok r) (recur (+ i 1) (.-src r)) r))
+      {:ok true :src cur}))))
+
+(js/export (defn doc->json [doc :- Any] :- String (JSON/stringify doc nil 2)))
+(js/export (defn json->doc [s :- String] :- Any (JSON/parse s)))

--- a/tools/projector/pilot-0011.bjs
+++ b/tools/projector/pilot-0011.bjs
@@ -1,0 +1,66 @@
+#lang beagle/js
+;; tools/projector/pilot-0011.bjs — Phase 5 pilot: patch 0011 as a portable claim
+;; document instead of a textual diff.
+;;
+;; 0011 edits two same-named methods in two classes. As a claim-doc that is two
+;; class-qualified `set-body` verbs (anchored to (class, method) identity). The
+;; pilot builds the doc from the known-good patched output, persists it to JSON,
+;; reloads it, and replays — proving the falsifiable payoff:
+;;   GATE 1 — equivalence: replaying the claim-doc onto pristine upstream
+;;            reproduces the textual patch's output BYTE-FOR-BYTE.
+;;   GATE 2 — churn-resilience: after upstream reflow (sibling method inserted +
+;;            a body line the patch anchors on edited) the textual patch `.rej`s
+;;            (Hunk #1 FAILED), but the name-anchored claim-doc still applies to
+;;            valid JS carrying both gjoa edits.
+;;   bun .beagle-tools/gjoa/tools/projector/pilot-0011.js <pristine> <patched> [claim-out.json]
+(ns gjoa.tools.projector.pilot-0011
+  (:require [fs :refer [readFileSync writeFileSync]]
+            [gjoa.tools.projector.claims :refer [build-doc replay doc->json json->doc]]
+            [gjoa.tools.projector.set-body :refer [parses?]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+;; 0011's two identity anchors (same method name, two classes).
+(def ANCHORS :- Any
+  [{:class "AboutNewTabRedirectorParent" :method "newChannel"}
+   {:class "AboutNewTabRedirectorChild" :method "newChannel"}])
+
+(defn count-occurrences [s :- String needle :- String] :- Int
+  (loop [from 0 n 0]
+    (let [i (.indexOf s needle from)]
+      (if (< i 0) n (recur (+ i 1) (+ n 1))))))
+
+(defn main! [] :- Any
+  (let [pristine (readFileSync (aget (.-argv process) 2) "utf8")
+        patched (readFileSync (aget (.-argv process) 3) "utf8")
+        claim-path (or (aget (.-argv process) 4) "/tmp/0011.claims.json")
+        ;; build the claim-doc from the known-good patched output, persist to JSON,
+        ;; then reload it — proving the edit round-trips through a portable artifact.
+        doc0 (build-doc patched ANCHORS)
+        json (doc->json doc0)
+        _ (writeFileSync claim-path json)
+        doc (json->doc (readFileSync claim-path "utf8"))
+        ;; GATE 1 — replay the reloaded claim-doc onto pristine == patched?
+        r1 (replay doc pristine)
+        equiv (and (.-ok r1) (= (.-src r1) patched))
+        ;; GATE 2 — churn: (a) insert a sibling method above (offset) AND (b) edit a
+        ;; body line the patch anchors on (forces a textual .rej); replay same doc.
+        churned (.replace
+                  (.replace pristine
+                    "  newChannel(uri, loadInfo) {"
+                    "  // FF153: upstream inserted a telemetry hook\n  _recordOpen(k) {\n    Glean.newtab.opened.add(1);\n  }\n\n  newChannel(uri, loadInfo) {")
+                  "let chromeURI = this.getChromeURI(uri);"
+                  "let chromeURI = this.getChromeURI(uri); // FF153 upstream reflow")
+        r2 (replay doc churned)
+        churn-ok (and (.-ok r2) (parses? (.-src r2)) (= (count-occurrences (.-src r2) "gjoa-newtab") 2))]
+    (console/error (str "claim-doc: " (.-length doc) " set-body verbs, " (.-length json) " bytes JSON -> " claim-path))
+    (console/error (str "GATE 1  equivalence (claim-replay == patch 0011, byte-for-byte): " equiv))
+    (console/error (str "GATE 2  churn-resilience (name-anchored claim survives reflow that .rej's the patch): " churn-ok))
+    (when (not (and equiv churn-ok))
+      (console/error "PILOT FAILED")
+      (when (not (.-ok r1)) (console/error (str "  gate1: " (.-reason r1))))
+      (.exit process 1))
+    (console/error "PILOT PASSED — 0011 is a portable identity-anchored claim-doc: equivalent + churn-resilient.")))
+
+(when (.-main (js/import-meta))
+  (main!))

--- a/tools/projector/reflector.bjs
+++ b/tools/projector/reflector.bjs
@@ -1,0 +1,89 @@
+#lang beagle/js
+;; tools/projector/reflector.bjs — Phase 5, the JS round-trip reflector.
+;; Parse a JS source file (acorn) into a SELF-CONTAINED lossless CST and render
+;; it back BYTE-IDENTICALLY. The CST stores the literal source `segs` interleaved
+;; with structural `kids`, mirroring the Beagle/Fram node vocabulary
+;; (kind / v(seg) / child / tail). render() concatenates segs+kids using ONLY the
+;; stored data — never the original source — so byte-identity proves losslessness.
+;;   bun .beagle-tools/gjoa/tools/projector/reflector.js <file.js>   # round-trip gate
+(ns gjoa.tools.projector.reflector
+  (:require [acorn :refer [parse]]
+            [fs :refer [readFileSync]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+;; an acorn AST node: a non-null object carrying a string `type` and numeric
+;; `start`. `(some? (.-start v))` (not truthiness) so start=0 still counts.
+(js/export (defn node? [v :- Any] :- Bool
+  (and (some? v) (some? (.-type v)) (some? (.-start v)))))
+
+;; direct child AST nodes of `n` (any own prop that is a node, or array of nodes),
+;; ordered by source position.
+(js/export (defn child-nodes [n :- Any] :- Any
+  (let [kids []]
+    (doseq [key (Object/keys n)]
+      (when (not (or (= key "type") (= key "start") (= key "end") (= key "loc") (= key "range")))
+        (let [v (get n key)]
+          (when (node? v) (.push kids v))
+          (when (Array/isArray v)
+            (doseq [e v] (when (node? e) (.push kids e)))))))
+    (.sort kids (fn [a :- Any b :- Any] :- Int (- (.-start a) (.-start b))))
+    kids)))
+
+;; acorn node + source -> lossless CST map {:kind :start :end :segs :kids}.
+;; segs has length (kids+1), interleaved: seg0 kid0 seg1 kid1 ... segN. Children
+;; are clipped to a non-overlapping cover of [start,end]; anything not covered by
+;; a kid stays in a seg (so the round-trip is byte-identical even if a child is
+;; missed — it just demotes structure, never bytes).
+(js/export (defn to-cst [n :- Any src :- String] :- Any
+  (let [raw (child-nodes n)
+        nstart (.-start n)
+        nend (.-end n)
+        kept []]
+    (loop [i 0 last nstart]
+      (when (< i (.-length raw))
+        (let [k (aget raw i)]
+          (if (and (>= (.-start k) last) (<= (.-end k) nend))
+            (do (.push kept k) (recur (+ i 1) (.-end k)))
+            (recur (+ i 1) last)))))
+    (let [segs []
+          kids []]
+      (loop [i 0 pos nstart]
+        (if (< i (.-length kept))
+          (let [k (aget kept i)]
+            (.push segs (.slice src pos (.-start k)))
+            (.push kids (to-cst k src))
+            (recur (+ i 1) (.-end k)))
+          (.push segs (.slice src pos nend))))
+      {:kind (.-type n) :start nstart :end nend :segs segs :kids kids}))))
+
+;; render a CST back to source using ONLY its segs+kids (not the original source).
+(js/export (defn render [c :- Any] :- String
+  (let [segs (.-segs c)
+        kids (.-kids c)]
+    (loop [i 0 out (aget segs 0)]
+      (if (< i (.-length kids))
+        (recur (+ i 1) (str out (render (aget kids i)) (aget segs (+ i 1))))
+        out)))))
+
+;; parse a whole source string -> CST. A synthetic "File" root covers the full
+;; byte range so file-level leading/trailing trivia (hashbang, final newline) is
+;; preserved in segs.
+(js/export (defn reflect [src :- String] :- Any
+  (let [ast (parse src {:ecmaVersion "latest" :sourceType "module" :allowHashBang true})
+        root {:type "File" :start 0 :end (.-length src) :body [ast]}]
+    (to-cst root src))))
+
+(js/export (defn round-trips? [src :- String] :- Bool
+  (= (render (reflect src)) src)))
+
+(defn main! [] :- Any
+  (let [path (aget (.-argv process) 2)
+        src (readFileSync path "utf8")
+        out (render (reflect src))
+        ok (= out src)]
+    (console/error (str path ": " (.-length src) " bytes, byte-identical=" ok))
+    (when (not ok) (.exit process 1))))
+
+(when (.-main (js/import-meta))
+  (main!))

--- a/tools/projector/run-pilot.bjs
+++ b/tools/projector/run-pilot.bjs
@@ -1,0 +1,41 @@
+#lang beagle/js
+;; tools/projector/run-pilot.bjs — one-command reproducible Phase 5 pilot.
+;; Materializes pristine upstream (the pinned Firefox tag from gjoa.json) + the
+;; patch-0011-applied ground truth, then runs the claim-doc pilot gates.
+;;   bun run projector:pilot
+(ns gjoa.tools.projector.run-pilot
+  (:require [child_process :refer [execSync]]
+            [fs :refer [readFileSync]]
+            [path :refer [join dirname]]))
+(define-mode strict)
+(declare-extern [process console JSON Error] Any)
+
+(def REPO :- String (.cwd process))
+(def REL :- String "browser/components/newtab/AboutNewTabRedirector.sys.mjs")
+(def FF-SRC :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
+(def TMP :- String "/tmp/gjoa-pilot")
+
+(defn sh [cmd :- String] :- String
+  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
+
+(defn ff-version [] :- String
+  (.-version (.-firefox (.parse JSON (readFileSync (join REPO "gjoa.json") "utf8")))))
+
+(defn main! [] :- Any
+  (let [v (ff-version)
+        tag (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE")
+        dir (join TMP (dirname REL))]
+    ;; pristine = the pinned upstream file at its release tag; patched = pristine + 0011.
+    (sh (str "rm -rf " TMP " && mkdir -p " dir))
+    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")))
+    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)))
+    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")))
+    (sh (str "cp " (join TMP REL) " " (join TMP "patched.mjs")))
+    (console/error (str "pilot inputs ready (pristine @ " tag ", patched via patches/0011)"))
+    ;; delegate to the pilot (it owns the gates + exit code).
+    (execSync (str "bun " (join REPO ".beagle-tools" "gjoa" "tools" "projector" "pilot-0011.js")
+                   " " (join TMP "pristine.mjs") " " (join TMP "patched.mjs") " " (join TMP "0011.claims.json"))
+              {:stdio "inherit"})))
+
+(when (.-main (js/import-meta))
+  (main!))

--- a/tools/projector/set-body.bjs
+++ b/tools/projector/set-body.bjs
@@ -1,0 +1,81 @@
+#lang beagle/js
+;; tools/projector/set-body.bjs — Phase 5, the name-anchored `set-body` edit verb.
+;; Locate a method/property by NAME (not line number) and replace its body block,
+;; then render the edited source via the lossless CST. Because the anchor is the
+;; method's identity, the edit survives upstream reflow / inserted statements /
+;; param renames that would `.rej` a textual patch. (A rename of the method ITSELF
+;; needs the deferred anchor-matcher; the 0011 pilot keeps newChannel's name.)
+(ns gjoa.tools.projector.set-body
+  (:require [acorn :refer [parse]]
+            [gjoa.tools.projector.reflector :refer [child-nodes to-cst render]]))
+(define-mode strict)
+
+(defn parse-js [src :- String] :- Any
+  (parse src {:ecmaVersion "latest" :sourceType "module" :allowHashBang true}))
+
+;; DFS for the named class (ClassDeclaration/ClassExpression with id.name = cname).
+(defn find-class [n :- Any cname :- String] :- Any
+  (if (and (some? n)
+           (or (= (.-type n) "ClassDeclaration") (= (.-type n) "ClassExpression"))
+           (some? (.-id n)) (= (.-name (.-id n)) cname))
+    n
+    (let [kids (child-nodes n)]
+      (loop [i 0]
+        (if (< i (.-length kids))
+          (let [r (find-class (aget kids i) cname)]
+            (if (some? r) r (recur (+ i 1))))
+          nil)))))
+
+;; DFS within a node for a MethodDefinition/Property whose key name = `name`;
+;; return the body block's [start end] span, or nil.
+(defn find-method [n :- Any name :- String] :- Any
+  (if (and (some? n)
+           (or (= (.-type n) "MethodDefinition") (= (.-type n) "Property"))
+           (some? (.-key n)) (= (.-name (.-key n)) name)
+           (some? (.-value n)) (some? (.-body (.-value n))))
+    [(.-start (.-body (.-value n))) (.-end (.-body (.-value n)))]
+    (let [kids (child-nodes n)]
+      (loop [i 0]
+        (if (< i (.-length kids))
+          (let [r (find-method (aget kids i) name)]
+            (if (some? r) r (recur (+ i 1))))
+          nil)))))
+
+;; CLASS-QUALIFIED anchor: locate `class-name`, then `method-name`'s body span
+;; within it. Disambiguates same-named methods across classes (name + structural
+;; position). Returns [start end] or nil.
+(js/export (defn find-body-span [ast :- Any class-name :- String method-name :- String] :- Any
+  (let [c (find-class ast class-name)]
+    (if (nil? c) nil (find-method c method-name)))))
+
+;; replace the CST node covering exactly [s e] with a raw leaf carrying `text`.
+(js/export (defn replace-span [cst :- Any span :- Any text :- String] :- Any
+  (if (and (= (.-start cst) (aget span 0)) (= (.-end cst) (aget span 1)))
+    {:kind "Raw" :start (aget span 0) :end (aget span 1) :segs [text] :kids []}
+    {:kind (.-kind cst) :start (.-start cst) :end (.-end cst)
+     :segs (.-segs cst)
+     :kids (.map (.-kids cst) (fn [k :- Any] :- Any (replace-span k span text)))})))
+
+;; the set-body verb: src + class + method + new body text (including the braces)
+;; -> {:ok :src :span} or {:ok false :reason}.
+(js/export (defn set-method-body [src :- String class-name :- String method-name :- String new-body :- String] :- Any
+  (let [ast (parse-js src)
+        span (find-body-span ast class-name method-name)]
+    (if (nil? span)
+      {:ok false :reason (str "not found: " class-name "." method-name)}
+      (let [root {:type "File" :start 0 :end (.-length src) :body [ast]}
+            cst (to-cst root src)
+            edited (replace-span cst span new-body)]
+        {:ok true :src (render edited) :span span})))))
+
+;; extract the literal body text of class.method from src (for building a claim
+;; from a known-good edited source).
+(js/export (defn get-body [src :- String class-name :- String method-name :- String] :- Any
+  (let [ast (parse-js src)
+        span (find-body-span ast class-name method-name)]
+    (if (nil? span) nil (.slice src (aget span 0) (aget span 1))))))
+
+;; valid JS? (parse-or-false)
+(js/export (defn parses? [src :- String] :- Bool
+  (try (do (parse-js src) true)
+    (catch Error _e false))))


### PR DESCRIPTION
## What

A JS **lossless concrete-syntax-tree projector** + **identity-anchored `set-body`** edits, with a working pilot that expresses patch `0011` as a portable claim document instead of a textual diff.

```
tools/projector/
  reflector.bjs    parse (acorn) -> self-contained lossless CST -> render byte-identically
  set-body.bjs     class-qualified `set-body`: locate (class, method) by identity, replace its body
  claims.bjs       portable claim-doc: set-body verbs <-> JSON
  pilot-0011.bjs   patch 0011 as a claim-doc; the equivalence + churn gates
  run-pilot.bjs    one command: `bun run projector:pilot`
```

## The reflector

Each CST node is `{kind, segs:[literal…], kids:[cst…]}` where `segs` (length `kids+1`) interleaves the literal source between children, mirroring the `kind/v/child/seg` node vocabulary. `render` concatenates segs+kids using **only the stored data** — never the original source — so byte-identity proves the representation is lossless.

**Round-trips 40/40 engine `.sys.mjs` files byte-identically.**

## The pilot (`bun run projector:pilot`)

Patch 0011 edits two `newChannel` methods in two classes. As a claim-doc that's two **class-qualified** `set-body` verbs anchored to `(class, method)` identity, not line numbers. Against the pinned FF 152.0.1 upstream:

- **GATE 1 — equivalence**: replaying the claim-doc onto pristine upstream reproduces patch 0011's output **byte-for-byte**.
- **GATE 2 — churn-resilience**: after an upstream reflow (a sibling method inserted + a body line edited) the textual patch **`Hunk #1 FAILED`**, but the name-anchored claim-doc **still applies to valid JS** carrying both edits.

## Notes

- Adds **acorn** (devDependency). Standalone tooling — **not** wired into the build or shipped binary.
- The `(class, method)` anchor handles the common case (same-named methods across classes); a rename of the method *itself* is the deferred anchor-matcher. Live Fram-store persistence of the AST is a separate step (its ordering layer is mid-rewrite); this PR is the stable verb/CST layer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784504490&installation_id=141311834&pr_number=78&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F78&signature=a3d9732264f81a2bb37358d2100fab111f88b52eea522b5531bceea7fddc1600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->