### PR TITLE
feat(settings): thin about:preferences pointer -> about:gjoa (no FF patch)

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaAboutPrefsChild.sys.mjs
+++ b/src/gjoa/browser/components/gjoa/GjoaAboutPrefsChild.sys.mjs
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Child half of the about:preferences POINTER. gjoa OWNS its settings at about:gjoa
+// and does NOT patch Firefox's preferences code (Zen patches three core files and
+// recalculates every release; this only OBSERVES the page and appends a node). The
+// pointer guides a user who lands in Firefox Settings looking for a gjoa feature.
+//
+// Graceful by construction: the top banner is appended to a container that always
+// exists (#mainPrefPane, else <body>); the category-nav entry is best-effort (its
+// markup is FF-version-specific) and a miss is harmless — about:gjoa is always
+// reachable by URL, and Firefox Settings still works untouched.
+export class GjoaAboutPrefsChild extends JSWindowActorChild {
+  handleEvent(event) {
+    if (event.type !== "DOMContentLoaded") {
+      return;
+    }
+    try {
+      this.#inject(this.document);
+    } catch (e) {
+      // Never break Firefox Settings over a cosmetic pointer.
+    }
+  }
+
+  #open() {
+    this.sendAsyncMessage("GjoaPrefs:OpenSettings", {});
+  }
+
+  #inject(doc) {
+    if (!doc || doc.getElementById("gjoa-prefs-pointer")) {
+      return;
+    }
+
+    // (1) Top banner — robust fallback, always shown.
+    const main = doc.getElementById("mainPrefPane") || doc.body;
+    if (main) {
+      const banner = doc.createElement("div");
+      banner.id = "gjoa-prefs-pointer";
+      banner.style.cssText =
+        "margin:14px 0;padding:12px 16px;border:1px solid #7aa2f7;" +
+        "border-radius:10px;display:flex;gap:12px;align-items:center;" +
+        "font:14px system-ui,sans-serif;";
+      const txt = doc.createElement("span");
+      txt.textContent = "gjoa-specific settings live in gjoa Settings.";
+      txt.style.flex = "1";
+      const btn = doc.createElement("button");
+      btn.textContent = "Open gjoa Settings";
+      btn.addEventListener("click", () => this.#open());
+      banner.append(txt, btn);
+      main.prepend(banner);
+    }
+
+    // (2) Category-nav entry — best-effort; structure is FF-version-specific.
+    const nav = doc.querySelector("moz-page-nav") || doc.getElementById("categories");
+    if (nav) {
+      const entry = doc.createElement("button");
+      entry.id = "category-gjoa-link";
+      entry.className = "category";
+      entry.textContent = "gjoa Settings";
+      entry.addEventListener("click", () => this.#open());
+      nav.append(entry);
+    }
+  }
+}

--- a/src/gjoa/browser/components/gjoa/GjoaAboutPrefsParent.sys.mjs
+++ b/src/gjoa/browser/components/gjoa/GjoaAboutPrefsParent.sys.mjs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Parent half of the about:preferences POINTER actor. gjoa owns its settings at
+// about:gjoa and does NOT patch Firefox's preferences UI — the child only injects a
+// thin pointer into about:preferences. The child has no tab-opening privilege, so
+// when the pointer is clicked it asks the parent to open about:gjoa.
+export class GjoaAboutPrefsParent extends JSWindowActorParent {
+  receiveMessage(msg) {
+    if (msg.name !== "GjoaPrefs:OpenSettings") {
+      return;
+    }
+    try {
+      const browser = this.browsingContext.top.embedderElement;
+      const win = browser?.ownerGlobal;
+      if (win?.openTrustedLinkIn) {
+        win.openTrustedLinkIn("about:gjoa", "tab");
+      }
+    } catch (e) {
+      console.error("GjoaAboutPrefs: failed to open about:gjoa", e);
+    }
+  }
+}

--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -360,6 +360,22 @@
     (catch Any e
       (console/error (str "gjoa-loader: register about:" what " failed") e))))
 
+;; The thin about:preferences POINTER — a window actor that injects a "gjoa Settings"
+;; pointer into Firefox Settings (→ about:gjoa). gjoa OWNS its settings surface and
+;; does NOT patch Firefox's preferences code; this only OBSERVES the page (graceful —
+;; a miss is harmless, about:gjoa is always reachable by URL). Matches about:preferences
+;; and its about:settings alias.
+(defn register-aboutprefs-actor! [] :- Any
+  (try
+    (.registerWindowActor ChromeUtils "GjoaAboutPrefs"
+      {:parent {:esModuleURI "resource:///modules/gjoa/GjoaAboutPrefsParent.sys.mjs"}
+       :child {:esModuleURI "resource:///modules/gjoa/GjoaAboutPrefsChild.sys.mjs"
+               :events {:DOMContentLoaded {:mozSystemGroup true}}}
+       :matches ["about:preferences*" "about:settings*"]})
+    (console/log "gjoa-loader: registered GjoaAboutPrefs actor (about:preferences pointer)")
+    (catch Any e
+      (console/error "gjoa-loader: register GjoaAboutPrefs actor failed" e))))
+
 (defn register-about-pages! [] :- Any
   (register-about! "sovereignty" "chrome://gjoa/content/sovereignty/sovereignty.html"
                    "{6a7c1e90-5b3d-4c2a-9f81-7e0d3a6b2c54}")
@@ -380,6 +396,7 @@
       (apply-all-profiles!)
       (.addObserver (.-prefs Services) "gjoa.profile." profile-observer)
       (register-about-pages!)
+      (register-aboutprefs-actor!)
       (set-new-tab-url!)
       (register-cosmetic-actor)
       (register-darkmode-actor)

--- a/src/gjoa/browser/components/gjoa/moz.build
+++ b/src/gjoa/browser/components/gjoa/moz.build
@@ -4,5 +4,7 @@
 JAR_MANIFESTS += ["jar.mn"]
 
 EXTRA_JS_MODULES.gjoa += [
+    "GjoaAboutPrefsChild.sys.mjs",
+    "GjoaAboutPrefsParent.sys.mjs",
     "GjoaLoader.sys.mjs",
 ]


### PR DESCRIPTION
Completes 'own the surface + signpost': gjoa owns about:gjoa, and Firefox Settings carries a thin pointer so a user who lands in about:preferences for a gjoa feature is guided, not stranded.

A **GjoaAboutPrefs window actor** (matches `about:preferences*`/`about:settings*`) injects on DOMContentLoaded: (1) a top banner + Open button, appended to a container that always exists (`#mainPrefPane` else `<body>`); (2) a best-effort category-nav entry. Click → message parent → `openTrustedLinkIn(about:gjoa)`.

**The seam difference vs Zen:** Zen patches 3 core preferences files (recalc every release, silent failure if broken); gjoa **observes the page and appends a node** — a miss is harmless (about:gjoa still reachable by URL; Firefox Settings untouched). Zero Mozilla-source patches.

`beagle check` clean; actor `.sys.mjs` syntactically valid. Needs one in-browser confirmation on next build (the about: registrations + this DOM selector are FF152-sensitive — all verified in one pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784548609&installation_id=141311834&pr_number=101&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F101&signature=35814e02ab01688e9760a460b7ca115fd326a182267878858dce17fb09a7b4d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->