### PR TITLE
feat(knobs): LibreWolf-mode profile + about:knobs dashboard (#83 core)

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -222,7 +222,9 @@
       ;; startup (AboutHomeStartupCache: activityStream is null). Disable it.
       (.setBoolPref d "browser.startup.homepage.abouthome_cache.enabled" false)
       ;; sovereignty: the maximal-egress-lockdown meta-pref, default OFF (see apply-lockdown!).
-      (.setBoolPref d "gjoa.sovereignty.maximalLockdown" false))
+      (.setBoolPref d "gjoa.sovereignty.maximalLockdown" false)
+      ;; knobs: profile meta-prefs, default OFF (see PROFILES / apply-profile!).
+      (.setBoolPref d "gjoa.profile.librewolf-mode.enabled" false))
     (catch Any e
       (console/error "gjoa-loader: setDefaults failed" e))))
 
@@ -296,24 +298,55 @@
 (def lockdown-observer :- Any
   {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-lockdown!))})
 
-;; --- about:sovereignty -------------------------------------------------------
-;; Register the egress trust panel as a real about: page at runtime (no rebuild,
-;; no Mozilla-source patch). It maps to the privileged chrome page, so the panel
-;; can read build-provenance prefs + the lockdown toggle and render the verifiable
-;; truth. (NOTE: about-module flag/principal semantics are FF-version-sensitive;
-;; this needs one in-browser confirmation on the next build — wrapped so a failure
-;; only logs and never blocks startup.)
-(def SOVEREIGNTY-URL :- String "chrome://gjoa/content/sovereignty/sovereignty.html")
-(def SOVEREIGNTY-CLASS-ID :- String "{6a7c1e90-5b3d-4c2a-9f81-7e0d3a6b2c54}")
-(def SOVEREIGNTY-CONTRACT :- String "@mozilla.org/network/protocol/about;1?what=sovereignty")
+;; --- knob profiles -----------------------------------------------------------
+;; A profile is a named meta-pref (gjoa.profile.<id>.enabled, default false) that
+;; batch-overrides a set of leaf prefs when ON. Same machine as apply-lockdown!,
+;; generalized: each leaf is [name on-value off-value type] — when the profile is on
+;; we set on-value, when off we set off-value (the gjoa/Firefox default), so toggling
+;; is cleanly reversible and nothing is ever destroyed. The about:knobs dashboard
+;; reads the live state; see private-docs/plan-knobs-debloat-librewolf.md.
+;; #79(a): "LibreWolf-grade DEFAULTS as one toggle" — NOT "as secure as LibreWolf".
+(def PROFILES :- Any
+  [{:pref "gjoa.profile.librewolf-mode.enabled"
+    :leaves [["privacy.resistFingerprinting" true false "bool"]
+             ["privacy.resistFingerprinting.letterboxing" true false "bool"]
+             ["network.http.referer.XOriginPolicy" 2 0 "int"]
+             ["network.http.referer.XOriginTrimmingPolicy" 2 0 "int"]
+             ["browser.search.suggest.enabled" false true "bool"]
+             ["browser.urlbar.suggest.searches" false true "bool"]
+             ["extensions.update.enabled" false true "bool"]
+             ["privacy.donottrackheader.enabled" true false "bool"]]}])
 
-(defn register-about-sovereignty! [] :- Any
+(defn apply-profile! [profile :- Any] :- Any
+  (try
+    (let [d (.getDefaultBranch (.-prefs Services) "")
+          on (.getBoolPref (.-prefs Services) (.-pref profile) false)]
+      (doseq [leaf (.-leaves profile)]
+        (let [name (aget leaf 0) v (if on (aget leaf 1) (aget leaf 2))]
+          (if (= (aget leaf 3) "int") (.setIntPref d name v) (.setBoolPref d name v))))
+      (console/log (str "gjoa-loader: profile " (.-pref profile) " " (if on "ON" "off"))))
+    (catch Any e
+      (console/error "gjoa-loader: apply-profile failed" e))))
+
+(defn apply-all-profiles! [] :- Any
+  (doseq [p PROFILES] (apply-profile! p)))
+
+(def profile-observer :- Any
+  {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-all-profiles!))})
+
+;; --- about: pages (sovereignty + knobs) --------------------------------------
+;; Register a privileged chrome page as a real about:<what> page at runtime (no
+;; rebuild, no Mozilla-source patch). The page reads build-provenance prefs + toggles
+;; and renders the verifiable truth. (NOTE: about-module flag/principal semantics are
+;; FF-version-sensitive — needs one in-browser confirmation; wrapped so a failure only
+;; logs and never blocks startup.)
+(defn register-about! [what :- String url :- String class-id :- String] :- Any
   (try
     (let [about-module
           {:QueryInterface (.generateQI ChromeUtils ["nsIAboutModule"])
            :newChannel (fn [uri :- Any load-info :- Any] :- Any
                          (let [ch (.newChannelFromURIWithLoadInfo (.-io Services)
-                                    (.newURI (.-io Services) SOVEREIGNTY-URL) load-info)]
+                                    (.newURI (.-io Services) url) load-info)]
                            (set! (.-originalURI ch) uri)
                            ch))
            :getURIFlags (fn [_uri :- Any] :- Any (.-ALLOW_SCRIPT (.-nsIAboutModule Ci)))}
@@ -321,11 +354,17 @@
           {:QueryInterface (.generateQI ChromeUtils ["nsIFactory"])
            :createInstance (fn [iid :- Any] :- Any (.QueryInterface about-module iid))}
           registrar (.QueryInterface (.-manager Components) (.-nsIComponentRegistrar Ci))]
-      (.registerFactory registrar (.ID Components SOVEREIGNTY-CLASS-ID)
-        "about:sovereignty" SOVEREIGNTY-CONTRACT factory)
-      (console/log "gjoa-loader: registered about:sovereignty"))
+      (.registerFactory registrar (.ID Components class-id)
+        (str "about:" what) (str "@mozilla.org/network/protocol/about;1?what=" what) factory)
+      (console/log (str "gjoa-loader: registered about:" what)))
     (catch Any e
-      (console/error "gjoa-loader: register about:sovereignty failed" e))))
+      (console/error (str "gjoa-loader: register about:" what " failed") e))))
+
+(defn register-about-pages! [] :- Any
+  (register-about! "sovereignty" "chrome://gjoa/content/sovereignty/sovereignty.html"
+                   "{6a7c1e90-5b3d-4c2a-9f81-7e0d3a6b2c54}")
+  (register-about! "knobs" "chrome://gjoa/content/knobs/knobs.html"
+                   "{b3d8f1a2-4c5e-4a9b-8f02-1e7d6c3b9a40}"))
 
 (js/export (def GjoaLoader :- Any
   {:start (fn [] :- Any
@@ -334,7 +373,9 @@
       (set-defaults)
       (apply-lockdown!)
       (.addObserver (.-prefs Services) LOCKDOWN-PREF lockdown-observer)
-      (register-about-sovereignty!)
+      (apply-all-profiles!)
+      (.addObserver (.-prefs Services) "gjoa.profile." profile-observer)
+      (register-about-pages!)
       (set-new-tab-url!)
       (register-cosmetic-actor)
       (register-darkmode-actor)

--- a/src/gjoa/browser/components/gjoa/content/knobs/knobs.css
+++ b/src/gjoa/browser/components/gjoa/content/knobs/knobs.css
@@ -1,0 +1,98 @@
+/* about:knobs — gjoa reversible-feature dashboard. Forced-dark, matching the gjoa
+   navigator + about:sovereignty aesthetic. */
+
+:root {
+  --bg: #0d0f12;
+  --panel: #14171c;
+  --ink: #e8eaed;
+  --muted: #9aa0a6;
+  --faint: #5f6368;
+  --ok: #34d399;
+  --warn: #f5b454;
+  --line: #23272e;
+  --accent: #7aa2f7;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#panel { max-width: 680px; margin: 0 auto; padding: 8vh 28px 64px; }
+
+.brand {
+  font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--faint); margin-bottom: 16px;
+}
+.intro { color: var(--muted); font-size: 14px; margin: 0 0 28px; }
+.intro a { color: var(--accent); text-decoration: none; }
+.intro a:hover { text-decoration: underline; }
+em { color: var(--ink); font-style: normal; font-weight: 600; }
+
+.h2 { font-size: 17px; margin: 28px 0 4px; }
+.sub { color: var(--faint); font-size: 12.5px; margin: 0 0 14px; }
+
+/* profiles */
+.profile {
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: 12px; padding: 16px 18px; margin-bottom: 14px;
+}
+.profile-head { display: flex; align-items: flex-start; gap: 16px; }
+.profile-txt { flex: 1; }
+.profile-title { font-weight: 600; font-size: 15.5px; }
+.profile-claim { color: var(--muted); font-size: 13px; margin-top: 2px; }
+.profile-disclaimer {
+  color: var(--warn); font-size: 12.5px; margin: 12px 0 0;
+  padding-top: 12px; border-top: 1px solid var(--line);
+}
+.tradeoffs { list-style: none; margin: 12px 0 0; padding: 0; }
+.tradeoff {
+  display: flex; flex-direction: column; gap: 1px;
+  padding: 8px 0; border-top: 1px solid var(--line); font-size: 13px;
+}
+.tradeoff-title { color: var(--ink); font-weight: 500; }
+.tradeoff-detail { color: var(--muted); font-size: 12.5px; }
+
+/* knobs */
+.cat {
+  font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--faint); margin: 22px 0 6px;
+}
+.knob {
+  display: flex; align-items: flex-start; gap: 16px;
+  padding: 12px 0; border-top: 1px solid var(--line);
+}
+.knob-main { flex: 1; min-width: 0; }
+.knob-title { font-weight: 500; }
+.knob-state { color: var(--muted); font-size: 12.5px; margin-top: 1px; }
+.knob-cost { color: var(--faint); font-size: 12px; margin-top: 4px; }
+.knob-basis { color: var(--faint); font-size: 11.5px; margin-top: 3px; line-height: 1.4; }
+.knob-pref {
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 11px; color: var(--faint); margin-top: 4px; word-break: break-all;
+}
+.knob-value { color: var(--muted); font-family: ui-monospace, monospace; font-size: 13px; }
+
+/* toggle switch (shared with about:sovereignty) */
+.toggle { flex: none; cursor: pointer; user-select: none; display: inline-flex; }
+.toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+.toggle-track {
+  width: 42px; height: 24px; border-radius: 999px; background: var(--line);
+  position: relative; transition: background 0.15s ease;
+}
+.toggle-thumb {
+  position: absolute; top: 3px; left: 3px; width: 18px; height: 18px;
+  border-radius: 50%; background: var(--muted);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.toggle input:checked + .toggle-track { background: rgba(52, 211, 153, 0.32); }
+.toggle input:checked + .toggle-track .toggle-thumb { transform: translateX(18px); background: var(--ok); }
+.toggle input:focus-visible + .toggle-track { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.foot { margin-top: 34px; color: var(--faint); font-size: 11.5px; }

--- a/src/gjoa/browser/components/gjoa/content/knobs/knobs.html
+++ b/src/gjoa/browser/components/gjoa/content/knobs/knobs.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- about:knobs — gjoa's reversible-feature dashboard. A PRIVILEGED chrome page: it
+     reads + flips prefs directly. The law (plan-knobs-debloat-librewolf.md): every
+     feature gjoa disables stays PRESENT and reversible; costs are measured or
+     honestly marked unmeasured (never invented). textContent-only render + CSP. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src chrome:; style-src chrome: 'unsafe-inline'; script-src chrome:; img-src chrome: data:;" />
+    <title>Knobs</title>
+    <link rel="stylesheet" href="chrome://gjoa/content/knobs/knobs.css" />
+  </head>
+  <body>
+    <main id="panel" aria-live="polite">
+      <header class="brand">gjoa · knobs</header>
+      <p class="intro">
+        Every feature gjoa disables stays <em>present</em> and reversible — flip a
+        knob to turn it back on. Costs are measured, or honestly marked unmeasured.
+        <a href="about:sovereignty">about:sovereignty →</a>
+      </p>
+
+      <section>
+        <h2 class="h2">Profiles</h2>
+        <p class="sub">A profile flips a whole bundle of knobs at once, and reverts cleanly when off.</p>
+        <div id="profiles"></div>
+      </section>
+
+      <section>
+        <h2 class="h2">Individual knobs</h2>
+        <p class="sub">Each is a single reversible pref. "gjoa default" is the shipped value.</p>
+        <div id="knobs"></div>
+      </section>
+
+      <footer class="foot" id="foot"></footer>
+    </main>
+    <script src="chrome://gjoa/content/knobs/knobs.js"></script>
+  </body>
+</html>

--- a/src/gjoa/browser/components/gjoa/content/knobs/knobs.js
+++ b/src/gjoa/browser/components/gjoa/content/knobs/knobs.js
@@ -1,0 +1,131 @@
+"use strict";
+
+// about:knobs — render the reversible-feature dashboard from the live pref state.
+// Every knob is a present, flippable pref; costs are shown as measured or honestly
+// "unmeasured". Profiles flip a whole bundle (applied by GjoaLoader's apply-profile!).
+// textContent-only — never innerHTML (privileged page rendering data + pref names).
+
+(function () {
+  const $ = (id) => document.getElementById(id);
+
+  let Services = null;
+  try { Services = globalThis.Services; } catch (_) {}
+
+  function getPref(name, type, dflt) {
+    try {
+      return type === "int"
+        ? Services.prefs.getIntPref(name, dflt)
+        : Services.prefs.getBoolPref(name, dflt);
+    } catch (_) { return dflt; }
+  }
+  function setBool(name, v) { try { Services.prefs.setBoolPref(name, v); } catch (_) {} }
+
+  function el(tag, cls, text) {
+    const e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  // a checkbox styled as a switch; onChange(bool).
+  function toggle(checked, onChange) {
+    const label = el("label", "toggle");
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = checked;
+    input.addEventListener("change", () => onChange(input.checked));
+    const track = el("span", "toggle-track");
+    track.appendChild(el("span", "toggle-thumb"));
+    label.appendChild(input);
+    label.appendChild(track);
+    return label;
+  }
+
+  function costText(m) {
+    if (!m) return "cost: unknown";
+    if (m.method === "unmeasured" || m.value == null) {
+      return "cost: unmeasured" + (m.method && m.method !== "unmeasured" ? " (" + m.method + ")" : "");
+    }
+    return "cost: " + m.value + " " + (m.unit || "") + " (" + (m.confidence || "") + ")";
+  }
+
+  function renderProfiles(reg) {
+    const root = $("profiles");
+    root.textContent = "";
+    for (const p of reg.profiles || []) {
+      const card = el("div", "profile");
+      const head = el("div", "profile-head");
+      const txt = el("div", "profile-txt");
+      txt.appendChild(el("div", "profile-title", p.title));
+      if (p.claim) txt.appendChild(el("div", "profile-claim", p.claim));
+      head.appendChild(txt);
+      head.appendChild(toggle(getPref(p.pref, "bool", false), (on) => { setBool(p.pref, on); render(reg); }));
+      card.appendChild(head);
+      if (p.disclaimer) card.appendChild(el("p", "profile-disclaimer", p.disclaimer));
+      if (p.tradeoffs && p.tradeoffs.length) {
+        const ul = el("ul", "tradeoffs");
+        for (const t of p.tradeoffs) {
+          const li = el("li", "tradeoff");
+          li.appendChild(el("span", "tradeoff-title", t.title));
+          li.appendChild(el("span", "tradeoff-detail", t.detail));
+          ul.appendChild(li);
+        }
+        card.appendChild(ul);
+      }
+      root.appendChild(card);
+    }
+  }
+
+  function renderKnobs(reg) {
+    const root = $("knobs");
+    root.textContent = "";
+    const cats = new Map();
+    for (const k of reg.knobs || []) {
+      if (!cats.has(k.category)) cats.set(k.category, []);
+      cats.get(k.category).push(k);
+    }
+    for (const [cat, ks] of cats) {
+      root.appendChild(el("h3", "cat", cat));
+      for (const k of ks) {
+        const row = el("div", "knob");
+        const main = el("div", "knob-main");
+        main.appendChild(el("div", "knob-title", k.title));
+        const cur = getPref(k.pref, k.type, k.gjoaDefault);
+        const isDefault = cur === k.gjoaDefault;
+        main.appendChild(el("div", "knob-state",
+          (cur ? "Enabled" : "Disabled") + (isDefault ? " · gjoa default" : " · overridden")));
+        main.appendChild(el("div", "knob-cost", costText(k.measurement)));
+        if (k.measurement && k.measurement.basis) {
+          main.appendChild(el("div", "knob-basis", k.measurement.basis));
+        }
+        main.appendChild(el("div", "knob-pref", k.pref));
+        row.appendChild(main);
+        // bool knobs get a switch; non-bool (rare) show the value read-only.
+        if (k.type === "bool") {
+          row.appendChild(toggle(!!cur, (on) => { setBool(k.pref, on); render(reg); }));
+        } else {
+          row.appendChild(el("div", "knob-value", String(cur)));
+        }
+        root.appendChild(row);
+      }
+    }
+  }
+
+  function render(reg) {
+    renderProfiles(reg);
+    renderKnobs(reg);
+    const n = (reg.knobs || []).length, p = (reg.profiles || []).length;
+    $("foot").textContent = p + " profile(s), " + n + " knob(s). " +
+      "Costs are measured against a real gjoa binary, or marked unmeasured — never invented.";
+  }
+
+  async function load() {
+    try {
+      const r = await fetch("chrome://gjoa/content/knobs/registry.json");
+      render(await r.json());
+    } catch (e) {
+      $("knobs").textContent = "could not load the knobs registry: " + e;
+    }
+  }
+  load();
+})();

--- a/src/gjoa/browser/components/gjoa/content/knobs/registry.json
+++ b/src/gjoa/browser/components/gjoa/content/knobs/registry.json
@@ -1,0 +1,36 @@
+{
+  "note": "The gjoa knobs registry. Each knob is a reversible pref (the feature is PRESENT, just toggled). gjoaDefault is gjoa's shipped value; flip the toggle to override. Costs are MEASURED or honestly 'unmeasured' — never invented.",
+  "knobs": [
+    { "id": "telemetry", "pref": "toolkit.telemetry.enabled", "type": "bool", "title": "Telemetry", "category": "Telemetry & data reporting", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Memory/CPU saving unmeasured on a gjoa binary. To measure: enable in a control build, capture about:memory at idle+30s, disable, recapture, report the delta + date." } },
+    { "id": "healthreport", "pref": "datareporting.healthreport.uploadEnabled", "type": "bool", "title": "Health Report upload", "category": "Telemetry & data reporting", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Egress/data feature, not a measured perf win. Cost is the data sent, not memory; vanity-until-proven for memory." } },
+    { "id": "pocket", "pref": "extensions.pocket.enabled", "type": "bool", "title": "Pocket", "category": "Bundled features", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "about:memory delta unmeasured on gjoa. Measure on a baseline where Pocket is ENABLED — you cannot claim a saving for a feature that was never running." } },
+    { "id": "fxaccounts", "pref": "identity.fxaccounts.enabled", "type": "bool", "title": "Firefox Accounts (sync)", "category": "Bundled features", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Disables Sync/FxA. Cost is feature loss, not a measured perf win. Unmeasured." } },
+    { "id": "discovery", "pref": "browser.discovery.enabled", "type": "bool", "title": "Add-on discovery (TAAR)", "category": "Recommendations", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Egress (recommendation service). Unmeasured for memory; vanity-until-proven." } },
+    { "id": "normandy", "pref": "app.normandy.enabled", "type": "bool", "title": "Normandy remote experiments", "category": "Experiments & studies", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Remote config/experiment delivery. Egress vector; memory cost unmeasured." } },
+    { "id": "shield", "pref": "app.shield.optoutstudies.enabled", "type": "bool", "title": "Shield studies", "category": "Experiments & studies", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Study enrollment. Unmeasured." } },
+    { "id": "activitystream", "pref": "browser.newtabpage.activity-stream.enabled", "type": "bool", "title": "Activity Stream new-tab", "category": "New tab", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "gjoa ships a custom new-tab; Activity Stream is replaced, not just off. Re-enabling does not restore gjoa's new-tab routing. Memory delta unmeasured." } },
+    { "id": "contile", "pref": "browser.contile.enabled", "type": "bool", "title": "Sponsored top sites (Contile)", "category": "Recommendations", "gjoaDefault": false, "firefoxDefault": true,
+      "measurement": { "method": "unmeasured", "value": null, "unit": null, "confidence": "unmeasured", "basis": "Egress to contile.services.mozilla.com. No functional cost (custom new-tab). Memory unmeasured." } },
+    { "id": "listdriven-scriptlets", "pref": "gjoa.contentblock.scriptlets.listDriven.enabled", "type": "bool", "title": "List-driven scriptlet injection", "category": "Content blocking (security)", "gjoaDefault": false, "firefoxDefault": false,
+      "measurement": { "method": "cve-surface", "value": null, "unit": null, "confidence": "moderate", "basis": "SECURITY GATE (finding F2), not a perf knob: default OFF means only curated baseline scriptlets run; flipping ON allows arbitrary +js() from uBO filter lists (user-supplied JS injection). Leave OFF unless you trust your lists." } }
+  ],
+  "profiles": [
+    { "id": "librewolf-mode", "pref": "gjoa.profile.librewolf-mode.enabled", "type": "bool", "title": "LibreWolf mode",
+      "claim": "LibreWolf-grade privacy DEFAULTS, as one toggle.",
+      "disclaimer": "NOT 'as secure as LibreWolf'. These prefs are only part of LibreWolf's hardening (their compile-time disables and ~20 C++ patches are not here), and flipping this changes none of gjoa's own added surface (the adblock classifier, content actors, custom about: pages).",
+      "applies": ["privacy.resistFingerprinting", "privacy.resistFingerprinting.letterboxing", "network.http.referer.XOriginPolicy", "network.http.referer.XOriginTrimmingPolicy", "browser.search.suggest.enabled", "browser.urlbar.suggest.searches", "extensions.update.enabled", "privacy.donottrackheader.enabled"],
+      "tradeoffs": [
+        { "title": "resistFingerprinting has a high UX cost", "detail": "Breaks canvas-reliant sites, letterboxes the window, reports UTC timezone + a generic UA. Default-off for a reason; on only inside this profile." },
+        { "title": "Safe Browsing stays ON (conflict, not flipped)", "detail": "LibreWolf neuters Safe Browsing, but gjoa deliberately KEPT download-reputation on (security finding F5). LibreWolf mode does NOT disable it here — the conflict is surfaced, not silently resolved." },
+        { "title": "Prefetch stays ON (gjoa speed decision)", "detail": "LibreWolf disables prefetch/dns-prefetch; gjoa keeps them on for page-load speed. Not changed by this profile." }
+      ] }
+  ]
+}

--- a/src/gjoa/browser/components/gjoa/jar.mn
+++ b/src/gjoa/browser/components/gjoa/jar.mn
@@ -31,6 +31,12 @@ browser.jar:
   content/gjoa/sovereignty/sovereignty.css (content/sovereignty/sovereignty.css)
   content/gjoa/sovereignty/sovereignty.js (content/sovereignty/sovereignty.js)
   content/gjoa/sovereignty/manifest.json (content/sovereignty/manifest.json)
+# about:knobs — reversible-feature dashboard. PRIVILEGED (reads + flips prefs),
+# registered as about:knobs at runtime by GjoaLoader.
+  content/gjoa/knobs/knobs.html (content/knobs/knobs.html)
+  content/gjoa/knobs/knobs.css (content/knobs/knobs.css)
+  content/gjoa/knobs/knobs.js (content/knobs/knobs.js)
+  content/gjoa/knobs/registry.json (content/knobs/registry.json)
 
 # The new-tab page is the only gjoa chrome that loads as a *content* document
 # (via AboutNewTab.newTabURL in GjoaLoader). It gets its own package marked


### PR DESCRIPTION
The #78/#79 plan made real. One machine, two directions — features stay present + reversible.

- **apply-profile!** generalizes `apply-lockdown!`: each leaf is `[name on-val off-val type]` so a profile toggle applies AND reverts cleanly. One `gjoa.profile.*` observer.
- **LibreWolf mode** (default off): RFP+letterboxing, referrer trimming, suggest-off, extension-autoupdate-off, DNT. Honest claim in the UI — *'LibreWolf-grade DEFAULTS, NOT as-secure-as-LibreWolf'* — with explicit tradeoff rows (RFP UX cost; Safe Browsing **kept** per F5; prefetch **kept** for speed — surfaced, not flipped).
- **about:knobs**: privileged dashboard (`register-about!` generalized; sovereignty + knobs both registered) — each reversible feature's live state + cost (measured or honestly *unmeasured*, never invented) + a toggle, plus the profiles. textContent-only + CSP; **zero added network egress** (registry fetch is local `chrome:`).

Remaining in #83: real measurement runs, preflight Gate N (knob-not-delete), the 2 flake build-flag decisions, unify PROFILES↔registry source. about-module live-confirm pending (same as sovereignty). `beagle check` clean; page parses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784547357&installation_id=141311834&pr_number=99&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F99&signature=4c11b20db6e8438ceb2a9be80ceb3b033e8f7cd3eb67747696da4cb2b10f02be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->