### PR TITLE
feat(tools): Firefox-API seam ratchet — drift monitor for the chrome API surface (#73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "preflight": "bun run tools:compile && bun .beagle-tools/gjoa/tools/scripts/preflight.js",
     "cost": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/patch-cost.js",
     "forecast": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/conflict-forecast.js",
+    "firefox-api-drift": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/firefox-api-surface.js",
     "projector:roundtrip": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/reflector.js",
     "projector:pilot": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/run-pilot.js",
     "projector:gen-claims": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/gen-claims.js",

--- a/tools/prep/firefox-api-surface.bjs
+++ b/tools/prep/firefox-api-surface.bjs
@@ -1,0 +1,81 @@
+#lang beagle/js
+;; tools/prep/firefox-api-surface.bjs — the Firefox-API seam ratchet (#73).
+;;
+;; gjoa's chrome JS calls into Firefox host globals (gBrowser, ChromeUtils,
+;; PathUtils, IOUtils). Those calls are gjoa's RUNTIME dependency on upstream's
+;; API — and unlike a patch, a removed/renamed method fails silently at runtime,
+;; not at build time. This auto-derives that dependency surface from the chrome
+;; source (no hand-maintained list) and verifies each member still RESOLVES in
+;; non-test engine/ source. A member that vanished upstream is a drift candidate
+;; to review before shipping a bump.
+;;
+;; HONEST SCOPE: this is an existence-level *removal* detector (the member name
+;; still appears in upstream non-test source), NOT an object-scoped signature
+;; check. Distinctive names (importESModule, makeDirectory, newChannelFrom...) are
+;; reliable; very common names (addTab) are looser. Typing the seams precisely was
+;; rejected: the `Obj/method` extern form is NOT closed-world (an undeclared member
+;; emits freely), so it gives no enforcement — see private-docs/research-externs-
+;; hardening.md. This monitors the surface instead of pretending to type it.
+;;   bun run firefox-api-drift
+(ns gjoa.tools.prep.firefox-api-surface
+  (:require [child_process :refer [execSync]]
+            [path :refer [join]]))
+(define-mode strict)
+(declare-extern [process] Any)
+
+(def REPO :- String (.cwd process))
+(def CHROME :- String (join REPO "src" "gjoa" "chrome" "bjs"))
+(def ENGINE :- String (join REPO "engine"))
+;; single-level method-call globals (gBrowser.X / ChromeUtils.X / ...). Services is
+;; two-level (Services.prefs.getBoolPref); its sub-service methods are out of scope
+;; here — the sub-service NAMES themselves are stable XPCOM getters.
+(def GLOBALS :- Any ["gBrowser" "ChromeUtils" "PathUtils" "IOUtils"])
+
+(defn sh [cmd :- String] :- String
+  (try (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024) :stdio ["ignore" "pipe" "ignore"]}))
+    (catch Error _e "")))
+
+;; derive [{:global g :members [member ...]} ...] from `(.<member> <Global> ...)`
+;; calls in chrome.
+(defn scan-surface [] :- Any
+  (let [result []]
+    (doseq [g GLOBALS]
+      (let [out (sh (str "grep -rhoE '\\(\\.[a-zA-Z]+ " g "\\b' " CHROME " 2>/dev/null"))
+            members []]
+        (doseq [line (.split out "\n")]
+          (let [m (.match line (RegExp. "\\(\\.([a-zA-Z]+)"))]
+            (when (and m (not (.includes members (aget m 1))))
+              (.push members (aget m 1)))))
+        (when (> (.-length members) 0)
+          (.push result {:global g :members (.sort members)}))))
+    result))
+
+;; does `member` still appear in non-test engine/ source? (definition or use)
+(defn resolves? [member :- String] :- Bool
+  (let [hits (sh (str "grep -rl --include=*.js --include=*.jsm --include=*.mjs --include=*.webidl --include=*.idl "
+                      "-e '" member "' " ENGINE " 2>/dev/null | grep -vE '/test/|/tests/|_test' | head -1"))]
+    (> (.-length (.trim hits)) 0)))
+
+(defn main! [] :- Any
+  (let [surface (scan-surface)
+        missing []
+        total [0]]
+    (console/log "Firefox-API seam ratchet — gjoa's chrome dependency on upstream host globals:\n")
+    (doseq [entry surface]
+      (let [g (.-global entry)
+            members (.-members entry)]
+        (console/log (str "  " g " (" (.-length members) " members)"))
+        (doseq [member members]
+          (aset total 0 (+ (aget total 0) 1))
+          (when (not (resolves? member))
+            (.push missing (str g "." member))))))
+    (console/log "")
+    (if (= (.-length missing) 0)
+      (console/log (str "✓ all " (aget total 0) " Firefox-API members resolve in non-test engine/ source — no drift."))
+      (do
+        (console/log (str "⚠ " (.-length missing) " of " (aget total 0) " members did NOT resolve in engine/ — review before shipping a bump:"))
+        (doseq [m missing] (console/log (str "    " m)))
+        (.exit process 1)))))
+
+(when (.-main (js/import-meta))
+  (main!))


### PR DESCRIPTION
## What
`bun run firefox-api-drift` auto-derives gjoa's Firefox host-global dependency surface from the chrome source (gBrowser/ChromeUtils/PathUtils/IOUtils method calls — **19 members** today) and verifies each still resolves in non-test `engine/` source. A member that vanished upstream is a drift candidate to review before a bump — the runtime analogue of Gate L's patch surface-contract.

## Honest scope
An **existence-level removal detector** (distinctive names like `importESModule`/`newChannelFromURIWithLoadInfo` are reliable; common ones like `addTab` looser), **not** object-scoped signature typing. Precise extern typing was **rejected** during the Phase 4 work: the `Obj/method` form is not closed-world (an undeclared member emits freely → no enforcement), so it would be fragile documentation churn. This monitors the surface instead of pretending to type it. Self-maintaining (no hand-list); matches the bump-time tooling pattern (`forecast`/`cost`).

Run today: all 19 members resolve — no drift.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784506892&installation_id=141311834&pr_number=80&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F80&signature=1b5c572f6360d501cc8cc37c56b6702cb3e047512f1b872a26a2f631ad0f7376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->