### PR TITLE
harden(tabs): load picker favicons via page-icon: cache, not the page URL

### DIFF
--- a/src/gjoa/chrome/bjs/tabs/picker.bjs
+++ b/src/gjoa/chrome/bjs/tabs/picker.bjs
@@ -119,7 +119,11 @@
 
                         ;; icon column
                         (when (.-icon item)
-                          (if (.test (RegExp. "^https?:|^data:|^chrome:|^moz-") (.-icon item))
+                          ;; Local schemes only — page-icon:/data:/chrome:/moz- never
+                          ;; trigger a network fetch from this privileged document. A
+                          ;; page-controlled http(s) favicon URL is deliberately NOT
+                          ;; loadable here (it would beacon with the chrome principal).
+                          (if (.test (RegExp. "^page-icon:|^data:|^chrome:|^moz-") (.-icon item))
                             (let [img (htm "img" "gjoa-picker-icon")]
                               (set! (.-src img) (.-icon item))
                               (set! (.-alt img) "")

--- a/src/gjoa/chrome/bjs/tabs/vim.bjs
+++ b/src/gjoa/chrome/bjs/tabs/vim.bjs
@@ -674,8 +674,12 @@
                   (when td
                     (let [url (tab-spec tab)
                           host (try (.-hostname (URL. url)) (catch Any _e ""))
-                          icon (try (or (.getIcon gBrowser tab) js/undefined)
-                                    (catch Any _e js/undefined))]
+                          ;; Load the favicon through the local page-icon: cache
+                          ;; (Places favicon store) rather than the page-declared
+                          ;; icon URL, so the privileged picker document never makes a
+                          ;; fresh network fetch with the chrome principal (a tracking
+                          ;; beacon / IP leak). Falls back to no icon for blank URLs.
+                          icon (if (and url (not= url "")) (str "page-icon:" url) js/undefined)]
                       (.push items
                         {:display (or (.-name td) (.-label tab) "(untitled)")
                          :secondary (or host url "")


### PR DESCRIPTION
The one real finding from a full adversarial security audit of all 109 authored units (108 clean).

**Finding (LOW):** the quick-open picker set `<img>.src` to `gBrowser.getIcon(tab)` (a page-declared favicon URL) inside the privileged sidebar chrome document. A page-controlled `https:` favicon URL caused a fresh network fetch carrying the chrome principal — a tracking-beacon / IP-leak vector.

**Fix:** load the favicon through the local `page-icon:` cache (Places favicon store) keyed on the tab's page URL — served locally, never a network fetch — and restrict the picker `<img>` allow-list to local schemes only (`page-icon:`/`data:`/`chrome:`/`moz-`), dropping `https?:`. A remote favicon URL can no longer beacon from the privileged document.

`beagle check` clean on both files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784532316&installation_id=141311834&pr_number=87&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F87&signature=4bc950f6e0710eda9b4968a0ba7f3aed176e48bfae66b502e890a2a65fa039a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->