### PR TITLE
docs(readme): clarify the build flavors (portable builds ARE for sharing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ nix build .#gjoa-dev --impure   # dev variant — fast, no LTO, CPU-portable
 ./result/bin/gjoa
 ```
 
-`.#gjoa` is tuned to the building machine's CPU (fastest, but SIGILLs on a different chip — the maintainer's daily driver, never handed out). Portable, distributable builds are the **CI artifacts** (`.github/workflows/`): a Linux x86_64 tarball, a macOS (Apple Silicon) `.dmg`, and a Windows x86_64 `.zip`, none `-march=native`. `nix bundle .#gjoa-dev --impure` emits a single relocatable Linux executable (no Nix on the target). CI clones the [Beagle](https://github.com/Autonymy/beagle) compiler as a sibling checkout.
+Two flavors, and the only difference is CPU portability:
+
+- **Your own machine → `.#gjoa`.** Compiled `-march=native` (for the CPU it's built on) — fastest, but it can crash (SIGILL) on hardware that lacks those instructions, so it's a *local* build, not for arbitrary machines.
+- **Sharing with anyone else → a portable build.** The **release artifacts** (`.github/workflows/` builds them on every tag — a Linux x86_64 tarball, a macOS Apple-Silicon `.dmg`, a Windows x86_64 `.zip`, all non-`-march=native`), or `nix bundle .#gjoa-dev --impure` for a single relocatable Linux executable that runs on any glibc distro with no Nix on the target. These are the builds to hand out.
+
+CI clones the [Beagle](https://github.com/Autonymy/beagle) compiler as a sibling checkout before building.
 
 ## Dev loop
 


### PR DESCRIPTION
The 'never handed out' phrasing read as 'gjoa isn't distributed' — it is. Reworded the Build section: **your own machine → `.#gjoa` (native, fastest); sharing with anyone → a portable build** (the release artifacts, or `nix bundle .#gjoa-dev`). `.#gjoa`'s `-march=native` is just the maintainer's local turbo build, CPU-specific.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784549209&installation_id=141311834&pr_number=103&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F103&signature=0bea67ff322a2478e3966e36f7f017aef24f5f317ee96486b5b64e36c76603af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->