### PR TITLE
feat(sovereignty): opt-in maximal-egress-lockdown toggle (default off)

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -220,7 +220,9 @@
       ;; The about:home startup cache pre-renders the activity-stream document we
       ;; no longer serve; with the activity-stream uninitialized it throws at
       ;; startup (AboutHomeStartupCache: activityStream is null). Disable it.
-      (.setBoolPref d "browser.startup.homepage.abouthome_cache.enabled" false))
+      (.setBoolPref d "browser.startup.homepage.abouthome_cache.enabled" false)
+      ;; sovereignty: the maximal-egress-lockdown meta-pref, default OFF (see apply-lockdown!).
+      (.setBoolPref d "gjoa.sovereignty.maximalLockdown" false))
     (catch Any e
       (console/error "gjoa-loader: setDefaults failed" e))))
 
@@ -268,11 +270,39 @@
     (catch Any e
       (console/error "gjoa-loader: failed to set newTabURL" e))))
 
+;; --- Maximal egress lockdown (opt-in) -----------------------------------------
+;; Two Firefox startup probes phone Mozilla: the captive-portal check
+;; (detectportal.firefox.com) and the connectivity service. They power "sign in to
+;; wifi" detection, so gjoa keeps them ON by default — sovereignty WITH adoptability.
+;; Flipping gjoa.sovereignty.maximalLockdown gives LibreWolf-grade egress silence
+;; for users who want it: the user decides their egress, the browser doesn't decide
+;; for them. The 4 zero-cost vectors (telemetry/Contile/sponsored) are always off
+;; via default prefs; only these two wifi-affecting probes are gated by the toggle.
+(def LOCKDOWN-PREF :- String "gjoa.sovereignty.maximalLockdown")
+(def LOCKDOWN-PROBES :- Any
+  ["network.captive-portal-service.enabled" "network.connectivity-service.enabled"])
+
+(defn apply-lockdown! [] :- Any
+  (try
+    (let [d (.getDefaultBranch (.-prefs Services) "")
+          on (.getBoolPref (.-prefs Services) LOCKDOWN-PREF false)]
+      (doseq [p LOCKDOWN-PROBES] (.setBoolPref d p (not on)))
+      (console/log (str "gjoa-loader: maximal-lockdown "
+                        (if on "ON — captive-portal/connectivity probes disabled"
+                               "off — wifi-detection probes active (default)"))))
+    (catch Any e
+      (console/error "gjoa-loader: apply-lockdown failed" e))))
+
+(def lockdown-observer :- Any
+  {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-lockdown!))})
+
 (js/export (def GjoaLoader :- Any
   {:start (fn [] :- Any
     (when (not (.-observer-registered st))
       (set! (.-observer-registered st) true)
       (set-defaults)
+      (apply-lockdown!)
+      (.addObserver (.-prefs Services) LOCKDOWN-PREF lockdown-observer)
       (set-new-tab-url!)
       (register-cosmetic-actor)
       (register-darkmode-actor)


### PR DESCRIPTION
The two remaining inherited-egress probes (`network.captive-portal-service`, `network.connectivity-service`) phone Mozilla on startup but power 'sign in to wifi' detection — disabling them outright is a real usability hit. So gate them behind a toggle instead of forcing the choice:

```
gjoa.sovereignty.maximalLockdown   (default false)
```

- **Default off** → both probes stay on → captive-portal/wifi detection works (adoptable).
- **Flip on** → both probes disabled → LibreWolf-grade egress silence.
- A pref observer re-applies on change → live one-click toggle, not restart-gated.

Wired in `GjoaLoader` (startup, default-branch, non-destructive — won't override a user's own pref). The four zero-cost vectors from #91 stay off unconditionally; only these two wifi-affecting probes are user-gated. *The user decides their egress; the browser doesn't decide for them.*

Emit verified (default→probes on, toggle→off); mirrors the existing `set-defaults`/pref-observer patterns. A marionette test (set pref → assert probe prefs flip) is a good follow-up when a build runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784538632&installation_id=141311834&pr_number=92&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F92&signature=8d4655f13771016d2ce74f974d6efc63c92537be4cc7133e447be5d7465caa28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->