### PR TITLE
harden(prep): validate version in pin-firefox before URL/path use

### DIFF
--- a/tools/prep/pin-firefox.bjs
+++ b/tools/prep/pin-firefox.bjs
@@ -30,6 +30,10 @@
   (str "firefox-" version ".source.tar.xz"))
 
 (js/export (defn pin-firefox! [version :- String] :- Any
+  ;; version reaches a fetch URL and a written file path — constrain it to a plain
+  ;; Firefox version first (same guard as config.bjs / conflict-forecast).
+  (when (not (.match version (RegExp. "^[0-9]+(\\.[0-9]+){1,3}(esr)?$")))
+    (throw (Error. (str "refusing unsafe version string: " version))))
   (let [p (join CONFIGS-DIR (str "firefox-" version ".sha256"))]
     (when (existsSync p)
       (.warn log (str "pin already exists (" p "); re-deriving after GPG-verify")))


### PR DESCRIPTION
Defense-in-depth follow-up to #88: the new `pin-firefox` interpolates the CLI `version` into a fetch URL and a written file path. Gate it through the same plain-version regex (`^[0-9]+(\.[0-9]+){1,3}(esr)?$`) used in `config.bjs` and `conflict-forecast` before use. Verified: `../../../tmp/x` → `refusing unsafe version string`; `152.0.1` proceeds to the GPG gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784535525&installation_id=141311834&pr_number=89&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F89&signature=996a5f2ad300e35c9d22f19e27bd1c2e92286f4afb52bdb22a06dd1ca5a0ffd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->