### PR TITLE
docs(readme): sharper headline — extension stack is native

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # gjoa
 
-**A Firefox fork that does natively — at near-zero runtime cost — what most people bolt onto Firefox with a stack of extensions.** An ad blocker, Dark Reader, tree-style tabs — built into one aggressively optimized build.
+**gjoa is a Firefox fork where the power-user extension stack is native.** Ad blocking, forced dark mode, vertical/tree tabs, workspaces, vim navigation, session history, and egress auditing live in the browser chrome and engine — not in extensions, content scripts, or autoconfig hacks.
 
 <img src="screenshots/gjoa-newtab.png" width="760" alt="gjoa — the new-tab navigator, vertical-tab sidebar, forced-dark" />
 
 </div>
 
-Built on Firefox 152. The UI is written in [Beagle](https://github.com/Autonymy/beagle) (a typed Clojure subset) as `.bjs` modules compiled to chrome JS, loaded by a native chrome loader baked into `omni.ja` — no fx-autoconfig, no extension process, no per-page injection.
+Built on Firefox 152, written in [Beagle](https://github.com/Autonymy/beagle) (a typed Clojure subset) compiled to chrome JS and a native loader baked into `omni.ja`. Native means near-free at runtime — no Dark Reader repaint, no content-script ad blocker, no per-page injection tax. That's the whole point.
 
 > This README is the stable shape. Volatile detail — exact feature state, build outcomes — lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`BUILD-LEDGER.md`](BUILD-LEDGER.md), and the [releases](../../releases).
 


### PR DESCRIPTION
Leads with the thesis (*the power-user extension stack is native*) + the capability enumeration + the precise mechanism (chrome and engine, not extensions/content-scripts/autoconfig), keeping the honest near-free-at-runtime hook.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784549473&installation_id=141311834&pr_number=104&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F104&signature=e134a2083f184321fea64fe1ea89da09bb0d91cdb6a0f22fd87cad6df77af7de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->