### PR TITLE
harden(prefs): close 4 Firefox inherited-egress vectors

### DIFF
--- a/src/gjoa/defaults/pref/perf-prefs.bjs
+++ b/src/gjoa/defaults/pref/perf-prefs.bjs
@@ -39,7 +39,12 @@
 (pref "identity.fxaccounts.enabled" false)
 (pref "browser.discovery.enabled" false)
 (pref "app.normandy.enabled" false)
+(pref "app.normandy.api_url" "")
 (pref "app.shield.optoutstudies.enabled" false)
+(pref "browser.ping-centre.telemetry" false)
+(pref "browser.contile.enabled" false)
+(pref "browser.newtabpage.activity-stream.showSponsored" false)
+(pref "browser.newtabpage.activity-stream.showSponsoredTopSites" false)
 
 ;; --- Networking: SPEED-positive ---
 ;; Firefox ships prefetch / DNS-prefetch / speculative-connect ON. They were


### PR DESCRIPTION
Disables four built-in Firefox network-egress vectors gjoa's defaults left at Firefox values: `browser.ping-centre.telemetry`, `app.normandy.api_url` (→ `""`), `browser.contile.enabled`, and sponsored content (`showSponsored`/`showSponsoredTopSites`). No functional cost (custom new-tab). 

Two further probes (`network.captive-portal-service`, `network.connectivity-service`) are intentionally left — disabling them breaks captive-portal 'sign in to wifi' detection, a deliberate UX trade. SafeBrowsing egress is kept (security feature).

`beagle check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784538241&installation_id=141311834&pr_number=91&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F91&signature=133d692656f351009eaaf2cecb4bb36e9eecbfd3f401728fd7280f7f993ebd0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->