### PR TITLE
feat(projector): JS-on-Fram live store — round-trip through Fram + Datalog queries (#75)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "projector:pilot": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/run-pilot.js",
     "projector:gen-claims": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/gen-claims.js",
     "projector:fram-log": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/fram-log.js",
+    "projector:fram": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/fram-roundtrip.js",
     "projector:test": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/test-projector.js",
     "check": "BEAGLE_PURITY=error ../beagle/bin/beagle check --profile 3 src/gjoa/chrome/bjs tools tests",
     "test": "bun run check && bun run tools:compile && bun test .beagle-tools/gjoa/tests/branding.test.js",

--- a/tools/projector/fram-log.bjs
+++ b/tools/projector/fram-log.bjs
@@ -1,43 +1,31 @@
 #lang beagle/js
 ;; tools/projector/fram-log.bjs — Phase 5 / JS-on-Fram (#75): project a JS source
-;; file's lossless CST into Fram-format claim records, and reconstruct byte-
-;; identically. This is the JS analogue of bin/fram-ingest-code (which does .bclj
-;; via racket): it mirrors the Beagle node vocabulary (kind / seg / child) and uses
-;; the CRDT order-key predicates the fram rewrite landed (f<path>~<tie>; single-
-;; writer ingest = sequential path, tie 0). Byte-identity proves the claim
-;; representation is lossless — the JS analogue of chartroom/roundtrip_fram.clj.
+;; file's lossless CST into Fram claims, persist through the LIVE Fram store, and
+;; reconstruct byte-identically. The JS analogue of bin/fram-ingest-code +
+;; chartroom/roundtrip_fram.clj. Mirrors the Beagle node vocab (kind/seg/child) and
+;; uses the CRDT order-key predicates the fram #36 rewrite landed (f<path>~<tie>;
+;; single-writer ingest = sequential path, tie 0).
 ;;
-;; This is the persistence FORMAT, verified standalone (no live daemon). Writing the
-;; records to a live Fram code-log + Datalog queries is the next layer.
-;;   bun .beagle-tools/gjoa/tools/projector/fram-log.js <file.js>
+;; Subcommands:
+;;   gate   <file.js>            in-memory CST<->claims round-trip (byte-identical?)
+;;   edn    <file.js>            print [s "pred" o] triples (int ids) — roundtrip_fram.clj input
+;;   log    <file.js> [module]   print a Fram log ({:tx :op :l :p :r :frame}) — `FRAM_LOG=… fram query`
+;;   render <triples.edn>        read [s p o] triples, reconstruct, render JS to stdout
 (ns gjoa.tools.projector.fram-log
   (:require [fs :refer [readFileSync]]
             [gjoa.tools.projector.reflector :refer [reflect render]]))
 (define-mode strict)
-(declare-extern [process console] Any)
+(declare-extern [process console JSON] Any)
 
 (def ORD-STEP :- Int 65536)
-;; CRDT order key for the k-th child of a node: sequential path, tie 0 (the single-
-;; writer ingest case; concurrent edits would get distinct ties via the daemon).
 (defn ord-key [k :- Int] :- String (str "f" (* ORD-STEP (+ k 1)) "~0"))
-;; parse the path int out of "f<int>~<tie>" (for sort-order on read).
-(defn ord-path [p :- String] :- Int
-  (parseInt (.slice p 1 (.indexOf p "~")) 10))
-(defn ord-key? [p :- String] :- Bool
-  (and (.startsWith p "f") (.includes p "~")))
+(defn ord-path [p :- String] :- Int (parseInt (.slice p 1 (.indexOf p "~")) 10))
+(defn ord-key? [p :- String] :- Bool (and (.startsWith p "f") (.includes p "~")))
 
-;; CST -> flat Fram claim records [{:l id :p pred :r obj} ...] + the root id.
-;; ids are "@<module>#<n>". preds: "kind" (-> type literal), "seg<i>" (-> literal),
-;; and an order-key "f<path>~<tie>" per child (-> child id link). `link?` marks an
-;; :r that is a node ref vs a literal value (mirrors fram-ingest-code's int-vs-string).
-(defn cst->records [cst :- Any module :- String] :- Any
-  (let [records []
-        counter [0]]
-    (loop-emit cst module records counter)
-    {:root (str "@" module "#0") :records records}))
-
-;; (defined as a separate recursive walker so beagle can self-call cleanly)
-(defn loop-emit [c :- Any module :- String records :- Any counter :- Any] :- String
+;; --- CST -> records ---------------------------------------------------------
+;; record: {:l "@<mod>#<int>" :p pred :r obj :link bool}. preds: "kind" (-> type
+;; literal), "seg<i>" (-> literal), "f<path>~<tie>" (-> child id link).
+(defn emit-node [c :- Any module :- String records :- Any counter :- Any] :- String
   (let [id (str "@" module "#" (aget counter 0))]
     (aset counter 0 (+ (aget counter 0) 1))
     (.push records {:l id :p "kind" :r (.-kind c) :link false})
@@ -48,53 +36,114 @@
           (recur (+ i 1))))
       (loop [i 0]
         (when (< i (.-length kids))
-          (let [cid (loop-emit (aget kids i) module records counter)]
+          (let [cid (emit-node (aget kids i) module records counter)]
             (.push records {:l id :p (ord-key i) :r cid :link true}))
           (recur (+ i 1)))))
     id))
 
-;; reconstruct a CST from the records, starting at `root`. Indexes records by node
-;; id (a JS Map for string keys), orders children by their CRDT key, and rebuilds
-;; the seg/child interleave.
-(defn records->cst [root :- String records :- Any] :- Any
-  (let [groups (Map.)]
-    (doseq [r records]
-      (let [g (.get groups (.-l r))]
-        (if (some? g) (.push g r) (.set groups (.-l r) [r]))))
-    (rebuild root groups)))
+(defn cst->records [cst :- Any module :- String] :- Any
+  (let [records [] counter [0]]
+    (emit-node cst module records counter)
+    records))
 
-(defn rebuild [id :- String groups :- Any] :- Any
-  (let [rs (.get groups id)
-        kind [""]
-        segs []         ; collected by index below
-        seg-pairs []    ; [index text]
-        kids []]        ; [pathInt childId]
-    (doseq [r rs]
-      (let [p (.-p r)]
+;; --- records -> wire formats ------------------------------------------------
+(defn int-of [name :- String] :- Int (parseInt (.slice name (+ (.indexOf name "#") 1)) 10))
+
+;; [s "pred" o] EDN — o is an INT (child ref) or a JSON/EDN-quoted string literal.
+(defn records->edn [records :- Any] :- String
+  (.join (.map records
+    (fn [r :- Any] :- String
+      (str "[" (int-of (.-l r)) " " (JSON/stringify (.-p r)) " "
+           (if (.-link r) (int-of (.-r r)) (JSON/stringify (.-r r))) "]")))
+    "\n"))
+
+;; a Fram log — one {:tx :op :l :p :r :frame} map per line. :r is always a string
+;; (refs are @-prefixed; literals are plain), matching fram's read-log.
+(defn records->log [records :- Any] :- String
+  (let [n [0]]
+    (.join (.map records
+      (fn [r :- Any] :- String
+        (aset n 0 (+ (aget n 0) 1))
+        (str "{:tx " (aget n 0) ", :op \"assert\", :l " (JSON/stringify (.-l r))
+             ", :p " (JSON/stringify (.-p r)) ", :r " (JSON/stringify (.-r r))
+             ", :frame \"gjoa-js\"}")))
+      "\n")))
+
+;; --- triples -> CST (reconstruct) -------------------------------------------
+;; parse a [s "pred" o] line -> {:s Int :p String :o Any :link Bool}, or nil.
+(defn parse-triple [line :- String] :- Any
+  (let [m (.match line (RegExp. "^\\[(\\d+) (\"(?:[^\"\\\\]|\\\\.)*\") (.+)\\]$"))]
+    (if (nil? m) nil
+      (let [s (parseInt (aget m 1) 10)
+            p (.parse JSON (aget m 2))
+            rest (aget m 3)
+            link (.test (RegExp. "^\\d+$") rest)]
+        {:s s :p p :o (if link (parseInt rest 10) (.parse JSON rest)) :link link}))))
+
+(defn parse-triples [text :- String] :- Any
+  (let [out []]
+    (doseq [line (.split text "\n")]
+      (when (> (.-length (.trim line)) 0)
+        (let [t (parse-triple line)] (when (some? t) (.push out t)))))
+    out))
+
+;; reconstruct the CST from triples. Map s -> [triples]; root = an s that is never
+;; a child ref. Order children by their CRDT key; interleave segs by index.
+(defn rebuild-node [id :- Int byId :- Any] :- Any
+  (let [ts (.get byId id)
+        kind [""] seg-pairs [] kids []]
+    (doseq [t ts]
+      (let [p (.-p t)]
         (cond
-          (= p "kind") (aset kind 0 (.-r r))
-          (.startsWith p "seg") (.push seg-pairs {:i (parseInt (.slice p 3) 10) :t (.-r r)})
-          (ord-key? p) (.push kids {:k (ord-path p) :id (.-r r)})
+          (= p "kind") (aset kind 0 (.-o t))
+          (.startsWith p "seg") (.push seg-pairs {:i (parseInt (.slice p 3) 10) :t (.-o t)})
+          (ord-key? p) (.push kids {:k (ord-path p) :id (.-o t)})
           :else nil)))
-    ;; segs in index order
     (.sort seg-pairs (fn [a :- Any b :- Any] :- Int (- (.-i a) (.-i b))))
-    (doseq [sp seg-pairs] (.push segs (.-t sp)))
-    ;; children in CRDT-key order
     (.sort kids (fn [a :- Any b :- Any] :- Int (- (.-k a) (.-k b))))
-    (let [child-csts []]
-      (doseq [kd kids] (.push child-csts (rebuild (.-id kd) groups)))
+    (let [segs [] child-csts []]
+      (doseq [sp seg-pairs] (.push segs (.-t sp)))
+      (doseq [kd kids] (.push child-csts (rebuild-node (.-id kd) byId)))
       {:kind (aget kind 0) :start 0 :end 0 :segs segs :kids child-csts})))
 
+(defn triples->cst [triples :- Any] :- Any
+  (let [byId (Map.) children (Set.)]
+    (doseq [t triples]
+      (let [g (.get byId (.-s t))]
+        (if (some? g) (.push g t) (.set byId (.-s t) [t])))
+      (when (.-link t) (.add children (.-o t))))
+    ;; root = the one subject that is never a child ref
+    (let [ks (Array/from (.keys byId))
+          root (loop [i 0]
+                 (if (< i (.-length ks))
+                   (if (not (.has children (aget ks i))) (aget ks i) (recur (+ i 1)))
+                   (aget ks 0)))]
+      (rebuild-node root byId))))
+
+;; --- CLI --------------------------------------------------------------------
 (defn main! [] :- Any
-  (let [path (aget (.-argv process) 2)
-        src (readFileSync path "utf8")
-        cst (reflect src)
-        proj (cst->records cst "newtab")
-        records (.-records proj)
-        round (render (records->cst (.-root proj) records))
-        ok (= round src)]
-    (console/log (str path ": " (.-length records) " claim records, byte-identical=" ok))
-    (when (not ok) (.exit process 1))))
+  (let [argv (.slice (.-argv process) 2)
+        cmd (aget argv 0)
+        arg (aget argv 1)]
+    (cond
+      (= cmd "gate")
+      (let [src (readFileSync arg "utf8")
+            records (cst->records (reflect src) "js")
+            round (render (triples->cst (parse-triples (records->edn records))))
+            ok (= round src)]
+        (console/error (str arg ": " (.-length records) " claim records, byte-identical=" ok))
+        (when (not ok) (.exit process 1)))
+
+      (= cmd "edn")
+      (console/log (records->edn (cst->records (reflect (readFileSync arg "utf8")) "js")))
+
+      (= cmd "log")
+      (console/log (records->log (cst->records (reflect (readFileSync arg "utf8")) (or (aget argv 2) "js"))))
+
+      (= cmd "render")            ; exact source — no trailing newline
+      (.write (.-stdout process) (render (triples->cst (parse-triples (readFileSync arg "utf8")))))
+
+      :else (do (console/error "usage: fram-log <gate|edn|log|render> <file>") (.exit process 1)))))
 
 (when (.-main (js/import-meta))
   (main!))

--- a/tools/projector/fram-roundtrip.bjs
+++ b/tools/projector/fram-roundtrip.bjs
@@ -1,0 +1,51 @@
+#lang beagle/js
+;; tools/projector/fram-roundtrip.bjs — JS-on-Fram end-to-end (#75): project a JS
+;; file into the LIVE Fram store, reconstruct byte-identically, and Datalog-query it.
+;;   bun run projector:fram [<js-file>]
+;; Steps: gjoa emits claims -> fram store loads + re-extracts (real engine) -> gjoa
+;; renders byte-identically -> Datalog query over gjoa's AST. Needs ~/code/fram.
+(ns gjoa.tools.projector.fram-roundtrip
+  (:require [child_process :refer [execSync]]
+            [fs :refer [readFileSync]]
+            [path :refer [join]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+(def REPO :- String (.cwd process))
+(def FRAM :- String (join (.-HOME (.-env process)) "code" "fram"))
+(def SELF :- String (join REPO ".beagle-tools" "gjoa" "tools" "projector" "fram-log.js"))
+(def DEFAULT :- String "engine/browser/components/newtab/AboutNewTabRedirector.sys.mjs")
+
+(defn sh [cmd :- String cwd :- String] :- String
+  (.toString (execSync cmd {:encoding "utf8" :cwd cwd :maxBuffer (* 128 1024 1024)})))
+
+;; the structural Datalog query: every MethodDefinition node in gjoa's JS.
+(def QUERY :- String
+  "{:find \"method\" :rules [{:head {:rel \"method\" :args [{:var \"l\"}]} :body [{:rel \"triple\" :args [{:var \"l\"} \"kind\" \"MethodDefinition\"]}]}]}")
+
+(defn main! [] :- Any
+  (let [F (or (aget (.-argv process) 2) DEFAULT)
+        src (readFileSync (join REPO F) "utf8")]
+    ;; 1. gjoa: JS -> claims (EDN triples for the store round-trip; a Fram log for query)
+    (sh (str "bun " SELF " edn " F " > /tmp/gjoa-A.edn") REPO)
+    (sh (str "bun " SELF " log " F " js > /tmp/gjoa-js.log") REPO)
+    (console/error (str "1. gjoa emitted " (.trim (sh "wc -l < /tmp/gjoa-A.edn" REPO)) " claims for " F))
+    ;; 2. fram: load the claims into a REAL Fram store + re-extract (the engine)
+    (sh "bb -cp out chartroom/src/roundtrip_fram.clj /tmp/gjoa-A.edn > /tmp/gjoa-B.edn 2>/dev/null" FRAM)
+    (console/error "2. fram loaded the claims into a real store + re-extracted them")
+    ;; 3. gjoa: render the re-extracted claims -> byte-identical?
+    (sh (str "bun " SELF " render /tmp/gjoa-B.edn > /tmp/gjoa-rendered.js") REPO)
+    (let [rendered (readFileSync "/tmp/gjoa-rendered.js" "utf8")
+          identical (= rendered src)]
+      (console/error (str "3. byte-identical through the live Fram store: " identical
+                          " (" (.-length rendered) " bytes)"))
+      ;; 4. Datalog: query gjoa's JS AST in the store
+      (let [out (.trim (sh (str "FRAM_LOG=/tmp/gjoa-js.log " (join FRAM "bin" "fram") " query '" QUERY "'") FRAM))
+            n (.-length (.filter (.split out "\n") (fn [s :- String] :- Bool (> (.-length (.trim s)) 0))))]
+        (console/error (str "4. Datalog query (MethodDefinition nodes) returned " n " methods from gjoa's JS"))
+        (if (and identical (> n 0))
+          (console/error "JS-ON-FRAM PASSED — gjoa's JS persists in the Fram store, byte-identical + Datalog-queryable.")
+          (do (console/error "JS-ON-FRAM FAILED") (.exit process 1)))))))
+
+(when (.-main (js/import-meta))
+  (main!))


### PR DESCRIPTION
The **deep layer** of JS-on-Fram (#75), unblocked by the fram #36 CRDT landing. gjoa's JS now persists in a **real Fram store** as a queryable claim graph.

## What
- `fram-log.bjs` → multi-mode CLI: `gate` (in-memory round-trip) · `edn` (`[s p o]` triples for `chartroom/roundtrip_fram.clj`) · `log` (a Fram `{:tx :op :l :p :r :frame}` log for `FRAM_LOG=… fram query`) · `render` (`[s p o]` → byte-exact JS).
- `fram-roundtrip.bjs` (`bun run projector:fram`) — the end-to-end:
  1. gjoa emits the JS as claims;
  2. `chartroom/roundtrip_fram.clj` loads them into a **real Fram store** + re-extracts;
  3. gjoa renders the re-extracted claims **byte-identically** (persistence through the engine, not an in-memory map — the JS analogue of `roundtrip_fram.clj`);
  4. `fram query` runs **Datalog** over gjoa's AST.

## Verified (newtab redirector)
```
1. gjoa emitted 5746 claims
2. fram loaded them into a real store + re-extracted
3. byte-identical through the live Fram store: true (20574 bytes)
4. Datalog query (MethodDefinition nodes) returned 11 methods
JS-ON-FRAM PASSED
```
Uses the CRDT order keys (`f<path>~<tie>`). Needs ~/code/fram (local capability, like `run-pilot`); not in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784525251&installation_id=141311834&pr_number=82&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F82&signature=73ff455412782225c7d04d504bfb77e962600919963e484d8d8eba9916524dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->