### PR TITLE
harden(prep): validate version strings + reject claim-doc path traversal

### DIFF
--- a/tools/prep/config.bjs
+++ b/tools/prep/config.bjs
@@ -42,5 +42,10 @@
         (throw (Error. (str "gjoa.json missing required field: " k)))))
     (if (not (.-version (.-firefox c)))
       (throw (Error. "gjoa.json: firefox.version is required")))
+    ;; firefox.version is interpolated into URLs and (via conflict-forecast) a git
+    ;; shell-out — constrain it to a plain version so every consumer inherits the
+    ;; guarantee (the trust-anchor systemic fix for the network-fetched bump value).
+    (if (not (.match (.-version (.-firefox c)) (RegExp. "^[0-9]+(\\.[0-9]+){1,3}(esr)?$")))
+      (throw (Error. (str "gjoa.json: firefox.version \"" (.-version (.-firefox c)) "\" is not a valid Firefox version"))))
     (if (not (.match (.-binaryName c) (RegExp. "^[a-z0-9-]+$")))
       (throw (Error. (str "gjoa.json: binaryName \"" (.-binaryName c) "\" must be lowercase alphanumeric+hyphen"))))))

--- a/tools/prep/conflict-forecast.bjs
+++ b/tools/prep/conflict-forecast.bjs
@@ -19,9 +19,14 @@
 (def PATCHES-DIR :- String (join REPO "patches"))
 (def FF :- String (join (.-HOME (.-env process)) "code" "reference" "firefox"))
 
-;; version "152.0.1" -> mozilla release tag "FIREFOX_152_0_1_RELEASE"
+;; version "152.0.1" -> mozilla release tag "FIREFOX_152_0_1_RELEASE".
+;; `from`/`to` flow from the network (latest-stable) and gjoa.json into a git
+;; shell-out, so reject anything that isn't a plain Firefox version before it can
+;; reach the shell (command-injection guard).
 (defn version->tag [v :- String] :- String
-  (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE"))
+  (if (not (.match v (RegExp. "^[0-9]+(\\.[0-9]+){1,3}(esr)?$")))
+    (throw (Error. (str "refusing unsafe version string: " v)))
+    (str "FIREFOX_" (.replaceAll v "." "_") "_RELEASE")))
 
 (defn gjoa-version [] :- String
   (.-version (.-firefox (JSON/parse (readFileSync (join REPO "gjoa.json") "utf8")))))

--- a/tools/projector/apply-claims.bjs
+++ b/tools/projector/apply-claims.bjs
@@ -6,7 +6,7 @@
 ;;   bun apply-claims.js <artifact.claims.json> <engine-dir>
 (ns gjoa.tools.projector.apply-claims
   (:require [fs :refer [readFileSync writeFileSync]]
-            [path :refer [join]]
+            [path :refer [join resolve sep]]
             [gjoa.tools.projector.claims :refer [json->doc replay]]
             [gjoa.tools.projector.set-body :refer [parses?]]))
 (define-mode strict)
@@ -18,18 +18,24 @@
         doc (json->doc (readFileSync artifact-path "utf8"))
         file (.-file doc)
         edits (.-edits doc)
-        target (join engine-dir file)
-        src (readFileSync target "utf8")
-        r (replay edits src)]
-    (if (and (.-ok r) (parses? (.-src r)))
-      (do
-        (writeFileSync target (.-src r))
-        (console/error (str "  claim-doc replay OK -> " file " (" (.-length edits) " set-body edit(s))"))
-        (.exit process 0))
-      (do
-        (console/error (str "  claim-doc replay FAILED: "
-                            (if (.-ok r) "rendered result does not parse" (.-reason r))))
-        (.exit process 1)))))
+        target (join engine-dir file)]
+    ;; the artifact's :file is replayed onto disk; reject any path that escapes
+    ;; engine-dir (absolute or `..`) before reading/writing it (path traversal).
+    (when (or (.includes file "..")
+              (not (.startsWith (resolve target) (str (resolve engine-dir) sep))))
+      (console/error (str "  claim-doc :file escapes engine-dir, refusing: " file))
+      (.exit process 1))
+    (let [src (readFileSync target "utf8")
+          r (replay edits src)]
+      (if (and (.-ok r) (parses? (.-src r)))
+        (do
+          (writeFileSync target (.-src r))
+          (console/error (str "  claim-doc replay OK -> " file " (" (.-length edits) " set-body edit(s))"))
+          (.exit process 0))
+        (do
+          (console/error (str "  claim-doc replay FAILED: "
+                              (if (.-ok r) "rendered result does not parse" (.-reason r))))
+          (.exit process 1))))))
 
 (when (.-main (js/import-meta))
   (main!))


### PR DESCRIPTION
Input-validation hardening on authored build tooling, surfaced by an incremental security audit of the post-projector churn.

## Fixes
- **conflict-forecast** — `from`/`to` versions flow from the network (`firefox_versions.json` latest-stable) and `gjoa.json` into a `git diff <tag> <tag>` shell-out. `version->tag` now rejects anything that isn't a plain Firefox version (`^[0-9]+(\.[0-9]+){1,3}(esr)?$`) before building the command.
- **config** — `validate` now checks `firefox.version` against the same regex, so every `gjoa.json` consumer inherits the constraint at one choke point (the trust-anchor for the network-fetched bump value).
- **apply-claims** — a claim-doc's `:file` is replayed onto disk under `engine-dir`. It now rejects any `:file` that is absolute or escapes `engine-dir` (resolve + `startsWith(resolve(engine-dir)+sep)`, no `..`) before read/write.

## Verification
- `beagle check --profile 3` clean on all three.
- conflict-forecast with `152;touch /tmp/PWNED;#` → `refusing unsafe version string`, no file created.
- apply-claims with `:file` `../../../tmp/ESCAPE` → `claim-doc :file escapes engine-dir, refusing`.
- Legit paths unchanged: `forecast` (152.0.1) and projector tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784531661&installation_id=141311834&pr_number=86&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F86&signature=2d8abbc7c78dc4e22cd22fc60876b99888fb132817979aa49da13afd7e5cfc47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->