### PR TITLE
feat(sovereignty): regenerate the egress manifest at import time

### DIFF
--- a/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
@@ -1,32 +1,81 @@
 {
   "claim": "This build makes 1 unattended network call: the Firefox version check.",
-  "gjoaVersion": "0.1.1",
-  "auditedCommit": "cd768e2",
+  "gjoaVersion": "0.3.3",
+  "auditedCommit": "adfd706",
   "generated": "2026-06-20",
-  "method": "static AST audit of all authored chrome (.sys.mjs + emitted .bjs), 57 sources, every source parsed",
+  "method": "static AST audit of all authored chrome (.sys.mjs + emitted .bjs + content .js), every source parsed",
   "ownCode": {
     "unattendedExternal": [
-      { "endpoint": "https://product-details.mozilla.org/1.0/firefox_versions.json", "what": "Firefox version freshness check", "file": "security/index.js", "line": 53, "basis": "resolved endpoint" }
+      {
+        "endpoint": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+        "what": "Firefox version freshness check",
+        "file": "src/gjoa/…/security/index.js",
+        "line": 53,
+        "basis": "endpoint"
+      }
     ],
     "userEnabledNetwork": [
-      { "endpoint": "adblock filter lists (https-only)", "what": "filter-list updates when adblock is on", "file": "ContentClassifierRemoteSettingsClient.sys.mjs", "line": 323, "basis": "https scheme guard" }
+      {
+        "endpoint": "(dynamic)",
+        "what": "fetch call",
+        "file": "src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs",
+        "line": 323,
+        "basis": "guard(url)"
+      }
     ],
     "local": [
-      { "endpoint": "resource://gre/modules/scriptlet-resources.json", "what": "bundled scriptlet resources", "basis": "resolved endpoint" },
-      { "endpoint": "resource://gre/modules/darkmode-fixes.json", "what": "bundled dark-mode fixes", "basis": "resolved endpoint" },
-      { "endpoint": "page-icon: (local favicon cache)", "what": "quick-open favicon", "file": "tabs/picker.js", "line": 99, "basis": "page-icon scheme guard" }
+      {
+        "endpoint": "resource://gre/modules/scriptlet-resources.json",
+        "what": "fetch call",
+        "file": "src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs",
+        "line": 236,
+        "basis": "endpoint"
+      },
+      {
+        "endpoint": "resource://gre/modules/darkmode-fixes.json",
+        "what": "fetch call",
+        "file": "src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs",
+        "line": 47,
+        "basis": "endpoint"
+      },
+      {
+        "endpoint": "chrome://gjoa/content/sovereignty/manifest.json",
+        "what": "fetch call",
+        "file": "src/gjoa/browser/components/gjoa/content/sovereignty/sovereignty.js",
+        "line": 238,
+        "basis": "endpoint"
+      },
+      {
+        "endpoint": "(dynamic)",
+        "what": "resource load",
+        "file": "src/gjoa/…/tabs/picker.js",
+        "line": 99,
+        "basis": "guard(item.icon)"
+      }
     ],
     "unproven": [
-      { "endpoint": "page's own background image", "what": "dark-mode image analysis (re-reads an image the page already loaded)", "file": "GjoaDarkmodeChild.sys.mjs", "line": 510, "basis": "no static guard — flagged for review" }
+      {
+        "endpoint": "(dynamic)",
+        "what": "resource load",
+        "file": "src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs",
+        "line": 510,
+        "basis": "unproven"
+      }
     ]
   },
   "inheritedEgress": {
     "disabled": 15,
     "catalogued": 17,
-    "note": "Firefox built-in egress vectors gjoa disables by default (telemetry, Normandy, Pocket, Contile, sponsored, FxA, ...). SafeBrowsing kept (security).",
+    "note": "Firefox built-in egress vectors gjoa disables by default. SafeBrowsing kept (security).",
     "toggleGated": [
-      { "pref": "network.captive-portal-service.enabled", "what": "captive-portal / 'sign in to wifi' detection" },
-      { "pref": "network.connectivity-service.enabled", "what": "connectivity check" }
+      {
+        "pref": "network.captive-portal-service.enabled",
+        "what": "Captive-portal probe"
+      },
+      {
+        "pref": "network.connectivity-service.enabled",
+        "what": "Connectivity check"
+      }
     ]
   }
 }

--- a/tools/prep/import.bjs
+++ b/tools/prep/import.bjs
@@ -7,13 +7,30 @@
             [gjoa.tools.prep.mozconfig :refer [mozconfig!]]
             [gjoa.tools.prep.overlay :refer [overlay]]
             [gjoa.tools.prep.patches :refer [patches]]
+            [gjoa.tools.prep.sh :refer [sh]]
             [gjoa.tools.prep.log :refer [log]]
-            [fs :refer [writeFileSync]]))
+            [fs :refer [writeFileSync existsSync]]))
 (define-mode strict)
+
+;; Regenerate the about:sovereignty manifest from a FRESH egress audit so its proof
+;; line matches the bytes being built (no stale-by-omission). Guarded: runs only if
+;; the egress tool is compiled here (the maintainer's tree, where releases are cut);
+;; on a checkout without it, the committed manifest ships and the page honestly flags
+;; any commit mismatch. Runs before overlay so the fresh manifest is what gets baked.
+(defn regen-sovereignty-manifest! [] :- Any
+  (let [tool ".beagle-tools/gjoa/tools/sovereignty/egress-scan.js"]
+    (if (not (existsSync tool))
+      (.info log "sovereignty: egress tool not present — keeping committed manifest")
+      (do
+        (.step log "phase 0 — regenerating about:sovereignty egress manifest")
+        (sh (str "bun " tool " manifest") {:quiet true})
+        (.ok log "sovereignty: manifest regenerated for this build")))))
 
 ;; Seven sequential phases. Each is idempotent, so re-running `bun run import`
 ;; after editing src/gjoa/ or gjoa.json picks up the changes correctly.
 (js/export (defn import-sources [] :- Any
+  (js/await (regen-sovereignty-manifest!))
+
   (.step log "phase 1/7 — overlaying src/gjoa/")
   (js/await (overlay))
 


### PR DESCRIPTION
The about:sovereignty proof line checks the shipped `manifest.json`'s commit against the running build — but a committed manifest can silently go **stale-by-omission** as code moves. This regenerates it from a fresh egress audit at import (phase 0, before overlay so the fresh manifest is baked).

**Guarded** so it never breaks a public build: runs only if the egress audit tool is compiled in this tree (the maintainer's, where releases are cut) → maintainer builds always ship a commit-accurate manifest; a checkout without the tool ships the committed manifest and the page honestly flags any mismatch. Never a hidden stale proof.

The regen immediately caught a real drift (committed manifest was stamped at the prior commit; now reflects the audited bytes). `beagle check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784540834&installation_id=141311834&pr_number=94&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F94&signature=f2c556aafc78d29667596e8d79d8fe0e0a688df540e1d3a6ad3134bc67a24655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->