### PR TITLE
feat(sovereignty): about:sovereignty egress trust panel

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -51,7 +51,7 @@
 ;; =============================================================================
 (ns gjoa.browser.components.gjoa.loader)
 (define-mode strict)
-(declare-extern [ChromeUtils Cc Ci Services] Any)
+(declare-extern [ChromeUtils Cc Ci Services Components] Any)
 
 (def lazy :- Any {})
 
@@ -296,6 +296,37 @@
 (def lockdown-observer :- Any
   {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-lockdown!))})
 
+;; --- about:sovereignty -------------------------------------------------------
+;; Register the egress trust panel as a real about: page at runtime (no rebuild,
+;; no Mozilla-source patch). It maps to the privileged chrome page, so the panel
+;; can read build-provenance prefs + the lockdown toggle and render the verifiable
+;; truth. (NOTE: about-module flag/principal semantics are FF-version-sensitive;
+;; this needs one in-browser confirmation on the next build — wrapped so a failure
+;; only logs and never blocks startup.)
+(def SOVEREIGNTY-URL :- String "chrome://gjoa/content/sovereignty/sovereignty.html")
+(def SOVEREIGNTY-CLASS-ID :- String "{6a7c1e90-5b3d-4c2a-9f81-7e0d3a6b2c54}")
+(def SOVEREIGNTY-CONTRACT :- String "@mozilla.org/network/protocol/about;1?what=sovereignty")
+
+(defn register-about-sovereignty! [] :- Any
+  (try
+    (let [about-module
+          {:QueryInterface (.generateQI ChromeUtils ["nsIAboutModule"])
+           :newChannel (fn [uri :- Any load-info :- Any] :- Any
+                         (let [ch (.newChannelFromURIWithLoadInfo (.-io Services)
+                                    (.newURI (.-io Services) SOVEREIGNTY-URL) load-info)]
+                           (set! (.-originalURI ch) uri)
+                           ch))
+           :getURIFlags (fn [_uri :- Any] :- Any (.-ALLOW_SCRIPT (.-nsIAboutModule Ci)))}
+          factory
+          {:QueryInterface (.generateQI ChromeUtils ["nsIFactory"])
+           :createInstance (fn [iid :- Any] :- Any (.QueryInterface about-module iid))}
+          registrar (.QueryInterface (.-manager Components) (.-nsIComponentRegistrar Ci))]
+      (.registerFactory registrar (.ID Components SOVEREIGNTY-CLASS-ID)
+        "about:sovereignty" SOVEREIGNTY-CONTRACT factory)
+      (console/log "gjoa-loader: registered about:sovereignty"))
+    (catch Any e
+      (console/error "gjoa-loader: register about:sovereignty failed" e))))
+
 (js/export (def GjoaLoader :- Any
   {:start (fn [] :- Any
     (when (not (.-observer-registered st))
@@ -303,6 +334,7 @@
       (set-defaults)
       (apply-lockdown!)
       (.addObserver (.-prefs Services) LOCKDOWN-PREF lockdown-observer)
+      (register-about-sovereignty!)
       (set-new-tab-url!)
       (register-cosmetic-actor)
       (register-darkmode-actor)

--- a/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
@@ -1,0 +1,32 @@
+{
+  "claim": "This build makes 1 unattended network call: the Firefox version check.",
+  "gjoaVersion": "0.1.1",
+  "auditedCommit": "cd768e2",
+  "generated": "2026-06-20",
+  "method": "static AST audit of all authored chrome (.sys.mjs + emitted .bjs), 57 sources, every source parsed",
+  "ownCode": {
+    "unattendedExternal": [
+      { "endpoint": "https://product-details.mozilla.org/1.0/firefox_versions.json", "what": "Firefox version freshness check", "file": "security/index.js", "line": 53, "basis": "resolved endpoint" }
+    ],
+    "userEnabledNetwork": [
+      { "endpoint": "adblock filter lists (https-only)", "what": "filter-list updates when adblock is on", "file": "ContentClassifierRemoteSettingsClient.sys.mjs", "line": 323, "basis": "https scheme guard" }
+    ],
+    "local": [
+      { "endpoint": "resource://gre/modules/scriptlet-resources.json", "what": "bundled scriptlet resources", "basis": "resolved endpoint" },
+      { "endpoint": "resource://gre/modules/darkmode-fixes.json", "what": "bundled dark-mode fixes", "basis": "resolved endpoint" },
+      { "endpoint": "page-icon: (local favicon cache)", "what": "quick-open favicon", "file": "tabs/picker.js", "line": 99, "basis": "page-icon scheme guard" }
+    ],
+    "unproven": [
+      { "endpoint": "page's own background image", "what": "dark-mode image analysis (re-reads an image the page already loaded)", "file": "GjoaDarkmodeChild.sys.mjs", "line": 510, "basis": "no static guard — flagged for review" }
+    ]
+  },
+  "inheritedEgress": {
+    "disabled": 15,
+    "catalogued": 17,
+    "note": "Firefox built-in egress vectors gjoa disables by default (telemetry, Normandy, Pocket, Contile, sponsored, FxA, ...). SafeBrowsing kept (security).",
+    "toggleGated": [
+      { "pref": "network.captive-portal-service.enabled", "what": "captive-portal / 'sign in to wifi' detection" },
+      { "pref": "network.connectivity-service.enabled", "what": "connectivity check" }
+    ]
+  }
+}

--- a/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.css
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.css
@@ -1,0 +1,171 @@
+/* about:sovereignty — gjoa egress trust panel. Forced-dark, matching the gjoa
+   navigator aesthetic. The proof line is visually the heaviest element; the badge
+   colors track the REAL state (matched build / live probes), never a fixed green. */
+
+:root {
+  --bg: #0d0f12;
+  --panel: #14171c;
+  --ink: #e8eaed;
+  --muted: #9aa0a6;
+  --faint: #5f6368;
+  --ok: #34d399;
+  --warn: #f5b454;
+  --line: #23272e;
+  --accent: #7aa2f7;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#panel {
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 9vh 28px 64px;
+}
+
+.brand {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-bottom: 28px;
+}
+
+/* Headline: the conservative, audit-proven core. */
+.headline {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+.count {
+  font-size: 76px;
+  font-weight: 700;
+  line-height: 0.9;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.count-lead { font-size: 19px; font-weight: 600; }
+.count-sub { color: var(--muted); margin-top: 2px; }
+
+.assertions {
+  color: var(--muted);
+  font-size: 13.5px;
+  margin: 0 0 26px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+/* The proof line — the centerpiece. Heaviest box on the page. */
+.proof {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 16px 18px;
+  margin-bottom: 22px;
+}
+.proof-verdict { font-weight: 600; font-size: 15px; }
+.proof-verdict.ok { color: var(--ok); }
+.proof-verdict.warn { color: var(--warn); }
+.proof-build {
+  margin-top: 7px;
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", monospace;
+  font-size: 12.5px;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+/* Toggle — flipping it visibly changes the panel state. */
+.toggle-row { margin-bottom: 22px; }
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+.toggle-track {
+  flex: none;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--line);
+  position: relative;
+  transition: background 0.15s ease;
+}
+.toggle-thumb {
+  position: absolute;
+  top: 3px; left: 3px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.toggle input:checked + .toggle-track { background: rgba(52, 211, 153, 0.32); }
+.toggle input:checked + .toggle-track .toggle-thumb {
+  transform: translateX(18px);
+  background: var(--ok);
+}
+.toggle input:focus-visible + .toggle-track { outline: 2px solid var(--accent); outline-offset: 2px; }
+.toggle-title { font-weight: 600; }
+.toggle-state { display: block; font-size: 12.5px; color: var(--muted); }
+.lockdown-off .toggle-state { color: var(--warn); }
+.lockdown-on .toggle-state { color: var(--ok); }
+
+/* Progressive disclosure — the stark ledger lives one click down. */
+.disclose-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: 13.5px;
+  padding: 4px 0;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 8px;
+}
+.disclose-btn:hover { text-decoration: underline; }
+.ledger { margin-top: 14px; }
+.ledger-h {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 18px 0 8px;
+}
+.ledger-list { list-style: none; margin: 0; padding: 0; }
+.ledger-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 0;
+  border-top: 1px solid var(--line);
+  font-size: 13px;
+}
+.ledger-endpoint { font-family: ui-monospace, monospace; color: var(--ink); }
+.ledger-what { color: var(--muted); }
+.ledger-basis {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--faint);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.ledger-note { color: var(--muted); font-size: 12.5px; margin: 4px 0 8px; }
+
+.foot {
+  margin-top: 34px;
+  color: var(--faint);
+  font-size: 11.5px;
+}

--- a/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.html
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!-- about:sovereignty — gjoa's egress trust panel.
+     A PRIVILEGED chrome page (system principal): it reads build-provenance prefs
+     and the maximal-lockdown toggle directly. It renders the VERIFIABLE TRUTH —
+     the badge degrades to the real current state (incl. the toggle); it never
+     asserts a slogan the audit doesn't support. Data: ./manifest.json (the
+     source-derived egress audit), checked against the running build's commit. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src chrome:; img-src chrome: data:; style-src chrome: 'unsafe-inline'; script-src chrome:;" />
+    <title>Sovereignty</title>
+    <link rel="stylesheet" href="chrome://gjoa/content/sovereignty/sovereignty.css" />
+  </head>
+  <body>
+    <main id="panel" aria-live="polite">
+      <header class="brand">gjoa · sovereignty</header>
+
+      <section class="headline">
+        <div class="count" id="unattended-count">—</div>
+        <div class="count-label">
+          <div class="count-lead" id="count-lead">unattended network call</div>
+          <div class="count-sub" id="count-sub"></div>
+        </div>
+      </section>
+
+      <p class="assertions" id="assertions"></p>
+
+      <!-- The proof line: the centerpiece. Ties the claim to the exact running
+           build and says whether this audit was generated against THESE bytes. -->
+      <section class="proof" id="proof">
+        <div class="proof-verdict" id="proof-verdict">checking build…</div>
+        <div class="proof-build" id="proof-build"></div>
+      </section>
+
+      <section class="toggle-row">
+        <label class="toggle">
+          <input type="checkbox" id="lockdown" />
+          <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          <span class="toggle-text">
+            <span class="toggle-title">Maximal lockdown</span>
+            <span class="toggle-state" id="lockdown-state"></span>
+          </span>
+        </label>
+      </section>
+
+      <section class="disclose">
+        <button id="disclose-btn" class="disclose-btn" aria-expanded="false">
+          <span id="disclose-caret">▸</span>
+          <span id="disclose-label">show the audited egress points</span>
+        </button>
+        <div id="ledger" class="ledger" hidden></div>
+      </section>
+
+      <footer class="foot" id="foot"></footer>
+    </main>
+    <script src="chrome://gjoa/content/sovereignty/sovereignty.js"></script>
+  </body>
+</html>

--- a/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.js
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.js
@@ -1,0 +1,249 @@
+"use strict";
+
+// about:sovereignty — render the verifiable egress truth, not a slogan.
+//
+// Hard rules (the trust panel a skeptic believes, not just the one a believer
+// likes):
+//   1. The build-hash proof line is the centerpiece: it ties the audit to the
+//      EXACT bytes you're running. If the audit was generated against a different
+//      commit than the running build, say so — never imply a match we can't show.
+//   2. The badge degrades honestly. It reflects the real current egress state,
+//      including the maximal-lockdown toggle. Flipping lockdown changes the panel.
+//      It never renders a static ✓ "SOVEREIGN" while probes are live.
+//   3. Claim (A) verbatim: "1 unattended network call: the Firefox version check."
+//      The most conservative true statement — never rounded up to "zero egress".
+
+(function () {
+  const $ = (id) => document.getElementById(id);
+
+  // Privileged chrome page: Services is a system-principal global. Guard anyway so
+  // the page degrades to a readable static state instead of a blank document.
+  let Services = null;
+  try {
+    Services = globalThis.Services;
+  } catch (_) {}
+
+  function getBoolPref(name, dflt) {
+    try {
+      return Services.prefs.getBoolPref(name, dflt);
+    } catch (_) {
+      return dflt;
+    }
+  }
+  function getCharPref(name, dflt) {
+    try {
+      return Services.prefs.getCharPref(name, dflt);
+    } catch (_) {
+      return dflt;
+    }
+  }
+
+  const LOCKDOWN_PREF = "gjoa.sovereignty.maximalLockdown";
+
+  function buildIdentity() {
+    let ffVersion = "?";
+    try {
+      ffVersion = Services.appinfo.version;
+    } catch (_) {}
+    return {
+      ffVersion,
+      commit: getCharPref("gjoa.build.commit", "unknown"),
+      patchHash: getCharPref("gjoa.build.engine-patch-hash", ""),
+      provenance: getCharPref("gjoa.build.provenance", "unknown"),
+      date: getCharPref("gjoa.build.date", ""),
+    };
+  }
+
+  function el(tag, cls, text) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text; // textContent only — never innerHTML.
+    return e;
+  }
+
+  function renderLedger(manifest) {
+    const root = $("ledger");
+    root.textContent = "";
+
+    const group = (title, items, render) => {
+      if (!items || !items.length) return;
+      root.appendChild(el("h3", "ledger-h", title));
+      const ul = el("ul", "ledger-list");
+      for (const it of items) ul.appendChild(render(it));
+      root.appendChild(ul);
+    };
+
+    const row = (primary, secondary, tag) => {
+      const li = el("li", "ledger-item");
+      li.appendChild(el("span", "ledger-endpoint", primary));
+      if (secondary) li.appendChild(el("span", "ledger-what", secondary));
+      if (tag) li.appendChild(el("span", "ledger-basis", tag));
+      return li;
+    };
+
+    const own = manifest.ownCode || {};
+    group(
+      "Unattended external call",
+      own.unattendedExternal,
+      (it) => row(it.endpoint, it.what, it.basis)
+    );
+    group(
+      "Network only when you enable the feature",
+      own.userEnabledNetwork,
+      (it) => row(it.endpoint, it.what, it.basis)
+    );
+    group(
+      "Local — never leaves the machine",
+      own.local,
+      (it) => row(it.endpoint, it.what, it.basis)
+    );
+    group(
+      "Unproven — flagged for review (honest)",
+      own.unproven,
+      (it) => row(it.endpoint, it.what, it.basis)
+    );
+
+    const inh = manifest.inheritedEgress;
+    if (inh) {
+      root.appendChild(
+        el(
+          "h3",
+          "ledger-h",
+          `Firefox built-in egress: ${inh.disabled}/${inh.catalogued} disabled by default`
+        )
+      );
+      root.appendChild(el("p", "ledger-note", inh.note || ""));
+      const ul = el("ul", "ledger-list");
+      for (const it of inh.toggleGated || []) {
+        ul.appendChild(
+          row(it.pref, it.what, "gated by maximal-lockdown toggle")
+        );
+      }
+      root.appendChild(ul);
+    }
+  }
+
+  function render(manifest) {
+    const id = buildIdentity();
+    const lockdown = getBoolPref(LOCKDOWN_PREF, false);
+    const unattended = (manifest.ownCode &&
+      manifest.ownCode.unattendedExternal &&
+      manifest.ownCode.unattendedExternal.length) || 0;
+
+    // Headline count = authored unattended external calls (claim A). Honest, fixed
+    // to what the audit proves — the toggle does not pretend to change this number.
+    $("unattended-count").textContent = String(unattended);
+    $("count-lead").textContent =
+      unattended === 1 ? "unattended network call" : "unattended network calls";
+    $("count-sub").textContent =
+      (manifest.ownCode.unattendedExternal[0] &&
+        manifest.ownCode.unattendedExternal[0].what) ||
+      "";
+
+    // Conservative, true secondary assertions (the inherited-egress audit backs these).
+    const inh = manifest.inheritedEgress || {};
+    $("assertions").textContent =
+      `No telemetry · No cloud AI · ${inh.disabled || 0} of ${inh.catalogued || 0} ` +
+      `Firefox egress vectors disabled by default`;
+
+    // The badge / panel state must reflect reality INCLUDING the toggle. With
+    // lockdown off the portal probes are live — say so, do not imply silence.
+    const panel = $("panel");
+    panel.classList.toggle("lockdown-on", lockdown);
+    panel.classList.toggle("lockdown-off", !lockdown);
+
+    $("lockdown").checked = lockdown;
+    $("lockdown-state").textContent = lockdown
+      ? "on — captive-portal + connectivity probes silenced"
+      : "off — Firefox captive-portal + connectivity probes are active (your choice)";
+
+    // Proof line: verify the audit was generated against the running build.
+    const matches =
+      manifest.auditedCommit &&
+      id.commit !== "unknown" &&
+      manifest.auditedCommit === id.commit;
+    const pv = $("proof-verdict");
+    if (matches) {
+      pv.textContent = "✓ This audit matches the build you're running.";
+      pv.className = "proof-verdict ok";
+    } else if (id.commit === "unknown") {
+      pv.textContent =
+        "• Running build is unstamped (dev build) — audit shown is from commit " +
+        (manifest.auditedCommit || "?") + ".";
+      pv.className = "proof-verdict warn";
+    } else {
+      pv.textContent =
+        "⚠ This audit was generated at commit " +
+        (manifest.auditedCommit || "?") +
+        ", but you are running " +
+        id.commit +
+        " — the audit may be stale. Re-run the egress audit for this build.";
+      pv.className = "proof-verdict warn";
+    }
+    $("proof-build").textContent =
+      `gjoa ${manifest.gjoaVersion || "?"} · Firefox ${id.ffVersion} · ` +
+      `build ${id.commit}` +
+      (id.patchHash ? ` · patches ${id.patchHash}` : "") +
+      (id.provenance && id.provenance !== "unknown" ? ` · ${id.provenance}` : "");
+
+    renderLedger(manifest);
+
+    const own = manifest.ownCode || {};
+    const total =
+      (own.unattendedExternal || []).length +
+      (own.userEnabledNetwork || []).length +
+      (own.local || []).length +
+      (own.unproven || []).length;
+    $("disclose-label").textContent = `show the ${total} audited egress points`;
+    $("foot").textContent =
+      `${manifest.method || ""}  ·  generated ${manifest.generated || ""}`;
+  }
+
+  function wireToggle() {
+    const box = $("lockdown");
+    box.addEventListener("change", () => {
+      try {
+        Services.prefs.setBoolPref(LOCKDOWN_PREF, box.checked);
+        // GjoaLoader's observer applies the probe prefs; re-read + re-render so the
+        // panel visibly reflects the new state immediately.
+        loadAndRender();
+      } catch (e) {
+        $("lockdown-state").textContent =
+          "could not set the pref (not privileged?) — " + e;
+      }
+    });
+  }
+
+  function wireDisclose() {
+    const btn = $("disclose-btn");
+    btn.addEventListener("click", () => {
+      const ledger = $("ledger");
+      const open = ledger.hasAttribute("hidden");
+      if (open) {
+        ledger.removeAttribute("hidden");
+      } else {
+        ledger.setAttribute("hidden", "");
+      }
+      btn.setAttribute("aria-expanded", String(open));
+      $("disclose-caret").textContent = open ? "▾" : "▸";
+    });
+  }
+
+  function fail(msg) {
+    $("count-sub").textContent = msg;
+  }
+
+  async function loadAndRender() {
+    try {
+      const resp = await fetch("chrome://gjoa/content/sovereignty/manifest.json");
+      const manifest = await resp.json();
+      render(manifest);
+    } catch (e) {
+      fail("could not load the egress manifest: " + e);
+    }
+  }
+
+  wireToggle();
+  wireDisclose();
+  loadAndRender();
+})();

--- a/src/gjoa/browser/components/gjoa/jar.mn
+++ b/src/gjoa/browser/components/gjoa/jar.mn
@@ -24,6 +24,13 @@ browser.jar:
   content/gjoa/styles/gjoa.uc.css (content/styles/gjoa.uc.css)
   content/gjoa/styles/gjoa-tabs.uc.css (content/styles/gjoa-tabs.uc.css)
   content/gjoa/styles/gjoa-which-key.uc.css (content/styles/gjoa-which-key.uc.css)
+# about:sovereignty — the egress trust panel. PRIVILEGED (under the `gjoa` package,
+# NOT contentaccessible): it reads build-provenance prefs + the lockdown toggle and
+# is registered as about:sovereignty at runtime by GjoaLoader.
+  content/gjoa/sovereignty/sovereignty.html (content/sovereignty/sovereignty.html)
+  content/gjoa/sovereignty/sovereignty.css (content/sovereignty/sovereignty.css)
+  content/gjoa/sovereignty/sovereignty.js (content/sovereignty/sovereignty.js)
+  content/gjoa/sovereignty/manifest.json (content/sovereignty/manifest.json)
 
 # The new-tab page is the only gjoa chrome that loads as a *content* document
 # (via AboutNewTab.newTabURL in GjoaLoader). It gets its own package marked


### PR DESCRIPTION
A privileged chrome page rendering gjoa's source-derived egress audit as a one-glance trust panel (full ledger one click down). Registered as `about:sovereignty` at runtime by GjoaLoader (no Mozilla-source patch).

**Renders verifiable truth, not a slogan:**
- **Proof line is the centerpiece** — reads `gjoa.build.commit` and checks the shipped `manifest.json` was generated against the running build's commit (✓ matches / ⚠ may be stale). Ties the claim to the exact bytes.
- **Badge degrades honestly** — reflects real state incl. the maximal-lockdown toggle; with lockdown off it says the portal/connectivity probes are active ('your choice'); flipping it visibly changes the panel. No hardcoded ✓.
- **Claim verbatim** — '1 unattended network call: the Firefox version check', never rounded to 'zero egress'.

`textContent`-only rendering + restrictive CSP. GjoaLoader compiles; page JS/HTML parse clean. The about-module principal/flag semantics need one in-browser confirmation on the next build (wrapped so a failure only logs, never blocks startup).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784539630&installation_id=141311834&pr_number=93&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F93&signature=f9f0884db8a544568e6dfa05f1070ed55c06263bc4a822403e0b5218bdda1286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->