### PR TITLE
refactor: compression dedup — shared NAV-JS + sh helper

### DIFF
--- a/tests/dsl.bjs
+++ b/tests/dsl.bjs
@@ -75,3 +75,19 @@
 ;; Resolve after `ms` milliseconds.
 (js/export (defn sleep [ms :- Any] :- Any
   (js/await (Promise. (fn [res] (setTimeout (fn [] (res)) ms))))))
+
+;; Navigate the selected tab to `url` and resolve when it finishes loading
+;; (nsIWebProgressListener STATE_STOP|STATE_IS_WINDOW; 15s safety). Shared by the
+;; darkmode/contrast/adblock tests that all open a page then assert on it.
+(js/export (def NAV-JS :- String
+  (str "\n"
+       "  const [url, resolve] = arguments;\n"
+       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
+       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
+       "  const b = win.gBrowser.selectedBrowser;\n"
+       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
+       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
+       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
+       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
+       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
+       "  setTimeout(() => finish(false), 15000);\n")))

--- a/tests/integration/adblock-cosmetic-actor.bjs
+++ b/tests/integration/adblock-cosmetic-actor.bjs
@@ -15,7 +15,7 @@
 ;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
 ;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "adblock M2 actor"
 (ns gjoa.tests.integration.adblock-cosmetic-actor
-  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect]]))
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect NAV-JS]]))
 (define-mode strict)
 
 (def TOP :- String "http://127.0.0.1:8975/")
@@ -34,21 +34,6 @@
        "  Services.prefs.setBoolPref('privacy.trackingprotection.content.protection.enabled', true);\n"
        "  Services.prefs.setCharPref('gjoa.contentblock.user.allow-hosts', '');\n"
        "  return 'setup-ok';\n"))
-
-;; Async chrome nav: listener attached before loadURI so a fast local load can't
-;; race past it; resolve on load-stop.
-(def NAV-JS :- String
-  (str "\n"
-       "  const [url, resolve] = arguments;\n"
-       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
-       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
-       "  const b = win.gBrowser.selectedBrowser;\n"
-       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
-       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
-       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
-       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
-       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
-       "  setTimeout(() => finish(false), 15000);\n"))
 
 (def STATIC-HIDDEN :- String
   "const s=document.getElementById('static'); return !!(s && getComputedStyle(s).display === 'none');")

--- a/tests/integration/contrast.bjs
+++ b/tests/integration/contrast.bjs
@@ -20,7 +20,7 @@
 ;; Precondition: tools/test-driver/contrast-fixture-server.mjs serving :8976
 ;; (the runner --with-fixtures flag spawns it).
 (ns gjoa.tests.integration.contrast
-  (:require [gjoa.tests.dsl :refer [deftest expect sleep]]
+  (:require [gjoa.tests.dsl :refer [deftest expect sleep NAV-JS]]
             [gjoa.tools.test-driver.contrast-score :refer [parse-rgb evaluate-box score-page]]
             [gjoa.tools.test-driver.contrast-sample :refer [decode-png sample-backdrop]]))
 (define-mode strict)
@@ -48,20 +48,6 @@
   (str "Services.prefs.setBoolPref('gjoa.darkmode.enabled', true);"
        " Services.prefs.setCharPref('gjoa.darkmode.mode', 'hybrid');"
        " return 'on';"))
-
-;; Chrome-side navigation: load url, resolve when the top window hits STATE_STOP.
-(def NAV-JS :- String
-  (str "\n"
-       "  const [url, resolve] = arguments;\n"
-       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
-       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
-       "  const b = win.gBrowser.selectedBrowser;\n"
-       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
-       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
-       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
-       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
-       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
-       "  setTimeout(() => finish(false), 15000);\n"))
 
 ;; Content-side enumeration: every visible text run -> page-relative box + its
 ;; post-inversion computed color + size/weight. Range.getClientRects (not the

--- a/tests/integration/darkmode-hybrid.bjs
+++ b/tests/integration/darkmode-hybrid.bjs
@@ -14,24 +14,11 @@
 ;; the authored bg pre-paint and dissolves that circularity; the "inactive"
 ;; assertion lands there.
 (ns gjoa.tests.integration.darkmode-hybrid
-  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq]]))
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq NAV-JS]]))
 (define-mode strict)
 
 (def TOP :- String "http://127.0.0.1:8975/") ;; no-bg page (UA-dark under hybrid)
 (def LIGHT-TOP :- String "http://127.0.0.1:8975/light") ;; hardcoded-light themeless site
-
-(def NAV-JS :- String
-  (str "\n"
-       "  const [url, resolve] = arguments;\n"
-       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
-       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
-       "  const b = win.gBrowser.selectedBrowser;\n"
-       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
-       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
-       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
-       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
-       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
-       "  setTimeout(() => finish(false), 15000);\n"))
 
 ;; Hybrid on; global engine invert OFF so ONLY the actor's per-document decision
 ;; can invert.

--- a/tests/integration/darkmode-invert.bjs
+++ b/tests/integration/darkmode-invert.bjs
@@ -12,23 +12,10 @@
 ;;   GJOA_BIN=$PWD/engine/obj-x86_64-pc-linux-gnu/dist/bin/gjoa \
 ;;     bun .beagle-tools/gjoa/tools/test-driver/runner.js --grep "darkmode P0"
 (ns gjoa.tests.integration.darkmode-invert
-  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq]]))
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect expect-eq NAV-JS]]))
 (define-mode strict)
 
 (def TOP :- String "http://127.0.0.1:8975/")
-
-(def NAV-JS :- String
-  (str "\n"
-       "  const [url, resolve] = arguments;\n"
-       "  let done = false; const finish = v => { if (!done) { done = true; resolve(v); } };\n"
-       "  const win = Services.wm.getMostRecentWindow('navigator:browser');\n"
-       "  const b = win.gBrowser.selectedBrowser;\n"
-       "  const l = { QueryInterface: ChromeUtils.generateQI(['nsIWebProgressListener','nsISupportsWeakReference']),\n"
-       "    onStateChange(wp, req, flags) { const S = Ci.nsIWebProgressListener;\n"
-       "      if ((flags & S.STATE_STOP) && (flags & S.STATE_IS_WINDOW)) { try { b.removeProgressListener(l); } catch {} finish(true); } } };\n"
-       "  b.addProgressListener(l, Ci.nsIWebProgress.NOTIFY_STATE_ALL);\n"
-       "  b.loadURI(Services.io.newURI(url), { triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal() });\n"
-       "  setTimeout(() => finish(false), 15000);\n"))
 
 ;; Inject a box with explicit white bg + black text, return its computed colors.
 (def PROBE :- String

--- a/tools/prep/conflict-forecast.bjs
+++ b/tools/prep/conflict-forecast.bjs
@@ -11,19 +11,13 @@
 (ns gjoa.tools.prep.conflict-forecast
   (:require [fs :refer [readdirSync readFileSync]]
             [path :refer [join]]
-            [child_process :refer [execSync]]))
+            [gjoa.tools.prep.sh :refer [sh]]))
 (define-mode strict)
 (declare-extern [process] Any)
 
 (def REPO :- String (.cwd process))
 (def PATCHES-DIR :- String (join REPO "patches"))
 (def FF :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
-
-(defn sh [cmd :- String] :- String
-  ;; 256MB buffer: a major-version delta (e.g. 151->152) is ~76k file paths
-  ;; (~6MB) and overflows execSync's 1MB default, which would silently empty.
-  (try (.toString (execSync cmd {:encoding "utf8" :stdio ["ignore" "pipe" "ignore"] :maxBuffer (* 256 1024 1024)}))
-    (catch Error _e "")))
 
 ;; version "152.0.1" -> mozilla release tag "FIREFOX_152_0_1_RELEASE"
 (defn version->tag [v :- String] :- String
@@ -33,7 +27,7 @@
   (.-version (.-firefox (JSON/parse (readFileSync (join REPO "gjoa.json") "utf8")))))
 
 (defn latest-stable [] :- String
-  (let [out (sh "curl -s 'https://product-details.mozilla.org/1.0/firefox_versions.json' 2>/dev/null")]
+  (let [out (sh "curl -s 'https://product-details.mozilla.org/1.0/firefox_versions.json' 2>/dev/null" {:quiet true})]
     (if (= out "") "" (.-LATEST_FIREFOX_VERSION (JSON/parse out)))))
 
 ;; mozilla files a patch touches (exclude the depends-on contract lines)
@@ -59,7 +53,7 @@
       (or (= from "") (= to "")) (console/log "forecast: could not determine from/to versions")
       (= from to) (console/log (str "forecast: already at " to " — nothing to forecast"))
       :else
-      (let [delta (.filter (.split (sh (str "git -C " FF " diff --name-only " (version->tag from) " " (version->tag to) " 2>/dev/null")) "\n")
+      (let [delta (.filter (.split (sh (str "git -C " FF " diff --name-only " (version->tag from) " " (version->tag to) " 2>/dev/null") {:quiet true}) "\n")
                            (fn [s :- String] :- Bool (> (.-length s) 0)))]
         (if (= (.-length delta) 0)
           (console/log (str "forecast " from " -> " to ": empty delta — are the release tags present in " FF "?"))

--- a/tools/prep/firefox-api-surface.bjs
+++ b/tools/prep/firefox-api-surface.bjs
@@ -18,7 +18,7 @@
 ;; hardening.md. This monitors the surface instead of pretending to type it.
 ;;   bun run firefox-api-drift
 (ns gjoa.tools.prep.firefox-api-surface
-  (:require [child_process :refer [execSync]]
+  (:require [gjoa.tools.prep.sh :refer [sh]]
             [path :refer [join]]))
 (define-mode strict)
 (declare-extern [process] Any)
@@ -31,16 +31,12 @@
 ;; here — the sub-service NAMES themselves are stable XPCOM getters.
 (def GLOBALS :- Any ["gBrowser" "ChromeUtils" "PathUtils" "IOUtils"])
 
-(defn sh [cmd :- String] :- String
-  (try (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024) :stdio ["ignore" "pipe" "ignore"]}))
-    (catch Error _e "")))
-
 ;; derive [{:global g :members [member ...]} ...] from `(.<member> <Global> ...)`
 ;; calls in chrome.
 (defn scan-surface [] :- Any
   (let [result []]
     (doseq [g GLOBALS]
-      (let [out (sh (str "grep -rhoE '\\(\\.[a-zA-Z]+ " g "\\b' " CHROME " 2>/dev/null"))
+      (let [out (sh (str "grep -rhoE '\\(\\.[a-zA-Z]+ " g "\\b' " CHROME " 2>/dev/null") {:quiet true})
             members []]
         (doseq [line (.split out "\n")]
           (let [m (.match line (RegExp. "\\(\\.([a-zA-Z]+)"))]
@@ -53,7 +49,7 @@
 ;; does `member` still appear in non-test engine/ source? (definition or use)
 (defn resolves? [member :- String] :- Bool
   (let [hits (sh (str "grep -rl --include=*.js --include=*.jsm --include=*.mjs --include=*.webidl --include=*.idl "
-                      "-e '" member "' " ENGINE " 2>/dev/null | grep -vE '/test/|/tests/|_test' | head -1"))]
+                      "-e '" member "' " ENGINE " 2>/dev/null | grep -vE '/test/|/tests/|_test' | head -1") {:quiet true})]
     (> (.-length (.trim hits)) 0)))
 
 (defn main! [] :- Any

--- a/tools/prep/patch-cost.bjs
+++ b/tools/prep/patch-cost.bjs
@@ -7,7 +7,7 @@
 (ns gjoa.tools.prep.patch-cost
   (:require [fs :refer [readdirSync readFileSync]]
             [path :refer [join]]
-            [child_process :refer [execSync]]))
+            [gjoa.tools.prep.sh :refer [sh]]))
 (define-mode strict)
 (declare-extern [process] Any)
 
@@ -16,13 +16,9 @@
 ;; mozilla-central full clone (the churn oracle). /reference per code/CLAUDE.md.
 (def FF :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
 
-(defn sh [cmd :- String] :- String
-  (try (.toString (execSync cmd {:encoding "utf8" :stdio ["ignore" "pipe" "ignore"]}))
-    (catch Error _e "")))
-
 ;; churn = commits touching <file> in mozilla-central over the last year.
 (defn churn [file :- String] :- Number
-  (parseInt (.trim (sh (str "git -C " FF " log --oneline --since='1 year ago' -- '" file "' 2>/dev/null | wc -l"))) 10))
+  (parseInt (.trim (sh (str "git -C " FF " log --oneline --since='1 year ago' -- '" file "' 2>/dev/null | wc -l") {:quiet true})) 10))
 
 (defn touches [text :- String] :- Any
   (let [out []]

--- a/tools/prep/sh.bjs
+++ b/tools/prep/sh.bjs
@@ -1,0 +1,22 @@
+#lang beagle/js
+;; tools/prep/sh.bjs — one shell-exec helper, replacing ~6 per-tool copies that
+;; drifted on buffer size and error handling. opts (all optional):
+;;   :cwd        run in this directory
+;;   :max-buffer stdout cap (default 256MB — large enough that no caller's buffer
+;;               shrinks; a too-small default silently EMPTIES on big output, the
+;;               bug that bit conflict-forecast on a 76k-file delta)
+;;   :quiet      swallow a nonzero exit / error to "" and silence stderr
+;;               (else throw on nonzero exit — execSync's default)
+(ns gjoa.tools.prep.sh
+  (:require [child_process :refer [execSync]]))
+(define-mode strict)
+(declare-extern [Error Object] Any)
+
+(js/export (defn sh [cmd :- String opts :- Any] :- String
+  (let [o (or opts {})
+        cfg {:encoding "utf8" :maxBuffer (or (.-maxBuffer o) (* 256 1024 1024))}
+        cfg2 (if (.-cwd o) (.assign Object {} cfg {:cwd (.-cwd o)}) cfg)]
+    (if (.-quiet o)
+      (try (.toString (execSync cmd (.assign Object {} cfg2 {:stdio ["ignore" "pipe" "ignore"]})))
+        (catch Error _e ""))
+      (.toString (execSync cmd cfg2))))))

--- a/tools/prep/symbol-resolve.bjs
+++ b/tools/prep/symbol-resolve.bjs
@@ -10,7 +10,7 @@
 (ns gjoa.tools.prep.symbol-resolve
   (:require [fs :refer [existsSync readFileSync]]
             [path :refer [join dirname]]
-            [child_process :refer [execSync]]))
+            [gjoa.tools.prep.sh :refer [sh]]))
 (define-mode strict)
 (declare-extern [process] Any)
 
@@ -20,10 +20,6 @@
 
 (defn slurp [f :- String] :- String
   (if (existsSync f) (readFileSync f "utf8") ""))
-
-(defn sh [cmd :- String] :- String
-  (try (.toString (execSync cmd {:encoding "utf8" :stdio ["ignore" "pipe" "ignore"]}))
-    (catch Error _e "")))
 
 (defn rel [f :- String] :- String (.replace f (str ENGINE "/") ""))
 
@@ -79,7 +75,7 @@
 ;; obj-*/.../style-*/out/properties.rs. Modern API is clone_<longhand>(); assert
 ;; the accessor (or a bare field) exists there.
 (defn objdir-properties [] :- String
-  (.trim (sh (str "ls -t " ENGINE "/obj-*/x86_64-unknown-linux-gnu/release/build/style-*/out/properties.rs 2>/dev/null | head -1"))))
+  (.trim (sh (str "ls -t " ENGINE "/obj-*/x86_64-unknown-linux-gnu/release/build/style-*/out/properties.rs 2>/dev/null | head -1") {:quiet true})))
 
 (js/export (defn resolve-rust-field [field :- String accessor :- String] :- Any
   (let [gen (objdir-properties)]
@@ -125,7 +121,7 @@
             (if (not present)
               {:verdict "not-found" :detail (str prop " not a member of " mod " (deleted/renamed)")}
               (if (and must-read (not= must-read ""))
-                (let [readers (.trim (sh (str "rg -l --no-messages '\\." prop "\\b' " (join ENGINE must-read) " 2>/dev/null | head -1")))]
+                (let [readers (.trim (sh (str "rg -l --no-messages '\\." prop "\\b' " (join ENGINE must-read) " 2>/dev/null | head -1") {:quiet true}))]
                   (if (= readers "")
                     {:verdict "not-found" :detail (str prop " exists but is ORPHANED — no reader under " must-read " (override silently ignored, like FF152 newTabURL)")}
                     {:verdict "resolved" :detail (str prop " present + read under " must-read)}))

--- a/tools/projector/fram-roundtrip.bjs
+++ b/tools/projector/fram-roundtrip.bjs
@@ -5,7 +5,7 @@
 ;; Steps: gjoa emits claims -> fram store loads + re-extracts (real engine) -> gjoa
 ;; renders byte-identically -> Datalog query over gjoa's AST. Needs ~/code/fram.
 (ns gjoa.tools.projector.fram-roundtrip
-  (:require [child_process :refer [execSync]]
+  (:require [gjoa.tools.prep.sh :refer [sh]]
             [fs :refer [readFileSync]]
             [path :refer [join]]))
 (define-mode strict)
@@ -16,9 +16,6 @@
 (def SELF :- String (join REPO ".beagle-tools" "gjoa" "tools" "projector" "fram-log.js"))
 (def DEFAULT :- String "engine/browser/components/newtab/AboutNewTabRedirector.sys.mjs")
 
-(defn sh [cmd :- String cwd :- String] :- String
-  (.toString (execSync cmd {:encoding "utf8" :cwd cwd :maxBuffer (* 128 1024 1024)})))
-
 ;; the structural Datalog query: every MethodDefinition node in gjoa's JS.
 (def QUERY :- String
   "{:find \"method\" :rules [{:head {:rel \"method\" :args [{:var \"l\"}]} :body [{:rel \"triple\" :args [{:var \"l\"} \"kind\" \"MethodDefinition\"]}]}]}")
@@ -27,20 +24,20 @@
   (let [F (or (aget (.-argv process) 2) DEFAULT)
         src (readFileSync (join REPO F) "utf8")]
     ;; 1. gjoa: JS -> claims (EDN triples for the store round-trip; a Fram log for query)
-    (sh (str "bun " SELF " edn " F " > /tmp/gjoa-A.edn") REPO)
-    (sh (str "bun " SELF " log " F " js > /tmp/gjoa-js.log") REPO)
-    (console/error (str "1. gjoa emitted " (.trim (sh "wc -l < /tmp/gjoa-A.edn" REPO)) " claims for " F))
+    (sh (str "bun " SELF " edn " F " > /tmp/gjoa-A.edn") {:cwd REPO})
+    (sh (str "bun " SELF " log " F " js > /tmp/gjoa-js.log") {:cwd REPO})
+    (console/error (str "1. gjoa emitted " (.trim (sh "wc -l < /tmp/gjoa-A.edn" {:cwd REPO})) " claims for " F))
     ;; 2. fram: load the claims into a REAL Fram store + re-extract (the engine)
-    (sh "bb -cp out chartroom/src/roundtrip_fram.clj /tmp/gjoa-A.edn > /tmp/gjoa-B.edn 2>/dev/null" FRAM)
+    (sh "bb -cp out chartroom/src/roundtrip_fram.clj /tmp/gjoa-A.edn > /tmp/gjoa-B.edn 2>/dev/null" {:cwd FRAM})
     (console/error "2. fram loaded the claims into a real store + re-extracted them")
     ;; 3. gjoa: render the re-extracted claims -> byte-identical?
-    (sh (str "bun " SELF " render /tmp/gjoa-B.edn > /tmp/gjoa-rendered.js") REPO)
+    (sh (str "bun " SELF " render /tmp/gjoa-B.edn > /tmp/gjoa-rendered.js") {:cwd REPO})
     (let [rendered (readFileSync "/tmp/gjoa-rendered.js" "utf8")
           identical (= rendered src)]
       (console/error (str "3. byte-identical through the live Fram store: " identical
                           " (" (.-length rendered) " bytes)"))
       ;; 4. Datalog: query gjoa's JS AST in the store
-      (let [out (.trim (sh (str "FRAM_LOG=/tmp/gjoa-js.log " (join FRAM "bin" "fram") " query '" QUERY "'") FRAM))
+      (let [out (.trim (sh (str "FRAM_LOG=/tmp/gjoa-js.log " (join FRAM "bin" "fram") " query '" QUERY "'") {:cwd FRAM}))
             n (.-length (.filter (.split out "\n") (fn [s :- String] :- Bool (> (.-length (.trim s)) 0))))]
         (console/error (str "4. Datalog query (MethodDefinition nodes) returned " n " methods from gjoa's JS"))
         (if (and identical (> n 0))

--- a/tools/projector/gen-claims.bjs
+++ b/tools/projector/gen-claims.bjs
@@ -6,9 +6,9 @@
 ;; once and commit; the build replays it as a fallback when the textual patch .rej's.
 ;;   bun run projector:gen-claims
 (ns gjoa.tools.projector.gen-claims
-  (:require [child_process :refer [execSync]]
-            [fs :refer [readFileSync writeFileSync]]
+  (:require [fs :refer [readFileSync writeFileSync]]
             [path :refer [join dirname]]
+            [gjoa.tools.prep.sh :refer [sh]]
             [gjoa.tools.projector.claims :refer [build-doc]]))
 (define-mode strict)
 (declare-extern [process console JSON] Any)
@@ -21,17 +21,14 @@
 (def FF-SRC :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
 (def TMP :- String "/tmp/gjoa-gen")
 
-(defn sh [cmd :- String] :- String
-  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
-
 (defn main! [] :- Any
   (let [v (.-version (.-firefox (.parse JSON (readFileSync (join REPO "gjoa.json") "utf8"))))
         tag (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE")
         dir (join TMP (dirname REL))]
-    (sh (str "rm -rf " TMP " && mkdir -p " dir))
-    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")))
-    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)))
-    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")))
+    (sh (str "rm -rf " TMP " && mkdir -p " dir) nil)
+    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")) nil)
+    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)) nil)
+    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")) nil)
     (let [patched (readFileSync (join TMP REL) "utf8")
           pristine (readFileSync (join TMP "pristine.mjs") "utf8")
           edits (build-doc patched pristine ANCHORS)

--- a/tools/projector/run-pilot.bjs
+++ b/tools/projector/run-pilot.bjs
@@ -6,7 +6,8 @@
 (ns gjoa.tools.projector.run-pilot
   (:require [child_process :refer [execSync]]
             [fs :refer [readFileSync]]
-            [path :refer [join dirname]]))
+            [path :refer [join dirname]]
+            [gjoa.tools.prep.sh :refer [sh]]))
 (define-mode strict)
 (declare-extern [process console JSON Error] Any)
 
@@ -14,9 +15,6 @@
 (def REL :- String "browser/components/newtab/AboutNewTabRedirector.sys.mjs")
 (def FF-SRC :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
 (def TMP :- String "/tmp/gjoa-pilot")
-
-(defn sh [cmd :- String] :- String
-  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
 
 (defn ff-version [] :- String
   (.-version (.-firefox (.parse JSON (readFileSync (join REPO "gjoa.json") "utf8")))))
@@ -26,11 +24,11 @@
         tag (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE")
         dir (join TMP (dirname REL))]
     ;; pristine = the pinned upstream file at its release tag; patched = pristine + 0011.
-    (sh (str "rm -rf " TMP " && mkdir -p " dir))
-    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")))
-    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)))
-    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")))
-    (sh (str "cp " (join TMP REL) " " (join TMP "patched.mjs")))
+    (sh (str "rm -rf " TMP " && mkdir -p " dir) nil)
+    (sh (str "git -C " FF-SRC " show " tag ":" REL " > " (join TMP "pristine.mjs")) nil)
+    (sh (str "cp " (join TMP "pristine.mjs") " " (join TMP REL)) nil)
+    (sh (str "cd " TMP " && patch -p1 < " (join REPO "patches" "0011-newtab-redirector-gjoa.patch")) nil)
+    (sh (str "cp " (join TMP REL) " " (join TMP "patched.mjs")) nil)
     (console/error (str "pilot inputs ready (pristine @ " tag ", patched via patches/0011)"))
     ;; delegate to the pilot (it owns the gates + exit code).
     (execSync (str "bun " (join REPO ".beagle-tools" "gjoa" "tools" "projector" "pilot-0011.js")

--- a/tools/projector/test-projector.bjs
+++ b/tools/projector/test-projector.bjs
@@ -7,9 +7,9 @@
 ;;            engine file exactly — i.e. the claim-doc stays equivalent to patch 0011.
 ;;   bun run projector:test
 (ns gjoa.tools.projector.test-projector
-  (:require [child_process :refer [execSync]]
-            [fs :refer [readFileSync]]
+  (:require [fs :refer [readFileSync]]
             [path :refer [join dirname]]
+            [gjoa.tools.prep.sh :refer [sh]]
             [gjoa.tools.projector.reflector :refer [round-trips?]]
             [gjoa.tools.projector.claims :refer [json->doc replay]]))
 (define-mode strict)
@@ -18,16 +18,13 @@
 (def REPO :- String (.cwd process))
 (def ENGINE :- String (join REPO "engine"))
 
-(defn sh [cmd :- String] :- String
-  (.toString (execSync cmd {:encoding "utf8" :maxBuffer (* 64 1024 1024)})))
-
 (defn fail! [msg :- String] :- Any
   (console/error (str "FAIL: " msg))
   (.exit process 1))
 
 (defn main! [] :- Any
   ;; GATE A — reflector round-trip over a corpus
-  (let [files (.filter (.split (sh (str "find " ENGINE "/browser/components " ENGINE "/toolkit/modules -name '*.sys.mjs' 2>/dev/null | head -40")) "\n")
+  (let [files (.filter (.split (sh (str "find " ENGINE "/browser/components " ENGINE "/toolkit/modules -name '*.sys.mjs' 2>/dev/null | head -40") nil) "\n")
                        (fn [s :- String] :- Bool (> (.-length s) 0)))]
     (loop [i 0 bad 0]
       (if (< i (.-length files))
@@ -43,9 +40,9 @@
         rel (.-file doc)
         engine-target (join ENGINE rel)
         tmp "/tmp/gjoa-projtest"]
-    (sh (str "rm -rf " tmp " && mkdir -p " (join tmp (dirname rel))))
-    (sh (str "cp " engine-target " " (join tmp rel)))
-    (sh (str "cd " tmp " && patch -R -p1 < " patch))   ; engine - 0011 = pristine
+    (sh (str "rm -rf " tmp " && mkdir -p " (join tmp (dirname rel))) nil)
+    (sh (str "cp " engine-target " " (join tmp rel)) nil)
+    (sh (str "cd " tmp " && patch -R -p1 < " patch) nil)   ; engine - 0011 = pristine
     (let [pristine (readFileSync (join tmp rel) "utf8")
           patched (readFileSync engine-target "utf8")
           r (replay (.-edits doc) pristine)]


### PR DESCRIPTION
Two verified dedups from the compression pass (the high-value shared-utility items).

## NAV-JS (tests)
4 integration tests inlined a byte-identical navigate-and-await chrome script → extracted to `dsl.bjs` as shared `NAV-JS`. **Proven byte-exact** (dsl's emitted NAV_JS hash == the inlined). The 2 genuine variants (adblock-production reorders loadURI + 25s; youtube-scriptlet a different script) left as-is.

## sh helper (tools)
8 per-tool `execSync` wrappers (drifted on buffer/error-handling) → one parameterized `tools/prep/sh.bjs` (`{:cwd :max-buffer :quiet}`, 256MB default so no buffer shrinks — also fixes the 1MB silent-empty class). Each variant's behavior preserved. **Verified by running every affected tool** (cost/forecast/firefox-api-drift/projector:test/pilot/fram all identical); byte-diff scope = only the intended files.

Both behavior-equivalent (not byte-identical — dedup changes emit by design), verified by string-exactness (NAV-JS) and tool-execution (sh). `reset-spaces` deferred (genuinely variant-laden); `repo-root` skipped (marginal).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784530338&installation_id=141311834&pr_number=85&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F85&signature=d6e7692feedb839383076ecf861e3d7150ca52728f6af595d4fecc087da10745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->