### PR TITLE
chore(sovereignty): drop arrow-objlit workaround (beagle PR #8 fixed it)

### DIFF
--- a/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
@@ -1,7 +1,7 @@
 {
   "claim": "This build makes 1 unattended network call: the Firefox version check.",
   "gjoaVersion": "0.3.3",
-  "auditedCommit": "adfd706",
+  "auditedCommit": "70d589f",
   "generated": "2026-06-20",
   "method": "static AST audit of all authored chrome (.sys.mjs + emitted .bjs + content .js), every source parsed",
   "ownCode": {

--- a/tools/sovereignty/egress-scan.bjs
+++ b/tools/sovereignty/egress-scan.bjs
@@ -335,10 +335,6 @@
 (defn item-of [r :- Any] :- Any
   {:endpoint (.-endpoint r) :what (describe r) :file (.-file r) :line (.-line r) :basis (.-basis r)})
 
-;; a named fn (defn returns cleanly) — an INLINE (fn [g] {map}) emits `(g) => {…}`,
-;; which JS parses as a block, not an object return (a beagle codegen bug).
-(defn gap-item [g :- Any] :- Any {:pref (.-name g) :what (.-vector g)})
-
 (js/export (defn write-manifest! [] :- Any
   (let [records (.-records (run))
         own {:unattendedExternal [] :userEnabledNetwork [] :local [] :unproven []}]
@@ -357,7 +353,8 @@
                     {:disabled (.-length (.-disabled inh))
                      :catalogued (.-catalogued inh)
                      :note "Firefox built-in egress vectors gjoa disables by default. SafeBrowsing kept (security)."
-                     :toggleGated (.map (.-gaps inh) gap-item)}}]
+                     :toggleGated (.map (.-gaps inh)
+                                    (fn [g :- Any] :- Any {:pref (.-name g) :what (.-vector g)}))}}]
       (writeFileSync MANIFEST-PATH (str (JSON/stringify manifest nil 2) "\n"))
       (console/log (str "sovereignty: wrote manifest @ " commit " ("
                         (.-length (.-unattendedExternal own)) " unattended, "


### PR DESCRIPTION
Beagle main now parenthesizes arrow fn bodies that emit object literals (Autonymy/beagle PR #8), so the `gap-item` named-defn workaround is no longer needed. Reverted to the inline `(fn [g] {…})` — emit is now `(g) => ({…})`, manifest generation intact. Dogfoods the upstream fix end-to-end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784543571&installation_id=141311834&pr_number=96&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F96&signature=158775661ce92b27ca863f6daf065893a9206d48ba4700ab5abb5b506c36223d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->