### PR TITLE
fix(drawer): remove dead js/import lines emitting invalid import() into chrome

### DIFF
--- a/src/gjoa/chrome/bjs/drawer/compact.bjs
+++ b/src/gjoa/chrome/bjs/drawer/compact.bjs
@@ -7,9 +7,6 @@
 
 (declare-extern [document window Services requestAnimationFrame] Any)
 
-(js/import create-logger! "../tabs/log.js" create_logger)
-(js/import collapse-protection-duration-ms "./timing.js" collapse_protection_duration_ms)
-
 (defn make-mode-ops! [cfg :- Any] :- Any
   (let [st       (.-st cfg)
         elem     (.-elem cfg)

--- a/src/gjoa/chrome/bjs/drawer/layout.bjs
+++ b/src/gjoa/chrome/bjs/drawer/layout.bjs
@@ -6,8 +6,6 @@
 
 (declare-extern [window] Any)
 
-(js/import create-logger! "../tabs/log.js" create_logger)
-
 (def WIDTH-PREF :- String "gjoa.sidebar.width")
 
 (js/export (defn make-layout! [deps] :- Any


### PR DESCRIPTION
`compact.bjs` and `layout.bjs` carried `(js/import create-logger! "../tabs/log.js" alias)` forms. `js/import` is **not** a beagle import form — it's the generic `js/` escape hatch, so it lowered to a literal **`import(create_logger_bang, "…", alias)`** call expression: invalid JS (dynamic `import()` takes a single specifier), breaking the emitted module under plain ESM. The bindings are already imported by the ns `:require :refer`, so the lines were redundant *and* broken.

Removing them: verified the valid `import { … } from '…'` named imports survive, the call sites still resolve, and no bogus `import(` remains in any emitted file.

Surfaced by dogfooding — an authored-chrome static analysis pass couldn't parse the two emitted files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784537270&installation_id=141311834&pr_number=90&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F90&signature=e754028bc3a288386e8b69b182a70385ed2955e2f71a6127ce7e6725b217cf55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->