### PR TITLE
feat(projector): claim-doc fallback for patch 0011 in the build (Phase 5 integration)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Apply overlays and patches
         run: bun run import
 
+      - name: Verify JS projector + claim-docs
+        run: bun run projector:test
+
       - name: Write mozconfig
         run: |
           cat > engine/mozconfig <<'MOZCONFIG'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Apply overlays and patches
         run: bun run import
 
+      - name: Verify JS projector + claim-docs
+        run: bun run projector:test
+
       - name: Write mozconfig
         run: |
           cat > engine/mozconfig <<'MOZCONFIG'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Apply overlays and patches
         run: bun run import
 
+      - name: Verify JS projector + claim-docs
+        run: bun run projector:test
+
       # --- Windows cross toolchain (adapted from zen windows-release-build.yml) ---
       - name: Setup Windows cross toolchain
         working-directory: engine

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "forecast": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/conflict-forecast.js",
     "projector:roundtrip": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/reflector.js",
     "projector:pilot": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/run-pilot.js",
+    "projector:gen-claims": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/gen-claims.js",
+    "projector:test": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/test-projector.js",
     "check": "BEAGLE_PURITY=error ../beagle/bin/beagle check --profile 3 src/gjoa/chrome/bjs tools tests",
     "test": "bun run check && bun run tools:compile && bun test .beagle-tools/gjoa/tests/branding.test.js",
     "test:chrome:ensure": "bun run tools:compile && bun .beagle-tools/gjoa/tools/chrome-bundle/ensure-installed.js",

--- a/patches/0011-newtab-redirector-gjoa.claims.json
+++ b/patches/0011-newtab-redirector-gjoa.claims.json
@@ -1,0 +1,17 @@
+{
+  "file": "browser/components/newtab/AboutNewTabRedirector.sys.mjs",
+  "edits": [
+    {
+      "verb": "set-body",
+      "class": "AboutNewTabRedirectorParent",
+      "method": "newChannel",
+      "body": "{\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon. FF152 removed the AboutNewTab.newTabURL\n    // hook, so this redirector is the only override point. Returned directly (not\n    // suspended on addon init) since the gjoa page has no built-in-addon dependency.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let chromeURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      chromeURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n\n    if (!this.#addonInitialized) {\n      return this.#getSuspendedChannel(resultChannel);\n    }\n\n    return resultChannel;\n  }"
+    },
+    {
+      "verb": "set-body",
+      "class": "AboutNewTabRedirectorChild",
+      "method": "newChannel",
+      "body": "{\n    if (!IS_PRIVILEGED_PROCESS) {\n      throw Components.Exception(\n        \"newChannel can only be called from the privilegedabout content process.\",\n        Cr.NS_ERROR_UNEXPECTED\n      );\n    }\n\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon or the (activity-stream) about:home startup\n    // cache. disqualifyCache() drops any stale cached activity-stream document.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      AboutHomeStartupCacheChild.disqualifyCache();\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let pageURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      pageURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n    return resultChannel;\n  }"
+    }
+  ]
+}

--- a/tools/prep/patches.bjs
+++ b/tools/prep/patches.bjs
@@ -12,7 +12,7 @@
             [gjoa.tools.prep.patch-header :refer [check-all]]
             [gjoa.tools.prep.log :refer [log]]))
 (define-mode strict)
-(declare-extern [Bun] Any)
+(declare-extern [Bun process] Any)
 
 (def APPLIED-LOG :- String ".gjoa-applied-patches")
 
@@ -64,12 +64,27 @@
 
 ;; Apply a single patch by name. Throws (with the patch name) on failure so
 ;; the caller surfaces exactly which patch broke.
+;;
+;; FALLBACK: if `git apply` fails AND a sibling claim-doc artifact exists
+;; (patches/<name>.claims.json), replay it via the JS projector. The claim-doc is
+;; anchored to (class, method) identity, so it survives upstream reflow that `.rej`s
+;; the line-anchored textual patch. `git apply` is atomic, so on failure the tree is
+;; untouched and the replay runs on pristine source.
 (defn applyOne [name :- String] :- Any
   (.step log (str "applying patch " name))
   (let [path (join PATCHES-DIR name)
         code (js/await (run-git ["git" "apply" "--whitespace=nowarn" path] ENGINE-DIR))]
     (if (not= code 0)
-      (throw (Error. (str "failed to apply patch " name ": git apply exited " code)))
+      (let [claims-path (join PATCHES-DIR (.replace name ".patch" ".claims.json"))]
+        (if (existsSync claims-path)
+          (let [repo (.cwd process)
+                applier (join repo ".beagle-tools" "gjoa" "tools" "projector" "apply-claims.js")
+                rc (js/await (run-git ["bun" applier claims-path ENGINE-DIR] repo))]
+            (if (= rc 0)
+              (.ok log (str "  " name ": textual patch .rej'd — recovered via claim-doc replay (identity-anchored)"))
+              (throw (Error. (str "failed to apply patch " name ": git apply exited " code
+                                  "; claim-doc fallback exited " rc)))))
+          (throw (Error. (str "failed to apply patch " name ": git apply exited " code)))))
       nil)))
 
 (js/export (defn patches [] :- Any

--- a/tools/projector/apply-claims.bjs
+++ b/tools/projector/apply-claims.bjs
@@ -1,0 +1,35 @@
+#lang beagle/js
+;; tools/projector/apply-claims.bjs — replay a committed claim-doc artifact onto an
+;; engine tree. Used by tools/prep/patches.bjs as a FALLBACK when a textual patch
+;; `.rej`s: the name-anchored claim-doc reproduces the edit even after upstream
+;; reflow that defeats line-anchored patching. Exit 0 on success, 1 on failure.
+;;   bun apply-claims.js <artifact.claims.json> <engine-dir>
+(ns gjoa.tools.projector.apply-claims
+  (:require [fs :refer [readFileSync writeFileSync]]
+            [path :refer [join]]
+            [gjoa.tools.projector.claims :refer [json->doc replay]]
+            [gjoa.tools.projector.set-body :refer [parses?]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+(defn main! [] :- Any
+  (let [artifact-path (aget (.-argv process) 2)
+        engine-dir (aget (.-argv process) 3)
+        doc (json->doc (readFileSync artifact-path "utf8"))
+        file (.-file doc)
+        edits (.-edits doc)
+        target (join engine-dir file)
+        src (readFileSync target "utf8")
+        r (replay edits src)]
+    (if (and (.-ok r) (parses? (.-src r)))
+      (do
+        (writeFileSync target (.-src r))
+        (console/error (str "  claim-doc replay OK -> " file " (" (.-length edits) " set-body edit(s))"))
+        (.exit process 0))
+      (do
+        (console/error (str "  claim-doc replay FAILED: "
+                            (if (.-ok r) "rendered result does not parse" (.-reason r))))
+        (.exit process 1)))))
+
+(when (.-main (js/import-meta))
+  (main!))

--- a/tools/projector/gen-claims.bjs
+++ b/tools/projector/gen-claims.bjs
@@ -1,0 +1,42 @@
+#lang beagle/js
+;; tools/projector/gen-claims.bjs — generate the committed claim-doc artifact for
+;; patch 0011: patches/0011-newtab-redirector-gjoa.claims.json. The artifact is the
+;; identity-anchored form of the patch ({file, edits:[set-body verbs]}), extracted
+;; from the known-good patched output (pinned upstream + the textual patch). Run
+;; once and commit; the build replays it as a fallback when the textual patch .rej's.
+;;   bun run projector:gen-claims
+(ns gjoa.tools.projector.gen-claims
+  (:require [child_process :refer [execSync]]
+            [fs :refer [readFileSync writeFileSync]]
+            [path :refer [join dirname]]
+            [gjoa.tools.projector.claims :refer [build-doc]]))
+(define-mode strict)
+(declare-extern [process console JSON] Any)
+
+(def REPO :- String (.cwd process))
+(def REL :- String "browser/components/newtab/AboutNewTabRedirector.sys.mjs")
+(def ANCHORS :- Any [{:class "AboutNewTabRedirectorParent" :method "newChannel"}
+                     {:class "AboutNewTabRedirectorChild" :method "newChannel"}])
+(def OUT :- String (join REPO "patches" "0011-newtab-redirector-gjoa.claims.json"))
+(def FF-SRC :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
+(def TMP :- String "/tmp/gjoa-gen")
+
+(defn sh [cmd :- String] :- String
+  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
+
+(defn main! [] :- Any
+  (let [v (.-version (.-firefox (.parse JSON (readFileSync (join REPO "gjoa.json") "utf8"))))
+        tag (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE")
+        dir (join TMP (dirname REL))]
+    (sh (str "rm -rf " TMP " && mkdir -p " dir))
+    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")))
+    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)))
+    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")))
+    (let [patched (readFileSync (join TMP REL) "utf8")
+          edits (build-doc patched ANCHORS)
+          artifact {:file REL :edits edits}]
+      (writeFileSync OUT (str (JSON/stringify artifact nil 2) "\n"))
+      (console/error (str "wrote " OUT "  (" (.-length edits) " set-body verbs, anchored @ " tag ")")))))
+
+(when (.-main (js/import-meta))
+  (main!))

--- a/tools/projector/test-projector.bjs
+++ b/tools/projector/test-projector.bjs
@@ -1,0 +1,58 @@
+#lang beagle/js
+;; tools/projector/test-projector.bjs — CI gate for the JS projector + claim-doc.
+;; Self-contained (needs only engine/, present after import): no reference checkout.
+;;   GATE A — reflector round-trips a corpus of engine .sys.mjs byte-identically.
+;;   GATE B — the committed 0011 claim-doc, replayed onto pristine (derived by
+;;            reverse-applying the textual patch to the engine file), reproduces the
+;;            engine file exactly — i.e. the claim-doc stays equivalent to patch 0011.
+;;   bun run projector:test
+(ns gjoa.tools.projector.test-projector
+  (:require [child_process :refer [execSync]]
+            [fs :refer [readFileSync]]
+            [path :refer [join dirname]]
+            [gjoa.tools.projector.reflector :refer [round-trips?]]
+            [gjoa.tools.projector.claims :refer [json->doc replay]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+(def REPO :- String (.cwd process))
+(def ENGINE :- String (join REPO "engine"))
+
+(defn sh [cmd :- String] :- String
+  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
+
+(defn fail! [msg :- String] :- Any
+  (console/error (str "FAIL: " msg))
+  (.exit process 1))
+
+(defn main! [] :- Any
+  ;; GATE A — reflector round-trip over a corpus
+  (let [files (.filter (.split (sh (str "find " ENGINE "/browser/components " ENGINE "/toolkit/modules -name '*.sys.mjs' 2>/dev/null | head -40")) "\n")
+                       (fn [s :- String] :- Bool (> (.-length s) 0)))]
+    (loop [i 0 bad 0]
+      (if (< i (.-length files))
+        (let [src (readFileSync (aget files i) "utf8")]
+          (recur (+ i 1) (if (round-trips? src) bad (+ bad 1))))
+        (do
+          (console/error (str "GATE A  reflector round-trip: " (- (.-length files) bad) "/" (.-length files) " byte-identical"))
+          (when (> bad 0) (fail! (str bad " file(s) failed round-trip")))))))
+  ;; GATE B — committed claim-doc reproduces the textual patch's output
+  (let [artifact (join REPO "patches" "0011-newtab-redirector-gjoa.claims.json")
+        patch (join REPO "patches" "0011-newtab-redirector-gjoa.patch")
+        doc (json->doc (readFileSync artifact "utf8"))
+        rel (.-file doc)
+        engine-target (join ENGINE rel)
+        tmp "/tmp/gjoa-projtest"]
+    (sh (str "rm -rf " tmp " && mkdir -p " (join tmp (dirname rel))))
+    (sh (str "cp " engine-target " " (join tmp rel)))
+    (sh (str "cd " tmp " && patch -R -p1 < " patch))   ; engine - 0011 = pristine
+    (let [pristine (readFileSync (join tmp rel) "utf8")
+          patched (readFileSync engine-target "utf8")
+          r (replay (.-edits doc) pristine)]
+      (if (and (.-ok r) (= (.-src r) patched))
+        (console/error "GATE B  claim-doc equivalence: replay(pristine) == engine (patch 0011) [byte-for-byte]")
+        (fail! (if (.-ok r) "claim-doc replay does not reproduce the engine file" (.-reason r))))))
+  (console/error "projector tests PASSED"))
+
+(when (.-main (js/import-meta))
+  (main!))


### PR DESCRIPTION
Production integration of the Phase 5 projector (#78).

## What
The import pipeline now **falls back to identity-anchored claim replay when a textual patch `.rej`s**. `tools/prep/patches.bjs` `applyOne`, on `git apply` failure, replays a sibling claim-doc (`patches/<name>.claims.json`) via the JS projector.

- **Happy path unchanged**: `git apply` succeeds → identical to before. The fallback only activates on rejection.
- On rejection, the `(class, method)`-anchored claim survives upstream reflow that defeats line-anchored patching.

## Pieces
- `patches/0011-newtab-redirector-gjoa.claims.json` — the committed claim-doc for 0011 (two `set-body` verbs), generated by `bun run projector:gen-claims`.
- `tools/projector/apply-claims` — fallback applier (replay + parse-verify + write).
- `tools/projector/test-projector` (`bun run projector:test`) — **CI gate** wired into all 3 build workflows after import: reflector round-trips a 40-file engine corpus byte-identically, and the committed claim-doc reproduces patch 0011's engine output **byte-for-byte** (pristine derived by reverse-applying the patch).

## Verified
- `bun run import` clean (happy path);
- fallback recovers a churned engine where the textual patch reports `Hunk #1 FAILED`;
- `projector:test` passes (GATE A 40/40, GATE B byte-for-byte).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784505350&installation_id=141311834&pr_number=79&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F79&signature=cd3da7a6569adcebf1142ee45c439116c9651733389a9c931a6cdb6c56cf7eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->