### PR TITLE
chore(prep): if-with-nil-else -> when/when-not (18 sites)

### DIFF
--- a/tools/prep/chrome-bake.bjs
+++ b/tools/prep/chrome-bake.bjs
@@ -49,9 +49,8 @@
                               :stdout "inherit"
                               :stderr "inherit"})
             code (js/await (.-exited proc))]
-        (if (not= code 0)
-          (throw (Error. (str "chrome:dist failed (exit " code ")")))
-          nil)))))
+        (when (not= code 0)
+          (throw (Error. (str "chrome:dist failed (exit " code ")"))))))))
 
 (defn bakeOne [srcSubdir :- String dstSubdir :- String names :- Any] :- Any
   (let [dstDir (join BAKE-ROOT dstSubdir)
@@ -60,7 +59,7 @@
     ;; Sequential index loop so each copyFile is awaited in order (a `doseq`
     ;; would emit .forEach, which does NOT await its async body).
     (loop [i 0]
-      (if (< i n)
+      (when (< i n)
         (let [fname (aget names i)
               src (join DIST-CHROME srcSubdir fname)]
           (do
@@ -68,8 +67,7 @@
               (throw (Error. (str "chrome-bake: expected " src
                                   " from chrome:dist (declared in jar.mn) — did the bundle list drift?"))))
             (js/await (copyFile src (join dstDir fname)))
-            (recur (+ i 1))))
-        nil))))
+            (recur (+ i 1))))))))
 
 (js/export (defn chrome-bake [] :- Any
   (js/await (ensureChromeDist))

--- a/tools/prep/darkmode-registry.bjs
+++ b/tools/prep/darkmode-registry.bjs
@@ -196,24 +196,22 @@
       (or (.startsWith lower "rgb(") (.startsWith lower "rgba("))
       (let [body (.slice s (+ (.indexOf s "(") 1) (.lastIndexOf s ")"))
             parts (split-args body)]
-        (if (>= (.-length parts) 3)
+        (when (>= (.-length parts) 3)
           [(clamp (Math.round (parse-component (aget parts 0) 255)) 0 255)
            (clamp (Math.round (parse-component (aget parts 1) 255)) 0 255)
            (clamp (Math.round (parse-component (aget parts 2) 255)) 0 255)
-           (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)]
-          nil))
+           (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)]))
 
       (or (.startsWith lower "hsl(") (.startsWith lower "hsla("))
       (let [body (.slice s (+ (.indexOf s "(") 1) (.lastIndexOf s ")"))
             parts (split-args body)]
-        (if (>= (.-length parts) 3)
+        (when (>= (.-length parts) 3)
           (let [h (parseFloat (aget parts 0))
                 sat (/ (parse-component (aget parts 1) 100) 100)
                 lit (/ (parse-component (aget parts 2) 100) 100)
                 rgb (hsl->rgb h (clamp sat 0 1) (clamp lit 0 1))]
             [(aget rgb 0) (aget rgb 1) (aget rgb 2)
-             (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)])
-          nil))
+             (if (>= (.-length parts) 4) (clamp (parse-component (aget parts 3) 1) 0 1) 1)])))
 
       ;; bare hex without '#', e.g. ${fff}
       (.test (RegExp. "^[0-9a-fA-F]{3,8}$") s)
@@ -277,9 +275,8 @@
 ;; text is not a parseable color (e.g. `transparent`, or a var() — handled earlier).
 (defn resolve-token [inner :- String] :- Any
   (let [parsed (parse-color inner)]
-    (if parsed
-      (rgba->css (flip-rgba parsed))
-      nil)))
+    (when parsed
+      (rgba->css (flip-rgba parsed)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dark Reader runtime theme variables.

--- a/tools/prep/download.bjs
+++ b/tools/prep/download.bjs
@@ -91,18 +91,16 @@
         (.warn log "gpg not available; skipping SHA256SUMS.asc signature check (pinned in-repo hash still enforced)")
         false)
       (let [ascRes (js/await (fetch (signatureUrl version)))]
-        (if (not (.-ok ascRes))
-          (throw (Error. (str "failed to fetch SHA256SUMS.asc: " (.-status ascRes))))
-          nil)
+        (when-not (.-ok ascRes)
+          (throw (Error. (str "failed to fetch SHA256SUMS.asc: " (.-status ascRes)))))
         (let [asc (js/await (.text ascRes))
               tmpDir (join SOURCES-CACHE ".gpg-verify")
               keyPath (join tmpDir "mozilla.key")
               sumsPath (join tmpDir "SHA256SUMS")
               ascPath (join tmpDir "SHA256SUMS.asc")
               keyRes (js/await (fetch (str "https://archive.mozilla.org/pub/firefox/releases/" version "/KEY")))]
-          (if (not (.-ok keyRes))
-            (throw (Error. (str "failed to fetch Mozilla KEY: " (.-status keyRes))))
-            nil)
+          (when-not (.-ok keyRes)
+            (throw (Error. (str "failed to fetch Mozilla KEY: " (.-status keyRes)))))
           (mkdirSync tmpDir {:recursive true})
           (js/await (.write Bun keyPath (js/await (.text keyRes))))
           (js/await (.write Bun sumsPath sumsText))
@@ -112,43 +110,38 @@
           (let [kr (join tmpDir "keyring.gpg")
                 imp (.spawnSync Bun ["gpg" "--no-default-keyring" "--keyring" kr "--import" keyPath]
                                 {:stdout "ignore" :stderr "ignore"})]
-            (if (not (.-success imp))
-              (throw (Error. "gpg: failed to import Mozilla KEY"))
-              nil)
+            (when-not (.-success imp)
+              (throw (Error. "gpg: failed to import Mozilla KEY")))
             ;; --status-fd 1 prints machine-readable VALIDSIG <fpr> ... lines.
             (let [ver (.spawnSync Bun ["gpg" "--no-default-keyring" "--keyring" kr
                                        "--status-fd" "1" "--verify" ascPath sumsPath]
                                   {:stdout "pipe" :stderr "ignore"})
                   out (.toString (.-stdout ver))]
-              (if (not (.includes out (str "VALIDSIG " MOZILLA-SIGNING-FPR)))
+              (when-not (.includes out (str "VALIDSIG " MOZILLA-SIGNING-FPR))
                 (throw (Error. (str "SHA256SUMS.asc not signed by pinned Mozilla key "
-                                    MOZILLA-SIGNING-FPR "\n  gpg --status output:\n" out)))
-                nil)
+                                    MOZILLA-SIGNING-FPR "\n  gpg --status output:\n" out))))
               (.ok log (str "SHA256SUMS.asc GPG-verified against pinned Mozilla key " MOZILLA-SIGNING-FPR))
               true)))))))
 
 (defn fetchSha256 [version :- String] :- Any
   (.step log (str "fetching upstream SHA256SUMS for firefox " version))
   (let [res (js/await (fetch (checksumUrl version)))]
-    (if (not (.-ok res))
-      (throw (Error. (str "failed to fetch SHA256SUMS: " (.-status res))))
-      nil)
+    (when-not (.-ok res)
+      (throw (Error. (str "failed to fetch SHA256SUMS: " (.-status res)))))
     (let [text (js/await (.text res))
           liveHash (hashFromSums text version)]
-      (if (not liveHash)
-        (throw (Error. (str "SHA256SUMS does not list " (tarballName version))))
-        nil)
+      (when-not liveHash
+        (throw (Error. (str "SHA256SUMS does not list " (tarballName version)))))
       ;; F9 trust anchor: the live SHA256SUMS comes from the SAME origin as the
       ;; tarball, so it can't be the sole authority. Assert it against the
       ;; in-repo pinned hash — a backdoored tarball + matching same-origin
       ;; SHA256SUMS can't move this committed value.
       (let [pinned (pinnedSha256 version)]
-        (if (not= liveHash pinned)
+        (when (not= liveHash pinned)
           (throw (Error. (str "live SHA256SUMS disagrees with pinned checksum for firefox " version
                               ".\n  pinned: " pinned
                               "\n  live:   " liveHash
-                              "\n  refusing to trust same-origin checksum over the committed pin.")))
-          nil))
+                              "\n  refusing to trust same-origin checksum over the committed pin.")))))
       ;; Defense-in-depth: verify the detached signature when gpg is present.
       (js/await (verifySignature version text))
       liveHash)))
@@ -163,13 +156,11 @@
 (defn downloadTo [url :- String dest :- String] :- Any
   (.step log (str "downloading " url))
   (let [res (js/await (fetch url))]
-    (if (not (.-ok res))
-      (throw (Error. (str "download failed (" (.-status res) "): " url)))
-      nil)
+    (when-not (.-ok res)
+      (throw (Error. (str "download failed (" (.-status res) "): " url))))
     (let [total (Number (or (.get (.-headers res) "content-length") 0))]
-      (if total
-        (.info log (str "expecting " (.toFixed (/ total 1024 1024) 1) " MB"))
-        nil)
+      (when total
+        (.info log (str "expecting " (.toFixed (/ total 1024 1024) 1) " MB")))
       (js/await (.write Bun dest res)))))
 
 (js/export (defn download! [] :- Any
@@ -189,10 +180,9 @@
         (js/await (downloadTo (tarballUrl version) tarball)))
       ;; Verify post-download (also catches partial writes / network corruption).
       (let [actualHash (js/await (sha256OfFile tarball))]
-        (if (not= actualHash expectedHash)
+        (when (not= actualHash expectedHash)
           (throw (Error. (str "tarball SHA256 mismatch.\n  expected: " expectedHash
-                              "\n  got:      " actualHash)))
-          nil))
+                              "\n  got:      " actualHash)))))
       (.ok log (str "tarball verified (" (.toFixed (/ (.-size (statSync tarball)) 1024 1024) 1) " MB)"))
       ;; Extract into engine/. mozilla-central tarballs unpack as firefox-VERSION/
       ;; — strip that level so engine/ holds the source tree directly.
@@ -208,7 +198,6 @@
                                   :stdout "inherit"
                                   :stderr "inherit"})
                 code (js/await (.-exited proc))]
-            (if (not= code 0)
-              (throw (Error. (str "tar extraction failed (exit " code ")")))
-              nil))
+            (when (not= code 0)
+              (throw (Error. (str "tar extraction failed (exit " code ")")))))
           (.ok log "engine/ ready")))))))

--- a/tools/prep/patches.bjs
+++ b/tools/prep/patches.bjs
@@ -56,9 +56,8 @@
 (defn runLint [] :- Any
   (try
     (let [problems (js/await (check-all))]
-      (if (> problems 0)
-        (.warn log (str problems " patch(es) missing the gjoa-patch header"))
-        nil))
+      (when (> problems 0)
+        (.warn log (str problems " patch(es) missing the gjoa-patch header"))))
     (catch Error e
       (.warn log (str "patch-header lint failed (non-fatal): " (.-message e))))))
 
@@ -74,7 +73,7 @@
   (.step log (str "applying patch " name))
   (let [path (join PATCHES-DIR name)
         code (js/await (run-git ["git" "apply" "--whitespace=nowarn" path] ENGINE-DIR))]
-    (if (not= code 0)
+    (when (not= code 0)
       (let [claims-path (join PATCHES-DIR (.replace name ".patch" ".claims.json"))]
         (if (existsSync claims-path)
           (let [repo (.cwd process)
@@ -84,8 +83,7 @@
               (.ok log (str "  " name ": textual patch .rej'd — recovered via claim-doc replay (identity-anchored)"))
               (throw (Error. (str "failed to apply patch " name ": git apply exited " code
                                   "; claim-doc fallback exited " rc)))))
-          (throw (Error. (str "failed to apply patch " name ": git apply exited " code)))))
-      nil)))
+          (throw (Error. (str "failed to apply patch " name ": git apply exited " code))))))))
 
 (js/export (defn patches [] :- Any
   (if (not (existsSync PATCHES-DIR))


### PR DESCRIPTION
Idiomatic cleanup across the prep tools: `(if COND BODY nil)` → `(when COND BODY)`. Behavior-equivalent under beagle nil semantics. Verified: `beagle check` clean + `bun run import` clean with identical dark-registry fingerprint. Not byte-identical (beagle emits if-with-nil-else as a `:null` ternary vs when as a no-else if-statement — the byte-diff caught that; the import run confirmed equivalence). Drops 18 dead nil branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784527491&installation_id=141311834&pr_number=84&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F84&signature=85fe8d1292803176b5ec31cd4b1f23ab904d007a8cb8185f02c74130496be2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->