### PR TITLE
docs(why-beagle): modern beagle/fram/claims affordances + README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Built on Firefox 152, written in [Beagle](https://github.com/Autonymy/beagle) (a typed Clojure subset) compiled to chrome JS and a native loader baked into `omni.ja`. Native means near-free at runtime — no Dark Reader repaint, no content-script ad blocker, no per-page injection tax. That's the whole point.
 
+Authoring in Beagle is a deliberate edge, not an aesthetic one: compile-time macros, **one** typed language across chrome / loader / tooling / tests / prefs, machine-checked effect discipline (`tsc` can't see purity), and engine patches anchored by *structural identity* — so an upstream refactor can't silently drop them. The honest case, including what *isn't* a win, is in [`docs/why-beagle.md`](docs/why-beagle.md).
+
 > This README is the stable shape. Volatile detail — exact feature state, build outcomes — lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`BUILD-LEDGER.md`](BUILD-LEDGER.md), and the [releases](../../releases).
 
 ## What's different

--- a/docs/why-beagle.md
+++ b/docs/why-beagle.md
@@ -1,18 +1,21 @@
-# Why Beagle for gjoa — the honest case vs TS/JS
+# Why Beagle for gjoa — the authoring substrate
 
-This document makes the case that authoring gjoa in Beagle (`.bjs`) was the right
-call over TypeScript/JavaScript. It leads with what is **measurable and
-undeniable**, and it is honest about what is *not* a win — because a claim that
-overreaches is one sentence away from being dismissed.
+gjoa is authored in **Beagle** (`.bjs`) — a typed Clojure that compiles `parse →
+check → emit` to chrome JS, the native ESM loader, build tooling, tests, and
+Firefox pref files. This document is the honest case for that choice. It leads
+with what is **measurable and CI-enforced**, and it is explicit about what is
+*not* a win — a claim that overreaches is one sentence away from being dismissed.
 
 ## TL;DR
 
-The win is **not raw line count**. It is three things TS structurally cannot do,
-plus targeted compression where boilerplate actually exists:
+The win is **not raw line count**. It is four things TS/JS structurally cannot
+do, plus a fifth that goes beyond authoring entirely:
 
 1. **Compile-time macros** — a zero-cost domain abstraction layer. TS has no macro system.
-2. **One typed language across the entire stack** — chrome JS, the ESM bootstrap module, build tooling, tests, Firefox pref files, and the Nix config. TS can author exactly one of those layers.
-3. **Targeted boilerplate collapse**, proven in a controlled experiment (the test suite).
+2. **One typed language across the entire stack** — chrome JS, the ESM loader, build tooling, tests, pref files, Nix config.
+3. **Machine-checked effect discipline** (`!`-purity) — the one bug class `tsc` cannot catch at any setting.
+4. **Targeted boilerplate collapse**, proven in a controlled experiment (the test suite).
+5. **Code as claims** — engine patches anchored by *structural identity*, not line numbers, so an upstream refactor can't silently lose them. CI-gated.
 
 ---
 
@@ -20,12 +23,12 @@ plus targeted compression where boilerplate actually exists:
 
 - **Raw LOC is a wash.** Beagle source is often *the same size or larger* than the
   JS it emits — inline types (`:- T`), `;;` comments that don't survive emit, and
-  Lisp's one-form-per-line verticality all cost lines. The chrome layer is **7,934
-  LOC of `.bjs` source → 5,946 LOC of emitted JS**. Beagle is not "fewer lines."
+  Lisp's one-form-per-line verticality all cost lines. The chrome layer is **8,516
+  LOC of `.bjs` source → 6,612 LOC of emitted JS**. Beagle is not "fewer lines."
 - **Cross-codebase LOC vs the old TS (palefox) is confounded.** gjoa does strictly
   more (SQLite history, Spaces, multi-window sync), the archive has multiple
-  iterations of each file, and formatting conventions differ. Any single
-  beagle-vs-TS ratio from it is cherry-picked. We don't headline one.
+  iterations of each file, and conventions differ. Any single beagle-vs-TS ratio
+  from it is cherry-picked. We don't headline one.
 - **Performance is a wash.** Chrome JS runs in the same SpiderMonkey whether it
   came from Beagle or TS; Beagle emits ~the same JS. The only real edges are small:
   macros inline (zero-cost) where a TS helper `byId()` is a runtime call, and
@@ -40,9 +43,9 @@ isn't, meaningfully — that was never the point." The point is below.
 
 ### 1. Compile-time macros — a capability TS lacks entirely
 
-`src/gjoa/chrome/bjs/macros.bjs` is **34 macros in 106 LOC**, expanded across
-**595 invocation sites** in the chrome layer (~5 sites per macro-line). Each
-expansion is zero-cost — it compiles to the primitive, with no runtime indirection.
+`src/gjoa/chrome/bjs/macros.bjs` is **37 macros in 123 LOC**, expanded across
+**~600 invocation sites** in the chrome layer. Each expansion is zero-cost — it
+compiles to the primitive, with no runtime indirection.
 
 ```clojure
 ;; the macro (defined once)
@@ -67,20 +70,14 @@ change it in one place.
 This is the cleanest measurement we have, because it controls for everything: same
 tests, same language, same features — the *only* variable is "add a macro DSL."
 
-`tests/dsl.bjs` is a **78-LOC** DSL (`deftest` / `chrome-eval` / `await-true` /
-`expect` / `expect-eq` + shared `wait-for`/`sleep`). Applying it across the 13
-integration files:
-
-| | before | after |
-|---|---|---|
-| `tests/integration` total | 2,436 LOC | **2,109 LOC (−13%)** |
-| duplicate `wait-for` definitions | 7 | **1** (shared) |
-| hand-rolled `(throw (Error. …))` assertions | 103 | collapsed into `expect`/`expect-eq` |
-| `(js/await (.executeScript mn …))` wrappers | 163 | collapsed into `chrome-eval` |
-
-Per file, the collapse tracks how much boilerplate existed: **−33%** (`spaces`),
-−24% (`new-tab-visibility`), −22% (`session-restore`) on assertion-heavy files;
-~0% on files that were already terse (`sqlite`, `adblock-smoke`). Honest spread.
+`tests/dsl.bjs` is a **93-LOC** DSL (`deftest` / `chrome-eval` / `await-true` /
+`expect` / `expect-eq` + shared `wait-for`/`sleep`), shared across the **integration
+suite (28 files, 80 `deftest` cases)**. It deduplicates what was 7 hand-rolled
+`wait-for` definitions down to **one**, collapses every `(throw (Error. …))`
+assertion into `expect`/`expect-eq`, and every `(js/await (.executeScript mn …))`
+wrapper into `chrome-eval`. When the DSL was introduced it cut the then-13-file
+suite **~13%** (−33% on assertion-heavy files like `spaces`, ~0% on already-terse
+ones — honest spread); the suite has since tripled in size on top of that one DSL.
 
 **Before:**
 ```clojure
@@ -91,11 +88,7 @@ Per file, the collapse tracks how much boilerplate existed: **−33%** (`spaces`
                      "return window.Spaces.list().map(s => ({ name: s.name }));"))]
           (if (or (not (.-length list)) (not= (.-name (aget list 0)) "Main"))
             (throw (Error. (str "expected default 'Main', got " (.stringify JSON list))))
-            nil)
-          (let [activeName (js/await (.executeScript mn "return window.Spaces.active().name;"))]
-            (if (not= activeName "Main")
-              (throw (Error. (str "expected active='Main', got '" activeName "'")))
-              nil))))}
+            nil)))}
 ```
 
 **After:**
@@ -104,24 +97,23 @@ Per file, the collapse tracks how much boilerplate existed: **−33%** (`spaces`
   (await-true "return !!window.Spaces && window.Spaces.list().length >= 1;")
   (let [list (chrome-eval "return window.Spaces.list().map(s => ({ name: s.name }));")]
     (expect (and (.-length list) (= (.-name (aget list 0)) "Main"))
-            (str "expected default 'Main', got " (.stringify JSON list))))
-  (expect-eq (chrome-eval "return window.Spaces.active().name;") "Main" "active space"))
+            (str "expected default 'Main', got " (.stringify JSON list)))))
 ```
 
-Same behavior, same assertions, same embedded JS — verified by the suite staying
-**42/42 green**. The `mn` Marionette client is threaded *anaphorically* by the
-macros (non-hygienic expansion), so the body never mentions it. TS cannot express
-`chrome-eval "…"` resolving `mn` from the enclosing test — it has no macros.
+Same behavior, same assertions, same embedded JS. The `mn` Marionette client is
+threaded *anaphorically* by the macros (non-hygienic expansion), so the body never
+mentions it. TS cannot express `chrome-eval "…"` resolving `mn` from the enclosing
+test — it has no macros.
 
 ### 3. Stack uniformity — one typed language for the whole browser
 
-The gjoa repo is **100% Beagle-authored**. One language, one type system, one set
-of macros, spanning:
+The gjoa repo is **100% Beagle-authored** (zero hand-written `.ts`/`.js` source).
+One language, one type system, one set of macros, spanning:
 
 | layer | file(s) | TS can do this? |
 |---|---|---|
 | chrome JS (the browser UI) | `src/gjoa/chrome/bjs/**` | ✅ (this is all TS does) |
-| ESM bootstrap module | `GjoaLoader.bjs` → `.sys.mjs` | ⚠️ as ESM, but not unified |
+| ESM loader module | `GjoaLoader.bjs` → `.sys.mjs` | ⚠️ as ESM, but not unified |
 | build tooling | `tools/**` | ⚠️ via ts-node |
 | integration tests | `tests/**` | ⚠️ separate |
 | Firefox pref files | `defaults/pref/*.bjs` → `pref(…)` | ❌ |
@@ -134,10 +126,9 @@ and it is not available in TS at any price.
 
 ### 4. Effect discipline — the one bug class beagle catches that `tsc` cannot
 
-This is the genuine "`tsc` would never catch this," and it's now *executable*. Beagle
-enforces a naming invariant: a function whose name does **not** end in `!` must have a
-**pure body** — no `set!`, no call to a `!`-named (effectful) function. Break it and
-the build fails with `E019 purity leak`.
+Beagle enforces a naming invariant: a function whose name does **not** end in `!`
+must have a **pure body** — no `set!`, no call to a `!`-named (effectful) function.
+Break it and the build fails with `E019 purity leak`.
 
 ```clojure
 ;; beagle — COMPILE ERROR (E019): "compute-total has no '!' suffix but its body
@@ -158,10 +149,55 @@ function computeTotal(items: number[]): number {
 `tsc` has no concept of purity at any setting — a function that reads like a
 calculation but silently mutates shared state type-checks perfectly, and ships as a
 heisenbug (it breaks the moment someone memoizes it, reorders it, or runs it twice).
-Beagle makes "no `!` means pure" a *machine-checked promise*. gjoa now enforces it
-across the whole corpus (`bun run check`, gated in `test`): every effectful function
-— all the `make-*` factories, every mutator — is marked `!`, so the *absence* of `!`
-is a guarantee you can reason on. That guarantee does not exist in TypeScript.
+Beagle makes "no `!` means pure" a *machine-checked promise*, enforced across the
+whole corpus (`bun run check`, gated in `test`): every effectful function — all the
+`make-*` factories, every mutator — is marked `!`, so the *absence* of `!` is a
+guarantee you can reason on. That guarantee does not exist in TypeScript.
+
+---
+
+## Beyond authoring: code as claims
+
+The previous four points are about writing the browser. This one is about the
+**engine patches** — and it is the affordance with no TS analogue at all, because
+it isn't a language feature, it's treating *code as structured data instead of
+text* end to end.
+
+gjoa carries patches against Mozilla source. A textual `.patch` is anchored to
+line numbers and surrounding context: when Mozilla reflows or renames around a
+hunk — which it does every release — the patch `.rej`s and you re-roll it by hand.
+gjoa's **projector** (`tools/projector/`) expresses selected edits as **claim-docs**
+instead: a small JSON document of verbs like `set-body` on
+`AboutNewTabRedirectorParent::newChannel`, anchored by *structural identity* — the
+method's parameter list, ordinal, and body identifiers — **not** by line. When the
+surrounding source moves, the claim-doc re-locates its target by identity and
+re-applies.
+
+This is **real and CI-gated** (`bun run projector:test`, gates A/B in all three
+build workflows):
+
+- **Gate A** round-trips the entire `.sys.mjs` corpus through a lossless CST
+  (`reflector.bjs`) and renders it back **byte-identically** — the projection
+  loses nothing.
+- **Gate B** proves the committed `0011` claim-doc
+  (`patches/0011-newtab-redirector-gjoa.claims.json`) reproduces its textual patch
+  output **exactly**.
+- Anchor-recovery (`anchor.bjs`) survives reflow *and a method rename* — fuzzy-
+  matching on params + body-identifier overlap when the name itself changes.
+
+The payoff for gjoa today is concrete: **a patch you can't silently lose to an
+upstream refactor.**
+
+The same projection also emits gjoa's source as a **Fram claim graph** — every AST
+node as `(subject, predicate, object)` triples — that a real claim engine persists
+and answers Datalog queries over (e.g. "find every `MethodDefinition`," round-
+tripped byte-identical through the live store). That direction is where "code as
+claims" gets its real power: scope-correct *"who calls this,"* transitive blast-
+radius, leverage. **Honest status:** in gjoa today the projection is *structural*
+(the AST as queryable claims, demonstrated end-to-end against a real engine); the
+*relational* call-graph queries live in the sibling Chartroom/fram project and are
+not yet wired into gjoa. We claim the patch-resilience win as shipped and CI-gated,
+and the relational graph as the direction — not as done.
 
 ---
 
@@ -170,12 +206,14 @@ is a guarantee you can reason on. That guarantee does not exist in TypeScript.
 | metric | verdict |
 |---|---|
 | compression — raw LOC | **wash / confounded** — not the win, don't claim it |
-| compression — boilerplate/duplication | **strong where it exists** (tests −13–33%; 595 macro sites from 106 LOC) |
+| compression — boilerplate/duplication | **strong where it exists** (test DSL: 93 LOC shared across 80 cases; ~600 macro sites from 123 LOC) |
 | performance | **wash** (same engine) + zero-cost macros + bloat-free emit |
 | readability | taste-dependent; the macro DSL reads at the domain level |
 | **stack uniformity** | **decisive** — one typed, macro-enabled language for the whole stack |
 | **effect discipline** | **decisive** — `!`-purity is enforced (the one bug class `tsc` cannot catch) |
+| **code as claims** | **shipped + CI-gated** for patch resilience (identity-anchored, churn-proof); relational graph is the direction, not done |
 | **correctness tooling** | macros + a repair loop with pointed, structured compile errors |
 
-The case for Beagle is **macros + uniformity + effect discipline**, demonstrated, not
-**"fewer lines"** or **"faster,"** asserted. Lead with what's true and it holds up.
+The case for Beagle is **macros + uniformity + effect discipline + code-as-claims**,
+demonstrated, not **"fewer lines"** or **"faster,"** asserted. Lead with what's true
+and it holds up.


### PR DESCRIPTION
why-beagle.md predated the code-as-claims universe — it made the macros / stack-uniformity / `!`-purity case vs TS but never mentioned the projector, and the README linked it nowhere.

- Refreshed stale numbers (37 macros / 123 LOC / ~600 sites; 8,516→6,612 chrome LOC; 28-file / 80-case suite; 93-LOC test DSL).
- New **Beyond authoring: code as claims** section — identity-anchored claim-doc engine patches (CI-gated by `projector:test`, resilient to Mozilla's churn) as the shipped win; the Fram claim-graph projection as the honestly-flagged *direction* (relational call-graph queries still live in Chartroom/fram, not gjoa).
- README gains a one-line affordance callout linking the doc.

Written to the honesty boundary: patch-resilience claimed as shipped + CI-gated; relational graph claimed as direction, not done.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784551399&installation_id=141311834&pr_number=107&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F107&signature=7355d106a69f7b67778cb4eee61da765ca34eabaea7e48f039fd38680c2cbe11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->