### PR TITLE
feat(projector): rename-recovery — confidence-scored structural anchor matcher (#74 tail)

### DIFF
--- a/patches/0011-newtab-redirector-gjoa.claims.json
+++ b/patches/0011-newtab-redirector-gjoa.claims.json
@@ -5,13 +5,70 @@
       "verb": "set-body",
       "class": "AboutNewTabRedirectorParent",
       "method": "newChannel",
-      "body": "{\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon. FF152 removed the AboutNewTab.newTabURL\n    // hook, so this redirector is the only override point. Returned directly (not\n    // suspended on addon init) since the gjoa page has no built-in-addon dependency.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let chromeURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      chromeURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n\n    if (!this.#addonInitialized) {\n      return this.#getSuspendedChannel(resultChannel);\n    }\n\n    return resultChannel;\n  }"
+      "body": "{\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon. FF152 removed the AboutNewTab.newTabURL\n    // hook, so this redirector is the only override point. Returned directly (not\n    // suspended on addon init) since the gjoa page has no built-in-addon dependency.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let chromeURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      chromeURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n\n    if (!this.#addonInitialized) {\n      return this.#getSuspendedChannel(resultChannel);\n    }\n\n    return resultChannel;\n  }",
+      "anchor": {
+        "params": [
+          "uri",
+          "loadInfo"
+        ],
+        "ordinal": 3,
+        "idents": [
+          "chromeURI",
+          "getChromeURI",
+          "uri",
+          "spec",
+          "startsWith",
+          "lazy",
+          "BUILTIN_NEWTAB_ENABLED",
+          "Services",
+          "io",
+          "newURI",
+          "defaultURL",
+          "resultChannel",
+          "newChannelFromURIWithLoadInfo",
+          "loadInfo",
+          "originalURI"
+        ]
+      }
     },
     {
       "verb": "set-body",
       "class": "AboutNewTabRedirectorChild",
       "method": "newChannel",
-      "body": "{\n    if (!IS_PRIVILEGED_PROCESS) {\n      throw Components.Exception(\n        \"newChannel can only be called from the privilegedabout content process.\",\n        Cr.NS_ERROR_UNEXPECTED\n      );\n    }\n\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon or the (activity-stream) about:home startup\n    // cache. disqualifyCache() drops any stale cached activity-stream document.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      AboutHomeStartupCacheChild.disqualifyCache();\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let pageURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      pageURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n    return resultChannel;\n  }"
+      "body": "{\n    if (!IS_PRIVILEGED_PROCESS) {\n      throw Components.Exception(\n        \"newChannel can only be called from the privilegedabout content process.\",\n        Cr.NS_ERROR_UNEXPECTED\n      );\n    }\n\n    // gjoa: serve the custom forced-dark newtab page for home + newtab, never the\n    // built-in activity-stream addon or the (activity-stream) about:home startup\n    // cache. disqualifyCache() drops any stale cached activity-stream document.\n    if (\n      uri.spec.startsWith(\"about:home\") ||\n      uri.spec.startsWith(\"about:newtab\")\n    ) {\n      AboutHomeStartupCacheChild.disqualifyCache();\n      let gjoaChannel = Services.io.newChannelFromURIWithLoadInfo(\n        Services.io.newURI(\"chrome://gjoa-newtab/content/newtab.html\"),\n        loadInfo\n      );\n      gjoaChannel.originalURI = uri;\n      return gjoaChannel;\n    }\n\n    let pageURI = this.getChromeURI(uri);\n    let resultChannel = Services.io.newChannelFromURIWithLoadInfo(\n      pageURI,\n      loadInfo\n    );\n    resultChannel.originalURI = uri;\n    return resultChannel;\n  }",
+      "anchor": {
+        "params": [
+          "uri",
+          "loadInfo"
+        ],
+        "ordinal": 0,
+        "idents": [
+          "IS_PRIVILEGED_PROCESS",
+          "Components",
+          "Exception",
+          "Cr",
+          "NS_ERROR_UNEXPECTED",
+          "pageURI",
+          "uri",
+          "spec",
+          "startsWith",
+          "cacheChannel",
+          "AboutHomeStartupCacheChild",
+          "maybeGetCachedPageChannel",
+          "loadInfo",
+          "Services",
+          "io",
+          "newURI",
+          "defaultURL",
+          "disqualifyCache",
+          "lazy",
+          "BUILTIN_NEWTAB_ENABLED",
+          "getChromeURI",
+          "resultChannel",
+          "newChannelFromURIWithLoadInfo",
+          "originalURI"
+        ]
+      }
     }
   ]
 }

--- a/tools/projector/anchor.bjs
+++ b/tools/projector/anchor.bjs
@@ -1,0 +1,118 @@
+#lang beagle/js
+;; tools/projector/anchor.bjs — Phase 5 rename-recovery: a structural anchor +
+;; confidence-scored fuzzy matcher for set-body, so a claim still applies when
+;; upstream RENAMED the target method (the case the exact (class, method) anchor
+;; misses). Design principle: PREFER FAILING LOUDLY over a wrong match — auto-
+;; recover only on a confident, unambiguous structural match; otherwise reject.
+;;
+;; The anchor fingerprint (captured from the PRISTINE method at gen time):
+;;   {params: [name…], ordinal: int, idents: [name…]}  (params + position + the
+;;   set of identifiers in the original body). A rename leaves params + body idents
+;;   ~unchanged, so the renamed method scores high; an unrelated method scores low.
+(ns gjoa.tools.projector.anchor
+  (:require [acorn :refer [parse]]
+            [gjoa.tools.projector.reflector :refer [child-nodes]]))
+(define-mode strict)
+
+(defn parse-js [src :- String] :- Any
+  (parse src {:ecmaVersion "latest" :sourceType "module" :allowHashBang true}))
+
+;; all Identifier names in a subtree (the body fingerprint).
+(defn collect-idents [node :- Any acc :- Any] :- Any
+  (when (some? node)
+    (when (= (.-type node) "Identifier") (.add acc (.-name node)))
+    (doseq [k (child-nodes node)] (collect-idents k acc)))
+  acc)
+
+(defn idents-of [body :- Any] :- Any
+  (Array/from (collect-idents body (Set.))))
+
+;; simple param names of a method's function value (Identifier params; others -> "?").
+(defn param-names [methodNode :- Any] :- Any
+  (.map (.-params (.-value methodNode))
+        (fn [p :- Any] :- String (if (= (.-type p) "Identifier") (.-name p) "?"))))
+
+;; the direct MethodDefinitions of a named class, in order:
+;; [{name node body params ordinal} …].
+(defn find-class [n :- Any cname :- String] :- Any
+  (if (and (some? n) (or (= (.-type n) "ClassDeclaration") (= (.-type n) "ClassExpression"))
+           (some? (.-id n)) (= (.-name (.-id n)) cname))
+    n
+    (let [kids (child-nodes n)]
+      (loop [i 0]
+        (if (< i (.-length kids))
+          (let [r (find-class (aget kids i) cname)] (if (some? r) r (recur (+ i 1))))
+          nil)))))
+
+(defn class-methods [classNode :- Any] :- Any
+  (let [out []]
+    (when (some? classNode)
+      (doseq [cb (child-nodes classNode)]
+        (when (= (.-type cb) "ClassBody")
+          (let [n [0]]
+            (doseq [m (child-nodes cb)]
+              (when (and (= (.-type m) "MethodDefinition") (some? (.-key m))
+                         (some? (.-value m)) (some? (.-body (.-value m))))
+                (.push out {:name (.-name (.-key m)) :node m :body (.-body (.-value m))
+                            :params (param-names m) :ordinal (aget n 0)})
+                (aset n 0 (+ (aget n 0) 1))))))))
+    out))
+
+;; capture an anchor fingerprint for class.method from a pristine source.
+(js/export (defn capture-anchor [src :- String cname :- String mname :- String] :- Any
+  (let [ast (parse-js src)
+        c (find-class ast cname)]
+    (if (nil? c) nil
+      (let [ms (class-methods c)
+            hit (.find ms (fn [m :- Any] :- Bool (= (.-name m) mname)))]
+        (if (nil? hit) nil
+          {:params (.-params hit) :ordinal (.-ordinal hit) :idents (idents-of (.-body hit))}))))))
+
+(defn arr= [a :- Any b :- Any] :- Bool
+  (and (= (.-length a) (.-length b))
+       (.every a (fn [x :- Any i :- Int] :- Bool (= x (aget b i))))))
+
+;; Jaccard overlap of two identifier arrays.
+(defn jaccard [a :- Any b :- Any] :- Float
+  (let [sa (Set. a) sb (Set. b)
+        inter (.filter (Array/from sa) (fn [x :- Any] :- Bool (.has sb x)))
+        uni (Set. (.concat (Array/from sa) (Array/from sb)))]
+    (if (= (.-size uni) 0) 0 (/ (.-length inter) (.-size uni)))))
+
+;; fuzzy-find the renamed target in `src`'s class `cname` given the anchor.
+;; Returns {:name :body :confidence :why} for the best candidate, or nil. Confidence
+;; couples body-identifier overlap (the dominant signal) with param-match and a
+;; position bonus; ONLY trust it (caller's job) when it's high AND unambiguous.
+(js/export (defn fuzzy-find [src :- String cname :- String anchor :- Any] :- Any
+  (let [ast (parse-js src)
+        c (find-class ast cname)]
+    (if (nil? c) nil
+      (let [ms (class-methods c)
+            scored (.map ms (fn [m :- Any] :- Any
+                     (let [j (jaccard (idents-of (.-body m)) (.-idents anchor))
+                           pm (if (arr= (.-params m) (.-params anchor)) 1.0 0.0)
+                           pos (if (= (.-ordinal m) (.-ordinal anchor)) 1.0 0.0)
+                           ;; body overlap dominates; params is a strong gate; position a nudge.
+                           score (+ (* 0.7 j) (* 0.25 pm) (* 0.05 pos))]
+                       {:name (.-name m) :node m :score score :j j :pm pm})))]
+        (if (= (.-length scored) 0) nil
+          (let [sorted (.sort (.slice scored) (fn [a :- Any b :- Any] :- Float (- (.-score b) (.-score a))))
+                best (aget sorted 0)
+                second (if (> (.-length sorted) 1) (.-score (aget sorted 1)) 0)
+                margin (- (.-score best) second)]
+            {:name (.-name best)
+             :body [(.-start (.-body (.-node best))) (.-end (.-body (.-node best)))]
+             :confidence (.-score best)
+             :margin margin
+             :j (.-j best) :pm (.-pm best)
+             :why (str "params=" (.-pm best) " bodyJaccard=" (.toFixed (.-j best) 2) " margin=" (.toFixed margin 2))})))))))
+
+;; the policy gate: should we AUTO-RECOVER with this match, or fail loudly?
+;; Conservative: require strong body overlap, param match, AND a clear margin over
+;; the runner-up (so ambiguous twins are rejected, not mis-applied).
+(js/export (defn confident? [match :- Any] :- Bool
+  (and (some? match)
+       (>= (.-j match) 0.6)        ; body is mostly the same identifiers
+       (= (.-pm match) 1.0)        ; same parameter list
+       (>= (.-margin match) 0.15)  ; a clear winner, not an ambiguous tie
+       (>= (.-confidence match) 0.7))))

--- a/tools/projector/claims.bjs
+++ b/tools/projector/claims.bjs
@@ -8,27 +8,35 @@
 ;; later integration step. Replaying a doc reproduces the edit; because it anchors
 ;; by name, it survives upstream reflow that `.rej`s the textual patch.
 (ns gjoa.tools.projector.claims
-  (:require [gjoa.tools.projector.set-body :refer [set-method-body get-body]]))
+  (:require [gjoa.tools.projector.set-body :refer [set-method-body get-body]]
+            [gjoa.tools.projector.anchor :refer [capture-anchor]]))
 (define-mode strict)
 
-;; build a claim-doc from a known-good edited source + (class,method) anchors:
-;; extract each method's body from the edited source as the set-body payload.
-(js/export (defn build-doc [edited :- String anchors :- Any] :- Any
+;; build a claim-doc from the edited source + the PRISTINE source + (class,method)
+;; anchors: the set-body payload is the method body from `edited`; the `:anchor`
+;; fingerprint (params/ordinal/idents) is captured from `pristine` for rename-recovery.
+(js/export (defn build-doc [edited :- String pristine :- String anchors :- Any] :- Any
   (let [out []]
     (doseq [a anchors]
-      (let [body (get-body edited (.-class a) (.-method a))]
+      (let [body (get-body edited (.-class a) (.-method a))
+            fp (capture-anchor pristine (.-class a) (.-method a))]
         (when (some? body)
-          (.push out {:verb "set-body" :class (.-class a) :method (.-method a) :body body}))))
+          (.push out {:verb "set-body" :class (.-class a) :method (.-method a) :body body :anchor fp}))))
     out)))
 
-;; replay a claim-doc onto a source -> {:ok :src} or {:ok false :reason}.
+;; replay a claim-doc onto a source -> {:ok :src :recoveries} or {:ok false :reason}.
+;; Each verb passes its :anchor so set-method-body can recover an upstream rename.
 (js/export (defn replay [doc :- Any src :- String] :- Any
-  (loop [i 0 cur src]
-    (if (< i (.-length doc))
-      (let [c (aget doc i)
-            r (set-method-body cur (.-class c) (.-method c) (.-body c))]
-        (if (.-ok r) (recur (+ i 1) (.-src r)) r))
-      {:ok true :src cur}))))
+  (let [recoveries []]
+    (loop [i 0 cur src]
+      (if (< i (.-length doc))
+        (let [c (aget doc i)
+              r (set-method-body cur (.-class c) (.-method c) (.-body c) (.-anchor c))]
+          (if (.-ok r)
+            (do (when (some? (.-recovered r)) (.push recoveries (.-recovered r)))
+                (recur (+ i 1) (.-src r)))
+            r))
+        {:ok true :src cur :recoveries recoveries})))))
 
 (js/export (defn doc->json [doc :- Any] :- String (JSON/stringify doc nil 2)))
 (js/export (defn json->doc [s :- String] :- Any (JSON/parse s)))

--- a/tools/projector/gen-claims.bjs
+++ b/tools/projector/gen-claims.bjs
@@ -33,7 +33,8 @@
     (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)))
     (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")))
     (let [patched (readFileSync (join TMP REL) "utf8")
-          edits (build-doc patched ANCHORS)
+          pristine (readFileSync (join TMP "pristine.mjs") "utf8")
+          edits (build-doc patched pristine ANCHORS)
           artifact {:file REL :edits edits}]
       (writeFileSync OUT (str (JSON/stringify artifact nil 2) "\n"))
       (console/error (str "wrote " OUT "  (" (.-length edits) " set-body verbs, anchored @ " tag ")")))))

--- a/tools/projector/pilot-0011.bjs
+++ b/tools/projector/pilot-0011.bjs
@@ -36,7 +36,7 @@
         claim-path (or (aget (.-argv process) 4) "/tmp/0011.claims.json")
         ;; build the claim-doc from the known-good patched output, persist to JSON,
         ;; then reload it — proving the edit round-trips through a portable artifact.
-        doc0 (build-doc patched ANCHORS)
+        doc0 (build-doc patched pristine ANCHORS)
         json (doc->json doc0)
         _ (writeFileSync claim-path json)
         doc (json->doc (readFileSync claim-path "utf8"))
@@ -52,15 +52,26 @@
                   "let chromeURI = this.getChromeURI(uri);"
                   "let chromeURI = this.getChromeURI(uri); // FF153 upstream reflow")
         r2 (replay doc churned)
-        churn-ok (and (.-ok r2) (parses? (.-src r2)) (= (count-occurrences (.-src r2) "gjoa-newtab") 2))]
+        churn-ok (and (.-ok r2) (parses? (.-src r2)) (= (count-occurrences (.-src r2) "gjoa-newtab") 2))
+        ;; GATE 3 — RENAME RECOVERY: upstream renames the target method (newChannel
+        ;; -> createChannel). The textual patch .rej's; the claim recovers via the
+        ;; structural anchor (params + body fingerprint) when confident + unambiguous.
+        renamed (.replaceAll pristine "newChannel(uri, loadInfo)" "createChannel(uri, loadInfo)")
+        r3 (replay doc renamed)
+        rename-ok (and (.-ok r3) (parses? (.-src r3))
+                       (= (count-occurrences (.-src r3) "gjoa-newtab") 2)
+                       (> (.-length (.-recoveries r3)) 0))]
     (console/error (str "claim-doc: " (.-length doc) " set-body verbs, " (.-length json) " bytes JSON -> " claim-path))
     (console/error (str "GATE 1  equivalence (claim-replay == patch 0011, byte-for-byte): " equiv))
     (console/error (str "GATE 2  churn-resilience (name-anchored claim survives reflow that .rej's the patch): " churn-ok))
-    (when (not (and equiv churn-ok))
+    (console/error (str "GATE 3  rename-recovery (claim survives a method rename that .rej's the patch): " rename-ok))
+    (when rename-ok
+      (doseq [rec (.-recoveries r3)] (console/error (str "          recovered: " rec))))
+    (when (not (and equiv churn-ok rename-ok))
       (console/error "PILOT FAILED")
       (when (not (.-ok r1)) (console/error (str "  gate1: " (.-reason r1))))
       (.exit process 1))
-    (console/error "PILOT PASSED — 0011 is a portable identity-anchored claim-doc: equivalent + churn-resilient.")))
+    (console/error "PILOT PASSED — 0011 as a claim-doc: equivalent, reflow-resilient, AND rename-recoverable.")))
 
 (when (.-main (js/import-meta))
   (main!))

--- a/tools/projector/set-body.bjs
+++ b/tools/projector/set-body.bjs
@@ -7,7 +7,8 @@
 ;; needs the deferred anchor-matcher; the 0011 pilot keeps newChannel's name.)
 (ns gjoa.tools.projector.set-body
   (:require [acorn :refer [parse]]
-            [gjoa.tools.projector.reflector :refer [child-nodes to-cst render]]))
+            [gjoa.tools.projector.reflector :refer [child-nodes to-cst render]]
+            [gjoa.tools.projector.anchor :refer [fuzzy-find confident?]]))
 (define-mode strict)
 
 (defn parse-js [src :- String] :- Any
@@ -56,17 +57,33 @@
      :segs (.-segs cst)
      :kids (.map (.-kids cst) (fn [k :- Any] :- Any (replace-span k span text)))})))
 
-;; the set-body verb: src + class + method + new body text (including the braces)
-;; -> {:ok :src :span} or {:ok false :reason}.
-(js/export (defn set-method-body [src :- String class-name :- String method-name :- String new-body :- String] :- Any
+;; replace the body block at `span` in `src` with `new-body`, byte-exactly.
+(defn apply-body [src :- String span :- Any new-body :- String] :- String
+  (let [root {:type "File" :start 0 :end (.-length src) :body [(parse-js src)]}]
+    (render (replace-span (to-cst root src) span new-body))))
+
+;; the set-body verb: src + class + method + new body text (including the braces),
+;; and an optional `anchor` fingerprint for RENAME-RECOVERY. Exact (class, method)
+;; match first; on a miss, if an anchor is given, try a confidence-scored fuzzy
+;; match (recovers an upstream rename) — but only AUTO-APPLY when confident +
+;; unambiguous, else fail loudly (never mis-apply). -> {:ok :src :span [:recovered]}
+;; or {:ok false :reason}.
+(js/export (defn set-method-body [src :- String class-name :- String method-name :- String new-body :- String anchor :- Any] :- Any
   (let [ast (parse-js src)
-        span (find-body-span ast class-name method-name)]
-    (if (nil? span)
-      {:ok false :reason (str "not found: " class-name "." method-name)}
-      (let [root {:type "File" :start 0 :end (.-length src) :body [ast]}
-            cst (to-cst root src)
-            edited (replace-span cst span new-body)]
-        {:ok true :src (render edited) :span span})))))
+        exact (find-body-span ast class-name method-name)]
+    (cond
+      (some? exact)
+      {:ok true :src (apply-body src exact new-body) :span exact}
+
+      (some? anchor)
+      (let [m (fuzzy-find src class-name anchor)]
+        (if (confident? m)
+          {:ok true :src (apply-body src (.-body m) new-body) :span (.-body m)
+           :recovered (str method-name " -> " (.-name m) " (" (.-why m) ")")}
+          {:ok false :reason (str "not found: " class-name "." method-name
+                                  (if (some? m) (str "; fuzzy candidate `" (.-name m) "` rejected: " (.-why m)) ""))}))
+
+      :else {:ok false :reason (str "not found: " class-name "." method-name)}))))
 
 ;; extract the literal body text of class.method from src (for building a claim
 ;; from a known-good edited source).


### PR DESCRIPTION
The deferred research tail of #74: the claim-doc fallback now recovers an upstream method **rename**, not just a reflow.

## How
Each `set-body` verb carries a structural **anchor** captured from the pristine method: **param list + ordinal + body-identifier set**. When the exact `(class, method)` anchor misses, `set-method-body` fuzzy-matches candidates by **body-identifier Jaccard overlap**, gated on **param equality** and a **clear margin** over the runner-up.

## Safety — prefer failing loudly over a wrong match
Auto-recover **only** when confident *and* unambiguous (`bodyJaccard ≥ 0.6`, params equal, `margin ≥ 0.15`); otherwise reject (the prior safe behavior). **Adversarially verified:**
| scenario | result |
|---|---|
| clean rename (params+body intact) | **recover** (conf 1.00, margin 0.93) |
| rename + param change | reject (pm=0) |
| ambiguous twins | reject (margin 0.05) |
| rename + heavy body rewrite | reject (jaccard 0.11) |

## End to end (pilot GATE 3)
An upstream `newChannel → createChannel` rename that makes the textual patch `Hunk #1 FAILED` is **auto-recovered on both methods**, edits landing on the renamed targets, recovery logged:
```
GATE 3  rename-recovery: true
          recovered: newChannel -> createChannel (params=1 bodyJaccard=1.00 margin=0.93)
          recovered: newChannel -> createChannel (params=1 bodyJaccard=1.00 margin=1.00)
```
`projector:test` (CI) + whole-tree check (134 files, 0 errors) green. Claims-as-patches now survives **reflow AND rename**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784526310&installation_id=141311834&pr_number=83&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F83&signature=c556a2635b55f7cbc9c44db1c16fbad1d1908d8eb5dc97dcfd73adcb39282e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->