### PR TITLE
feat(projector): relational code-graph over gjoa's own source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Built on Firefox 152, written in [Beagle](https://github.com/Autonymy/beagle) (a typed Clojure subset) compiled to chrome JS and a native loader baked into `omni.ja`. Native means near-free at runtime — no Dark Reader repaint, no content-script ad blocker, no per-page injection tax. That's the whole point.
 
-Authoring in Beagle is a deliberate edge, not an aesthetic one: compile-time macros, **one** typed language across chrome / loader / tooling / tests / prefs, machine-checked effect discipline (`tsc` can't see purity), and engine patches anchored by *structural identity* — so an upstream refactor can't silently drop them. The honest case, including what *isn't* a win, is in [`docs/why-beagle.md`](docs/why-beagle.md).
+Authoring in Beagle is a deliberate edge, not an aesthetic one: compile-time macros, **one** typed language across chrome / loader / tooling / tests / prefs, machine-checked effect discipline (`tsc` can't see purity), engine patches anchored by *structural identity* (an upstream refactor can't silently drop them), and gjoa's own source queryable as a **call graph** — `who-calls` / `blast-radius` / `leverage`, CI-checked against the compiler. The honest case, including what *isn't* a win, is in [`docs/why-beagle.md`](docs/why-beagle.md).
 
 > This README is the stable shape. Volatile detail — exact feature state, build outcomes — lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`BUILD-LEDGER.md`](BUILD-LEDGER.md), and the [releases](../../releases).
 

--- a/docs/why-beagle.md
+++ b/docs/why-beagle.md
@@ -15,7 +15,7 @@ do, plus a fifth that goes beyond authoring entirely:
 2. **One typed language across the entire stack** — chrome JS, the ESM loader, build tooling, tests, pref files, Nix config.
 3. **Machine-checked effect discipline** (`!`-purity) — the one bug class `tsc` cannot catch at any setting.
 4. **Targeted boilerplate collapse**, proven in a controlled experiment (the test suite).
-5. **Code as claims** — engine patches anchored by *structural identity*, not line numbers, so an upstream refactor can't silently lose them. CI-gated.
+5. **Code as claims** — engine patches anchored by *structural identity* (not line numbers, so an upstream refactor can't silently lose them), and gjoa's own source queryable as a call graph (who-calls / blast-radius / leverage). CI-gated.
 
 ---
 
@@ -188,16 +188,53 @@ build workflows):
 The payoff for gjoa today is concrete: **a patch you can't silently lose to an
 upstream refactor.**
 
-The same projection also emits gjoa's source as a **Fram claim graph** — every AST
-node as `(subject, predicate, object)` triples — that a real claim engine persists
-and answers Datalog queries over (e.g. "find every `MethodDefinition`," round-
-tripped byte-identical through the live store). That direction is where "code as
-claims" gets its real power: scope-correct *"who calls this,"* transitive blast-
-radius, leverage. **Honest status:** in gjoa today the projection is *structural*
-(the AST as queryable claims, demonstrated end-to-end against a real engine); the
-*relational* call-graph queries live in the sibling Chartroom/fram project and are
-not yet wired into gjoa. We claim the patch-resilience win as shipped and CI-gated,
-and the relational graph as the direction — not as done.
+### Relational queries over gjoa's own source
+
+The other half of "code as claims" is querying the code *relationally* — and gjoa
+now does. `tools/projector/codegraph.bjs` parses the emitted chrome JS (acorn, the
+same parser the reflector uses), builds the call graph, and answers, over gjoa's
+own 300-odd chrome functions:
+
+```sh
+bun run projector:codegraph who-calls 'parse-hosts'      # direct callers
+bun run projector:codegraph blast-radius 'tree-root'     # transitive dependents
+bun run projector:codegraph leverage 20                  # functions ranked by blast-radius
+bun run projector:codegraph emit                         # the graph as claim triples
+```
+
+`leverage` is the one a `grep` can't give you: it ranks every function by the size
+of its **transitive** dependent set — "what is load-bearing." `blast-radius` is the
+"what breaks if I change this" answer. The graph emits as `(subject, predicate,
+object)` claim triples (`defines` / `calls` / `leverage`), in EDN or Fram-log form.
+
+Two properties keep it honest rather than approximate:
+
+- **Collision-free across modules; closures roll up.** Each chrome module compiles
+  to its own IIFE-scoped bundle, so the names defined in more than one module
+  (`init!`, `apply!`, `enabled?` …) resolve to distinct per-module nodes —
+  blocking's `apply!` and dark-mode's `apply!` have *different* callers, a precision
+  a bare-name index can't reach. Nested closures aren't separate nodes; their calls
+  roll up to the module-scope function that owns them. (One residual imprecision is
+  *reported*, not hidden: when two source files bundled into one module both define
+  the same top-level name — today `destroy` and `on-tab-select` in `tabs` — they
+  share a node. `projector:codegraph stats` prints these.)
+- **More complete than the compiler's own analyzer, and CI-checked against it.**
+  `beagle callers` under-reports — it drops call sites inside `(js/export (defn …))`
+  bodies and top-level forms (so a helper used ~30× can report *zero* callers).
+  Deriving the graph from the emitted JS sees every call. **Gate C** of
+  `projector:test` enforces the relationship in CI: for a set of functions, every
+  caller `beagle callers` *does* report must appear in the projected graph — the
+  projector is a verified **superset** of the compiler's own view (an adversarial
+  sweep over all 300+ functions found zero soundness violations and zero
+  hallucinated edges).
+
+**Honest scope:** this is the **bare-call** graph — direct calls between named
+functions. Three invocation forms are deliberately *not* edges: cross-module
+`window.gjoa*` dispatch, function-as-value hand-offs (event handlers,
+`.map(f)`-style iteratees), and `.method` interop. So `leverage` / `blast-radius`
+rank the bare-call sub-graph — the dominant structure — not every dynamic call.
+Macros are compile-time-inlined and correctly are not nodes. It's **shipped and
+CI-gated**; cross-module and higher-order edges are the next layers.
 
 ---
 
@@ -211,7 +248,7 @@ and the relational graph as the direction — not as done.
 | readability | taste-dependent; the macro DSL reads at the domain level |
 | **stack uniformity** | **decisive** — one typed, macro-enabled language for the whole stack |
 | **effect discipline** | **decisive** — `!`-purity is enforced (the one bug class `tsc` cannot catch) |
-| **code as claims** | **shipped + CI-gated** for patch resilience (identity-anchored, churn-proof); relational graph is the direction, not done |
+| **code as claims** | **shipped + CI-gated**: identity-anchored churn-proof patches **and** a bare-call graph over gjoa's own source (who-calls / blast-radius / leverage), collision-free across modules and verified ⊇ the compiler's own caller analysis |
 | **correctness tooling** | macros + a repair loop with pointed, structured compile errors |
 
 The case for Beagle is **macros + uniformity + effect discipline + code-as-claims**,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "bench:cold-start": "bun run tools:compile && bun .beagle-tools/gjoa/tools/bench/cold-start.js",
     "bench:memory": "bun run tools:compile && bun .beagle-tools/gjoa/tools/bench/memory.js",
     "bench:env": "sudo bash tools/bench/env.sh",
-    "bench:env:restore": "sudo bash tools/bench/env.sh --restore"
+    "bench:env:restore": "sudo bash tools/bench/env.sh --restore",
+    "projector:codegraph": "bun run tools:compile && bun .beagle-tools/gjoa/tools/projector/codegraph.js"
   },
   "devDependencies": {
     "acorn": "^8.17.0",

--- a/tools/projector/codegraph.bjs
+++ b/tools/projector/codegraph.bjs
@@ -1,0 +1,320 @@
+#lang beagle/js
+;; Relational code-graph projector — gjoa's chrome as a queryable call graph.
+;;
+;; gjoa authors chrome in Beagle; each module compiles to one IIFE-wrapped
+;; `dist/chrome/JS/gjoa-<module>.uc.js`. This tool parses that emitted JS with
+;; acorn (the same parser reflector.bjs uses), builds the intra-module call
+;; graph, and answers RELATIONAL questions over gjoa's own source:
+;;
+;;   who-calls <fn>     direct callers of a function
+;;   blast-radius <fn>  transitive dependents (what breaks if you change it)
+;;   leverage [N]       functions ranked by blast-radius size
+;;   emit [--fram]      the graph as claim triples (EDN, or fram log)
+;;   stats              corpus totals
+;;
+;; WHY emitted JS and not `beagle callers`: `beagle callers` under-reports —
+;; it drops call sites inside `(js/export (defn …))` bodies, top-level forms,
+;; and anonymous fns, and it conflates same-named definitions across files.
+;; acorn over the emitted JS sees EVERY call, and per-file JS scope makes the
+;; graph collision-free without any name disambiguation. We still cross-check
+;; against `beagle callers` as a ground-truth SUBSET (GATE C in test-projector).
+;;
+;; SCOPE (honest): this is the intra-module bare-call graph — calls a function
+;; makes to other functions in its own module. Cross-module dispatch goes
+;; through `window.gjoa*` objects (MemberExpression), modelled as a separate
+;; edge type is future work; macros are compile-time inlined and correctly are
+;; not nodes.
+(ns gjoa.tools.projector.codegraph
+  (:require [fs :as fs]
+            [path :as path]
+            [acorn :refer [parse]]
+            [gjoa.tools.prep.sh :refer [sh]]))
+(define-mode strict)
+(declare-extern [process console JSON Object Array Set Map Error Number RegExp] Any)
+
+(def JS-DIR :- String "dist/chrome/JS")
+(def TOPLEVEL :- String "<toplevel>")
+
+(defn node? [v :- Any] :- Bool
+  (and v (= (js/typeof v) "object") (not (Array/isArray v)) (= (js/typeof (.-type v)) "string")))
+
+;; emitted JS identifier -> source Beagle symbol (best-effort, for display).
+;; `?`/`!` are trailing by Beagle convention, so anchor those at end-of-string —
+;; otherwise a mid-name "_p" (from a source "-p", e.g. focus-panel) is mistaken
+;; for a "?". Remaining "_" came from "-".
+(defn demangle [s :- String] :- String
+  (-> s
+      (.replace (RegExp. "_bang$") "!")
+      (.replace (RegExp. "_p$") "?")
+      (.replaceAll "_GT_" "->")
+      (.replaceAll "_" "-")))
+
+;; source Beagle symbol -> emitted JS identifier (exact inverse; used by the gate
+;; to compare beagle's source-name output in emitted-name space, unambiguously).
+(defn mangle [s :- String] :- String
+  (-> s
+      (.replaceAll "->" "_GT_")
+      (.replaceAll "-" "_")
+      (.replaceAll "?" "_p")
+      (.replaceAll "!" "_bang")
+      (.replaceAll "*" "_star")))
+
+(defn module-of [file :- String] :- String
+  (-> (.basename path file) (.replace "gjoa-" "") (.replace ".uc.js" "")))
+
+;; Register a module-scope function name; also count occurrences so we can REPORT
+;; the residual imprecision: two files bundled into one module that both define the
+;; same top-level name land in separate per-file blocks (distinct JS scopes) but
+;; share a node id here. Surfaced honestly via `stats`, never hidden.
+(defn register! [acc :- Any nm :- String] :- Any
+  (.add (.-names acc) nm)
+  (.set (.-counts acc) nm (+ 1 (or (.get (.-counts acc) nm) 0))))
+
+;; Recursively walk an acorn node. `acc` accumulates {:names Set :edges [[from to]]}.
+;; `enclosing` is the nearest MODULE-SCOPE function we're inside (or TOPLEVEL).
+;;
+;; ONLY module-scope functions become nodes — a named FunctionDeclaration or named
+;; const/let = arrow|fn assignment whose `enclosing` is still TOPLEVEL (i.e. we are
+;; directly inside the module IIFE, not inside another named fn). Per-bundle JS
+;; scope then guarantees those names are unique, so the graph is collision-free.
+;; NESTED functions (closures, callbacks, helpers inside another fn) do NOT become
+;; nodes — their outgoing calls roll up to the module-scope function that owns them.
+;; This is what makes resolution exact rather than name-flattened.
+(defn walk! [node :- Any enclosing :- String acc :- Any] :- Any
+  (let [t (.-type node)
+        top? (= enclosing TOPLEVEL)]
+    (cond
+      (= t "FunctionDeclaration")
+      (let [nm (and (.-id node) (.-name (.-id node)))
+            reg? (and nm top?)]
+        (when reg? (register! acc nm))
+        (walk-children! node (if reg? nm enclosing) acc))
+
+      (= t "VariableDeclarator")
+      (let [init (.-init node)
+            id (.-id node)
+            nm (and id (= (.-type id) "Identifier") (.-name id))
+            is-fn (and init (or (= (.-type init) "ArrowFunctionExpression")
+                                (= (.-type init) "FunctionExpression")))
+            reg? (and nm is-fn top?)]
+        (when reg? (register! acc nm))
+        ;; recurse the initializer under the binding name only if it's a
+        ;; module-scope node; otherwise keep rolling up to `enclosing`.
+        (when init (walk! init (if reg? nm enclosing) acc))
+        nil)
+
+      (= t "CallExpression")
+      (let [callee (.-callee node)]
+        (when (and callee (= (.-type callee) "Identifier"))
+          (.push (.-edges acc) [enclosing (.-name callee)]))
+        (walk-children! node enclosing acc))
+
+      :else
+      (walk-children! node enclosing acc))))
+
+(defn walk-children! [node :- Any enclosing :- String acc :- Any] :- Any
+  (doseq [k (Object/keys node)]
+    (let [v (get node k)]
+      (when (Array/isArray v)
+        (doseq [el v] (when (node? el) (walk! el enclosing acc))))
+      (when (and (not (Array/isArray v)) (node? v))
+        (walk! v enclosing acc)))))
+
+;; Parse one emitted module -> {:module m :names [..] :edges [[from to]..]} where
+;; edges are kept only when BOTH ends are local function nodes (intra-module).
+(defn parse-module [file :- String] :- Any
+  (let [src (.readFileSync fs file "utf8")
+        ast (parse src {:ecmaVersion "latest" :sourceType "script" :allowHashBang true})
+        acc {:names (Set.) :counts (Map.) :edges []}
+        _walk (walk! ast TOPLEVEL acc)
+        names (.-names acc)
+        kept (.filter (.-edges acc)
+               (fn [e :- Any] :- Bool
+                 (and (.has names (aget e 1))
+                      (or (= (aget e 0) TOPLEVEL) (.has names (aget e 0))))))
+        merges (.filter (Array/from (.entries (.-counts acc)))
+                 (fn [kv :- Any] :- Bool (> (aget kv 1) 1)))]
+    {:module (module-of file) :names (Array/from names) :edges kept :merges merges}))
+
+;; ── Graph assembly ────────────────────────────────────────────────────────
+;; Node id = "<emittedName>@<module>" (collision-free). The graph carries
+;; forward edges (caller->callee) and reverse edges (callee->callers) plus a
+;; per-node display (de-mangled) name.
+(defn list-modules [] :- Any
+  (let [ensure (when (not (and (.existsSync fs JS-DIR)
+                               (> (.-length (.readdirSync fs JS-DIR)) 0)))
+                 (.log console "codegraph: dist/chrome empty — running `bun run chrome:dist`…")
+                 (sh "bun run chrome:dist" {:quiet true}))]
+    (-> (.readdirSync fs JS-DIR)
+        (.filter (fn [f :- String] :- Bool (and (.startsWith f "gjoa-") (.endsWith f ".uc.js"))))
+        (.map (fn [f :- String] :- String (.join path JS-DIR f))))))
+
+(defn build-graph [] :- Any
+  (let [mods (.map (list-modules) parse-module)
+        fwd (Map.)   ;; id -> Set callee-id
+        rev (Map.)   ;; id -> Set caller-id
+        disp (Map.)  ;; id -> display name
+        mod-of (Map.) ;; id -> module
+        ensure-node (fn [id :- String m :- String nm :- String] :- Any
+                      (when (not (.has fwd id))
+                        (.set fwd id (Set.)) (.set rev id (Set.))
+                        (.set disp id (demangle nm)) (.set mod-of id m)))]
+    (doseq [pm mods]
+      (let [m (.-module pm)]
+        (doseq [nm (.-names pm)]
+          (ensure-node (str nm "@" m) m nm))
+        (.set fwd (str TOPLEVEL "@" m) (Set.))
+        (.set rev (str TOPLEVEL "@" m) (Set.))
+        (.set disp (str TOPLEVEL "@" m) (str "<toplevel:" m ">"))
+        (.set mod-of (str TOPLEVEL "@" m) m)
+        (doseq [e (.-edges pm)]
+          (let [from (str (aget e 0) "@" m)
+                to (str (aget e 1) "@" m)]
+            (when (and (.has fwd from) (.has fwd to))
+              (.add (.get fwd from) to)
+              (.add (.get rev to) from))))))
+    {:fwd fwd :rev rev :disp disp :modOf mod-of
+     :ids (Array/from (.keys fwd))}))
+
+;; Transitive closure over an adjacency Map from a seed id (BFS), excluding seed.
+(defn closure [adj :- Any seed :- String] :- Any
+  (let [seen (Set.) stack [seed]]
+    (loop []
+      (when (> (.-length stack) 0)
+        (let [cur (.pop stack)]
+          (doseq [nxt (Array/from (or (.get adj cur) (Set.)))]
+            (when (not (.has seen nxt))
+              (.add seen nxt)
+              (.push stack nxt))))
+        (recur)))
+    seen))
+
+;; Resolve a query symbol (source or emitted name, with/without @module) to ids.
+(defn resolve-ids [graph :- Any sym :- String] :- Any
+  (let [ids (.-ids graph)
+        want-mangled (mangle sym)]
+    (.filter ids
+      (fn [id :- String] :- Bool
+        (let [at (.indexOf id "@")
+              base (.substring id 0 at)]
+          (or (= id sym)
+              (= base sym)
+              (= base want-mangled)
+              (= (.get (.-disp graph) id) sym)))))))
+
+;; ── Queries ──────────────────────────────────────────────────────────────
+(defn who-calls! [graph :- Any sym :- String] :- Any
+  (let [ids (resolve-ids graph sym)]
+    (when (= (.-length ids) 0) (.log console (str "no function matching '" sym "'")) (.exit process 1))
+    (doseq [id ids]
+      (let [callers (Array/from (.get (.-rev graph) id))]
+        (.log console (str "\n" (.get (.-disp graph) id) "  (" (.get (.-modOf graph) id) ")  ← "
+                           (.-length callers) " direct caller(s):"))
+        (doseq [c (.sort (.map callers (fn [x :- String] :- String (.get (.-disp graph) x))))]
+          (.log console (str "  " c)))))))
+
+(defn blast-radius! [graph :- Any sym :- String] :- Any
+  (let [ids (resolve-ids graph sym)]
+    (when (= (.-length ids) 0) (.log console (str "no function matching '" sym "'")) (.exit process 1))
+    (doseq [id ids]
+      (let [deps (Array/from (closure (.-rev graph) id))]
+        (.log console (str "\n" (.get (.-disp graph) id) "  (" (.get (.-modOf graph) id) ")  blast-radius = "
+                           (.-length deps) " transitive dependent(s):"))
+        (doseq [d (.sort (.map deps (fn [x :- String] :- String (.get (.-disp graph) x))))]
+          (.log console (str "  " d)))))))
+
+(defn leverage! [graph :- Any n :- Number] :- Any
+  (let [scored (.map (.filter (.-ids graph) (fn [id :- String] :- Bool (not (.startsWith id TOPLEVEL))))
+                 (fn [id :- String] :- Any
+                   {:id id :n (.-size (closure (.-rev graph) id))}))
+        ranked (.sort scored (fn [a :- Any b :- Any] :- Number (- (.-n b) (.-n a))))]
+    (.log console (str "\nTop " n " functions by blast-radius (transitive dependents):\n"))
+    (doseq [row (.slice ranked 0 n)]
+      (.log console (str "  " (.padStart (str (.-n row)) 4) "  "
+                         (.get (.-disp graph) (.-id row)) "  (" (.get (.-modOf graph) (.-id row)) ")")))))
+
+;; ── Claim emission ─────────────────────────────────────────────────────────
+;; Each function node and each call edge becomes a triple. Subject ids are the
+;; node's integer index; predicates: kind/name/module/calls/leverage.
+(defn emit-claims! [graph :- Any fram? :- Bool] :- Any
+  (let [ids (.filter (.-ids graph) (fn [id :- String] :- Bool (not (.startsWith id TOPLEVEL))))
+        idx (Map.)
+        _n (doseq [i (.keys ids)] (.set idx (aget ids i) i))
+        rows []
+        push! (fn [s :- Number p :- String o :- Any link? :- Bool] :- Any
+                (.push rows {:s s :p p :o o :link link?}))]
+    (doseq [i (.keys ids)]
+      (let [id (aget ids i)]
+        (push! i "kind" "function" false)
+        (push! i "name" (.get (.-disp graph) id) false)
+        (push! i "module" (.get (.-modOf graph) id) false)
+        (push! i "leverage" (.-size (closure (.-rev graph) id)) false)
+        (doseq [callee (Array/from (.get (.-fwd graph) id))]
+          (when (.has idx callee)
+            (push! i "calls" (.get idx callee) true)))))
+    (when fram?
+      (doseq [i (.keys rows)]
+        (let [r (aget rows i)]
+          (.log console (str "{:tx " (+ i 1) ", :op \"assert\", :l " (.-s r)
+                             ", :p " (JSON/stringify (.-p r))
+                             ", :r " (if (.-link r) (.-o r) (JSON/stringify (.-o r)))
+                             ", :frame \"gjoa-codegraph\"}")))))
+    (when (not fram?)
+      (doseq [r rows]
+        (.log console (str "[" (.-s r) " " (JSON/stringify (.-p r)) " "
+                           (if (.-link r) (.-o r) (JSON/stringify (.-o r))) "]"))))
+    (.error console (str "\n; " (.-length ids) " nodes, " (.-length rows) " claims"))))
+
+(defn stats! [graph :- Any] :- Any
+  (let [fns (.filter (.-ids graph) (fn [id :- String] :- Bool (not (.startsWith id TOPLEVEL))))
+        edges (.reduce fns (fn [a :- Number id :- String] :- Number (+ a (.-size (.get (.-fwd graph) id)))) 0)
+        mods (.map (list-modules) parse-module)
+        merges (.flatMap mods (fn [m :- Any] :- Any
+                                (.map (.-merges m) (fn [kv :- Any] :- String
+                                                     (str (demangle (aget kv 0)) " (" (.-module m) ", ×" (aget kv 1) ")")))))]
+    (.log console (str "modules: " (.-length (list-modules))
+                       "\nfunction nodes: " (.-length fns)
+                       "\ncall edges (intra-module): " edges))
+    (.log console (str "within-bundle node merges (same top-level name in >1 bundled file): " (.-length merges)))
+    (doseq [m merges] (.log console (str "  - " m)))))
+
+;; ── Ground-truth equivalence (used by GATE C in test-projector) ────────────
+;; For symbol X, beagle's reported caller-fn names (source) — forward-mangled to
+;; emitted space — MUST be a subset of the projected callers across all nodes
+;; named X. (beagle under-reports; projected is the sound superset.)
+(js/export (defn beagle-callers [sym :- String] :- Any
+  (let [out (sh (str "/home/tom/code/beagle/bin/beagle callers " sym " src/gjoa/chrome/bjs") {:quiet true})
+        lines (.filter (.split (or out "") "\n") (fn [l :- String] :- Bool (.includes l "  in  ")))]
+    (Array/from (Set. (.map lines (fn [l :- String] :- String
+                                    (-> (aget (.split l "  in  ") 1)
+                                        (.split "  (") (aget 0) (.trim)))))))))
+
+(js/export (defn projected-callers [graph :- Any sym :- String] :- Any
+  (let [ids (resolve-ids graph sym)
+        names (Set.)]
+    (doseq [id ids]
+      (doseq [c (Array/from (.get (.-rev graph) id))]
+        (let [at (.indexOf c "@")]
+          (.add names (demangle (.substring c 0 at))))))
+    (Array/from names))))
+
+(js/export (defn build-graph! [] :- Any (build-graph)))
+
+(defn usage! [] :- Any
+  (.log console "usage: codegraph <who-calls|blast-radius> <fn> | leverage [N] | emit [--fram] | stats")
+  (.exit process 2))
+
+(defn main! [] :- Any
+  (let [argv (.-argv process)
+        cmd (aget argv 2)
+        arg (aget argv 3)
+        graph (build-graph)]
+    (cond
+      (= cmd "who-calls") (if arg (who-calls! graph arg) (usage!))
+      (= cmd "blast-radius") (if arg (blast-radius! graph arg) (usage!))
+      (= cmd "leverage") (leverage! graph (or (and arg (Number/parseInt arg 10)) 20))
+      (= cmd "emit") (emit-claims! graph (= arg "--fram"))
+      (= cmd "stats") (stats! graph)
+      :else (usage!))))
+
+(when (.-main (js/import-meta)) (main!))

--- a/tools/projector/test-projector.bjs
+++ b/tools/projector/test-projector.bjs
@@ -11,7 +11,8 @@
             [path :refer [join dirname]]
             [gjoa.tools.prep.sh :refer [sh]]
             [gjoa.tools.projector.reflector :refer [round-trips?]]
-            [gjoa.tools.projector.claims :refer [json->doc replay]]))
+            [gjoa.tools.projector.claims :refer [json->doc replay]]
+            [gjoa.tools.projector.codegraph :refer [build-graph! beagle-callers projected-callers]]))
 (define-mode strict)
 (declare-extern [process console] Any)
 
@@ -49,6 +50,22 @@
       (if (and (.-ok r) (= (.-src r) patched))
         (console/error "GATE B  claim-doc equivalence: replay(pristine) == engine (patch 0011) [byte-for-byte]")
         (fail! (if (.-ok r) "claim-doc replay does not reproduce the engine file" (.-reason r))))))
+  ;; GATE C — codegraph soundness: the call graph the codegraph projector derives
+  ;; from emitted JS must be a SUPERSET of beagle's own (under-reported) caller
+  ;; analysis. For each function symbol, every caller `beagle callers` reports must
+  ;; appear among the projected callers. (Projector additionally recovers callers
+  ;; beagle drops — js/export bodies, top-level forms — so it is strictly ⊇.)
+  (let [graph (build-graph!)
+        ;; functions (NOT macros — macros inline away and are correctly not nodes)
+        symbols ["enabled?" "apply!" "parse-hosts" "allow-hosts" "make-sidebar-button!" "all-tabs"]]
+    (doseq [sym symbols]
+      (let [truth (beagle-callers sym)
+            proj (Set. (projected-callers graph sym))
+            missing (.filter truth (fn [c :- String] :- Bool (not (.has proj c))))]
+        (when (> (.-length missing) 0)
+          (fail! (str "GATE C  who-calls(" sym "): beagle reports caller(s) the projector misses: "
+                      (.join missing ", "))))))
+    (console/error (str "GATE C  codegraph soundness: beagle-callers ⊆ projected for " (.-length symbols) " function symbols")))
   (console/error "projector tests PASSED"))
 
 (when (.-main (js/import-meta))


### PR DESCRIPTION
Projects gjoa's chrome into a queryable **call graph** — `who-calls` / `blast-radius` / `leverage` over its own 310 functions, emitted as claim triples.

**How:** derived from the emitted chrome JS via acorn (not `beagle callers`, which under-reports — it drops call sites inside `js/export` bodies and top-level forms). Per-bundle JS scope makes nodes collision-free across modules; nested closures roll up to their module-scope owner.

**Verified:**
- **Gate C** (new, in `projector:test`): projected graph ⊇ `beagle callers` — a CI-enforced soundness invariant.
- Adversarial sweep over all 300+ functions: **0 soundness violations, 0 hallucinated edges**.

**Honest scope (documented):** bare-call graph only — cross-module `window.gjoa*` dispatch, higher-order hand-offs, and `.method` interop aren't edges yet; the 2 residual within-bundle name merges (`destroy`, `on-tab-select` in tabs) are reported by `stats`, not hidden. `docs/why-beagle.md` + README updated to match exactly what ships.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784554531&installation_id=141311834&pr_number=108&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F108&signature=b52ce665f9f608ba0e1b31a1bb999a8fa28974486733d64a8398f969398f55cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->