### PR TITLE
feat(release): release-notes takes an optional end-ref

### DIFF
--- a/tools/release/release-notes.bjs
+++ b/tools/release/release-notes.bjs
@@ -44,8 +44,8 @@
     (doseq [p rows] (console/log (fmt-row p)))
     (console/log "")))
 
-(defn generate! [prev :- String] :- Any
-  (let [range (if (= prev "") "HEAD" (str prev "..HEAD"))
+(defn generate! [prev :- String end :- String] :- Any
+  (let [range (str (if (= prev "") "" (str prev "..")) end)
         raw (sh (str "git log " range " --no-merges --pretty=format:%s") {:quiet true})
         subjects (.filter (.split raw "\n") (fn [s :- String] :- Bool (> (.-length (.trim s)) 0)))
         parsed (.map subjects parse-subject)]
@@ -75,7 +75,9 @@
   (let [argv (.-argv process) cmd (aget argv 2)]
     (cond
       (= cmd "check") (gate! (or (aget argv 3) ""))
-      :else (generate! (or cmd (last-tag))))))
+      ;; release-notes [<prev-tag> [<end-ref>]] — defaults: last tag .. HEAD.
+      ;; e.g. `release-notes v0.3.2 v0.3.3` regenerates a past release's notes.
+      :else (generate! (or cmd (last-tag)) (or (aget argv 3) "HEAD")))))
 
 (when (.-main (js/import-meta))
   (main!))


### PR DESCRIPTION
`release-notes [<prev-tag> [<end-ref>]]` — same last-tag..HEAD default, but `release-notes v0.3.2 v0.3.3` now regenerates any past release's notes. Used to backfill v0.3.3 (which shipped with the CI placeholder).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784549843&installation_id=141311834&pr_number=105&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F105&signature=7d1b8322226e6b0d768b99e51a1df7ec6e234d529d169f19fe52f18dddd44db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->