### PR TITLE
harden(supply-chain): GPG-mandatory pin creation + fix gpg-absent crash

### DIFF
--- a/configs/firefox-152.0.1.sha256
+++ b/configs/firefox-152.0.1.sha256
@@ -7,8 +7,9 @@
 # SHA256SUMS still fails verification (the attacker cannot change this file).
 #
 # Format is `sha256sum -c` compatible: `<hash>  <path-as-listed-in-SHA256SUMS>`.
-# To bump FF_VERSION: add a configs/firefox-<version>.sha256 with the value from
-# https://archive.mozilla.org/pub/firefox/releases/<version>/SHA256SUMS, after
-# verifying that file's GPG signature (SHA256SUMS.asc) against Mozilla's
-# release-signing key fingerprint 14F26682D0916CDD81E37B6D61B7B526D98F0353.
+# To bump FF_VERSION, generate this file with `bun run pin:firefox <version>`,
+# which fetches SHA256SUMS, REQUIRES its GPG signature (SHA256SUMS.asc) verify
+# against Mozilla's release key (fingerprint 14F26682D0916CDD81E37B6D61B7B526D98F0353),
+# and only then writes the pin — so a pin can never be created from an unsigned
+# (TLS-only) checksum. (gnupg must be installed for that step.)
 bff037bd04f0df25a330daa7133bea6eee5a02b7ce39da30581580271502f15e  source/firefox-152.0.1.source.tar.xz

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "preflight": "bun run tools:compile && bun .beagle-tools/gjoa/tools/scripts/preflight.js",
     "cost": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/patch-cost.js",
     "forecast": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/conflict-forecast.js",
+    "pin:firefox": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/pin-firefox.js",
     "firefox-api-drift": "bun run tools:compile && bun .beagle-tools/gjoa/tools/prep/firefox-api-surface.js",
     "projector:roundtrip": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/reflector.js",
     "projector:pilot": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/run-pilot.js",

--- a/tools/prep/download.bjs
+++ b/tools/prep/download.bjs
@@ -49,7 +49,7 @@
 ;; Parse a SHA256SUMS body for the tarball's hash. Mozilla lists files with
 ;; subdirectory prefixes, e.g. `source/firefox-150.0.source.tar.xz` — match by
 ;; basename. Returns nil if the tarball isn't listed.
-(defn hashFromSums [text :- String version :- String] :- Any
+(js/export (defn hashFromSums [text :- String version :- String] :- Any
   (let [want (tarballName version)
         lines (.split text "\n")]
     (loop [i 0]
@@ -60,7 +60,7 @@
               file (aget parts 1)]
           (if (and file (or (= file want) (.endsWith file (str "/" want))))
             hash
-            (recur (+ i 1))))))))
+            (recur (+ i 1)))))))))
 
 ;; Read the in-repo pinned hash for this version (the F9 trust anchor). The
 ;; committed file is `sha256sum -c`-shaped (`<hash>  <path>`); the same parser
@@ -84,12 +84,21 @@
 ;; gpg isn't installed we log and skip (the pinned-hash assertion below is the
 ;; load-bearing check, so absence of gpg never weakens the happy path). Returns
 ;; true if verified, false if skipped/unavailable; throws on an actual bad sig.
-(defn verifySignature [version :- String sumsText :- String] :- Any
-  (let [probe (.spawnSync Bun ["gpg" "--version"] {:stdout "ignore" :stderr "ignore"})]
-    (if (not (.-success probe))
-      (do
-        (.warn log "gpg not available; skipping SHA256SUMS.asc signature check (pinned in-repo hash still enforced)")
-        false)
+(js/export (defn verifySignature [version :- String sumsText :- String strict :- Bool] :- Any
+  ;; Bun.spawnSync THROWS ("Executable not found") when gpg is absent entirely,
+  ;; rather than returning {success:false} — so probe under try/catch. A missing
+  ;; gpg must degrade to a clean skip (non-strict daily build) or a clear refusal
+  ;; (strict pin creation), never an opaque crash mid-build.
+  (let [available (try (.-success (.spawnSync Bun ["gpg" "--version"] {:stdout "ignore" :stderr "ignore"}))
+                    (catch Any _e false))]
+    (if (not available)
+      (if strict
+        (throw (Error. (str "gpg is REQUIRED to establish a Firefox source pin but is not installed.\n"
+                            "  the committed pin must be proven signed by Mozilla's release key "
+                            MOZILLA-SIGNING-FPR " before it can be trusted; install gnupg and retry.")))
+        (do
+          (.warn log "gpg not available; skipping SHA256SUMS.asc signature check (pinned in-repo hash still enforced)")
+          false))
       (let [ascRes (js/await (fetch (signatureUrl version)))]
         (when-not (.-ok ascRes)
           (throw (Error. (str "failed to fetch SHA256SUMS.asc: " (.-status ascRes)))))
@@ -121,7 +130,7 @@
                 (throw (Error. (str "SHA256SUMS.asc not signed by pinned Mozilla key "
                                     MOZILLA-SIGNING-FPR "\n  gpg --status output:\n" out))))
               (.ok log (str "SHA256SUMS.asc GPG-verified against pinned Mozilla key " MOZILLA-SIGNING-FPR))
-              true)))))))
+              true))))))))
 
 (defn fetchSha256 [version :- String] :- Any
   (.step log (str "fetching upstream SHA256SUMS for firefox " version))
@@ -142,8 +151,10 @@
                               ".\n  pinned: " pinned
                               "\n  live:   " liveHash
                               "\n  refusing to trust same-origin checksum over the committed pin.")))))
-      ;; Defense-in-depth: verify the detached signature when gpg is present.
-      (js/await (verifySignature version text))
+      ;; Defense-in-depth on the daily build: verify the detached signature when
+      ;; gpg is present (non-strict — the committed pin is the load-bearing anchor,
+      ;; and it was itself GPG-established by `pin-firefox`).
+      (js/await (verifySignature version text false))
       liveHash)))
 
 (defn sha256OfFile [path :- String] :- Any

--- a/tools/prep/pin-firefox.bjs
+++ b/tools/prep/pin-firefox.bjs
@@ -1,0 +1,53 @@
+#lang beagle/js
+;; tools/prep/pin-firefox.bjs — establish the in-repo Firefox source pin with
+;; MANDATORY GPG verification.
+;;
+;; The committed configs/firefox-<v>.sha256 is the daily build's trust anchor:
+;; download.bjs asserts the downloaded tarball against it and refuses a live
+;; SHA256SUMS that disagrees. But a pin is only as trustworthy as the moment it
+;; was created — if you pin by trusting TLS to archive.mozilla.org, the pin only
+;; proves "matches what the archive served then", not "Mozilla authored it". This
+;; tool closes that: it fetches SHA256SUMS + its detached signature, REQUIRES that
+;; the signature verify against Mozilla's release key (fingerprint pinned in
+;; download.bjs), and only then writes the pin. gpg absent or a bad/wrong-key
+;; signature => refuse to write. Daily builds then ride the committed pin and
+;; re-check the signature best-effort.
+;;
+;;   bun .beagle-tools/gjoa/tools/prep/pin-firefox.js <version>
+(ns gjoa.tools.prep.pin-firefox
+  (:require [fs :refer [writeFileSync existsSync]]
+            [path :refer [join]]
+            [gjoa.tools.prep.paths :refer [CONFIGS-DIR]]
+            [gjoa.tools.prep.download :refer [verifySignature hashFromSums]]
+            [gjoa.tools.prep.log :refer [log]]))
+(define-mode strict)
+(declare-extern [process console] Any)
+
+(defn checksumUrl [version :- String] :- String
+  (str "https://archive.mozilla.org/pub/firefox/releases/" version "/SHA256SUMS"))
+
+(defn tarballName [version :- String] :- String
+  (str "firefox-" version ".source.tar.xz"))
+
+(js/export (defn pin-firefox! [version :- String] :- Any
+  (let [p (join CONFIGS-DIR (str "firefox-" version ".sha256"))]
+    (when (existsSync p)
+      (.warn log (str "pin already exists (" p "); re-deriving after GPG-verify")))
+    (.step log (str "fetching SHA256SUMS for firefox " version))
+    (let [res (js/await (fetch (checksumUrl version)))]
+      (when-not (.-ok res)
+        (throw (Error. (str "failed to fetch SHA256SUMS: " (.-status res)))))
+      (let [text (js/await (.text res))]
+        ;; MANDATORY proof: refuse to create a pin without a Mozilla-signed sums.
+        (js/await (verifySignature version text true))
+        (let [hash (hashFromSums text version)]
+          (when-not hash
+            (throw (Error. (str "SHA256SUMS does not list " (tarballName version)))))
+          (writeFileSync p (str hash "  source/" (tarballName version) "\n"))
+          (.ok log (str "wrote GPG-verified pin " p "\n  " hash))))))))
+
+(when (.-main (js/import-meta))
+  (let [v (aget (.-argv process) 2)]
+    (if (not v)
+      (do (console/error "usage: pin-firefox <version>") (.exit process 1))
+      (js/await (pin-firefox! v)))))


### PR DESCRIPTION
## What
- **`bun run pin:firefox <version>`** (new `tools/prep/pin-firefox.bjs`) creates the in-repo `configs/firefox-<v>.sha256` pin only after the upstream `SHA256SUMS` **verifies against Mozilla's release key** (fingerprint pinned in `download.bjs`). A pin can no longer be created from a TLS-only (unsigned) checksum — it must be provably Mozilla-authored at creation.
- **Latent build-breaker fixed:** `Bun.spawnSync` *throws* `Executable not found` when gpg is absent entirely (it does not return `{success:false}`), so the existing best-effort signature check would **crash a gpg-less build** instead of skipping. `verifySignature` now probes under try/catch.
- `verifySignature` gains a `strict` flag: daily build = best-effort (rides the committed pin, which is the load-bearing anchor), pin creation = mandatory.

## Why
The committed pin already defeats a same-origin tarball+SHA256SUMS swap (an attacker can't change the committed file). The remaining gap was the pin's *own provenance* — this closes it at the one moment that matters. This is a stronger model than verifying every build against a live (swappable) signature with no committed anchor.

## Verification
- `beagle check` clean on both files.
- Refusal path (gpg absent → strict): exits 1 with a fingerprint-naming message, writes no pin. ✓
- gpg-absent no longer crashes (the latent bug). ✓
- The GPG **happy path** (signature actually verifies) needs `gnupg` installed to exercise end-to-end — not runnable in this environment; logic mirrors the pre-existing verify code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784535429&installation_id=141311834&pr_number=88&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F88&signature=3248bb912f3be32a40d19462fd5c2a4643a90eedf24e155ecd3bedaf0875b75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->