### PR TITLE
feat(knobs): preflight Gate N + real egress costs + PROFILES↔registry sync

### DIFF
--- a/src/gjoa/browser/components/gjoa/content/settings/registry.json
+++ b/src/gjoa/browser/components/gjoa/content/settings/registry.json
@@ -1,9 +1,19 @@
 {
-  "note": "The about:gjoa settings registry. gjoa's single settings home. Each setting is a live pref (present + reversible). Costs are MEASURED or honestly 'unmeasured' — never invented. Firefox's own settings stay in Firefox Settings; this is gjoa's surface.",
+  "note": "The about:gjoa settings registry. gjoa's single settings home. Each setting is a live pref (present + reversible). Costs are MEASURED, characterized as real EGRESS endpoints, or honestly 'unmeasured' — never invented. The `leaves` of a profile are the exact prefs it flips, kept in sync with GjoaLoader's PROFILES by preflight Gate N. Firefox's own settings stay in Firefox Settings; this is gjoa's surface.",
   "profiles": [
     { "id": "librewolf-mode", "pref": "gjoa.profile.librewolf-mode.enabled", "type": "bool", "title": "LibreWolf mode",
       "claim": "LibreWolf-grade privacy DEFAULTS, as one toggle.",
       "disclaimer": "NOT 'as secure as LibreWolf'. These prefs are only part of LibreWolf's hardening (their compile-time disables and ~20 C++ patches are not here), and flipping this changes none of gjoa's own added surface (the adblock classifier, content actors, custom about: pages).",
+      "leaves": [
+        { "pref": "privacy.resistFingerprinting", "on": true, "off": false, "type": "bool" },
+        { "pref": "privacy.resistFingerprinting.letterboxing", "on": true, "off": false, "type": "bool" },
+        { "pref": "network.http.referer.XOriginPolicy", "on": 2, "off": 0, "type": "int" },
+        { "pref": "network.http.referer.XOriginTrimmingPolicy", "on": 2, "off": 0, "type": "int" },
+        { "pref": "browser.search.suggest.enabled", "on": false, "off": true, "type": "bool" },
+        { "pref": "browser.urlbar.suggest.searches", "on": false, "off": true, "type": "bool" },
+        { "pref": "extensions.update.enabled", "on": false, "off": true, "type": "bool" },
+        { "pref": "privacy.donottrackheader.enabled", "on": true, "off": false, "type": "bool" }
+      ],
       "tradeoffs": [
         { "title": "resistFingerprinting has a high UX cost", "detail": "Breaks canvas-reliant sites, letterboxes the window, reports UTC timezone + a generic UA. Default-off for a reason; on only inside this profile." },
         { "title": "Safe Browsing stays ON (conflict, not flipped)", "detail": "LibreWolf neuters Safe Browsing, but gjoa deliberately KEPT download-reputation on (security finding F5). LibreWolf mode does NOT disable it here — the conflict is surfaced, not silently resolved." },
@@ -22,27 +32,29 @@
     { "id": "content-blocking", "title": "Content blocking", "intro": "Native (adblock-rust) ad + tracker blocking.",
       "settings": [
         { "pref": "gjoa.contentblock.enabled", "type": "bool", "title": "Ad / tracker blocking", "default": true },
+        { "pref": "gjoa.contentblock.user.allow-hosts", "type": "string", "title": "Allow-list (hosts)", "default": "",
+          "help": "Comma-separated hosts to exempt from blocking (your own allow-list). Empty = block everywhere." },
         { "pref": "gjoa.contentblock.scriptlets.listDriven.enabled", "type": "bool", "title": "List-driven scriptlets", "default": false,
           "help": "SECURITY: off = only curated baseline scriptlets run; on allows arbitrary +js() injection from your filter lists. Leave off unless you trust your lists.",
           "measurement": { "method": "cve-surface", "confidence": "moderate", "basis": "A security gate (finding F2), not a perf knob." } }
       ] },
     { "id": "reversible", "title": "Reversible features (debloat)",
-      "intro": "Firefox subsystems gjoa disables by default - present and reversible. gjoa never deletes a capability; it parks it behind a knob. Costs are measured against a real gjoa binary, or honestly marked unmeasured.",
+      "intro": "Firefox subsystems gjoa disables by default - present and reversible. gjoa never deletes a capability; it parks it behind a knob. These are EGRESS/feature toggles, not memory knobs - so the honest cost is the network endpoint each would re-contact if you toggle it on (documented Firefox behaviour), not an invented perf number. Idle-memory deltas remain unmeasured; they are not the relevant axis here.",
       "settings": [
         { "pref": "toolkit.telemetry.enabled", "type": "bool", "title": "Telemetry", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Memory/CPU saving unmeasured on a gjoa binary. Measure: enable in a control build, about:memory at idle+30s, disable, recapture, report delta + date." } },
+          "measurement": { "method": "egress", "endpoint": "incoming.telemetry.mozilla.org", "confidence": "documented", "basis": "Firefox submits telemetry pings to incoming.telemetry.mozilla.org. Off in gjoa, so it never fires; toggling on re-enables that egress. Idle CPU/memory of the telemetry subsystem is unmeasured (not the relevant cost)." } },
         { "pref": "datareporting.healthreport.uploadEnabled", "type": "bool", "title": "Health Report upload", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Egress feature; cost is the data sent, not memory. Unmeasured." } },
+          "measurement": { "method": "egress", "endpoint": "incoming.telemetry.mozilla.org", "confidence": "documented", "basis": "Firefox Health Report uploads to incoming.telemetry.mozilla.org. The cost is the data sent, not memory." } },
         { "pref": "extensions.pocket.enabled", "type": "bool", "title": "Pocket", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Measure on a baseline where Pocket is ENABLED - no saving exists for a feature that was never running." } },
+          "measurement": { "method": "egress", "endpoint": "spocs.getpocket.com, getpocket.cdn.mozilla.net", "confidence": "documented", "basis": "Pocket fetches recommendations/sponsored content from getpocket endpoints (surfaced on the stock new-tab, which gjoa replaces anyway). Feature toggle; no saving exists for a feature that was never running." } },
         { "pref": "identity.fxaccounts.enabled", "type": "bool", "title": "Firefox Accounts (Sync)", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Disables Sync. Feature loss, not a measured perf win." } },
+          "measurement": { "method": "feature", "endpoint": "accounts.firefox.com", "confidence": "documented", "basis": "Disables Sync (accounts.firefox.com). Feature loss, not a measured perf win - egress only occurs if you actively sign in." } },
         { "pref": "browser.discovery.enabled", "type": "bool", "title": "Add-on discovery (TAAR)", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Egress (recommendation service). Memory cost unmeasured." } },
+          "measurement": { "method": "egress", "endpoint": "services.addons.mozilla.org", "confidence": "documented", "basis": "The add-ons recommendation service (TAAR) sends usage signals to services.addons.mozilla.org. Egress vector; memory cost unmeasured." } },
         { "pref": "app.normandy.enabled", "type": "bool", "title": "Normandy remote experiments", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Remote experiment delivery; egress vector. Memory cost unmeasured." } },
+          "measurement": { "method": "egress", "endpoint": "normandy.cdn.mozilla.net", "confidence": "documented", "basis": "Normandy pulls remote experiment/recipe definitions from normandy.cdn.mozilla.net and can flip prefs remotely. Disabling it removes both that egress and remote mutation of your build." } },
         { "pref": "browser.contile.enabled", "type": "bool", "title": "Sponsored top sites (Contile)", "default": false, "firefoxDefault": true,
-          "measurement": { "method": "unmeasured", "confidence": "unmeasured", "basis": "Egress to contile.services.mozilla.com. No functional cost (custom new-tab). Memory unmeasured." } }
+          "measurement": { "method": "egress", "endpoint": "contile.services.mozilla.com", "confidence": "documented", "basis": "Sponsored-tile placement is fetched from contile.services.mozilla.com. No functional cost (custom new-tab); the cost is the egress." } }
       ] }
   ],
   "links": [

--- a/src/gjoa/browser/components/gjoa/content/settings/settings.css
+++ b/src/gjoa/browser/components/gjoa/content/settings/settings.css
@@ -108,3 +108,21 @@ html, body {
 .link-desc { color: var(--muted); font-size: 12.5px; margin-top: 3px; }
 
 .foot { margin-top: 36px; color: var(--faint); font-size: 11.5px; }
+
+/* string control (e.g. content-blocking allow-list) */
+.control-text {
+  background: var(--bg); color: var(--ink); border: 1px solid var(--line);
+  border-radius: 6px; padding: 6px 8px; font-size: 13px; min-width: 220px;
+}
+.control-text:focus { outline: none; border-color: var(--accent); }
+
+/* profile "Flips N preferences" disclosure */
+.leaves { margin-top: 10px; }
+.leaves-sum {
+  color: var(--muted); font-size: 12.5px; cursor: pointer; user-select: none;
+}
+.leaves-sum:hover { color: var(--accent); }
+.leaves-list { margin: 8px 0 0; padding-left: 16px; list-style: none; }
+.leaf { font-size: 12px; padding: 2px 0; }
+.leaf-pref { color: var(--faint); font-family: monospace; }
+.leaf-val { color: var(--ok); }

--- a/src/gjoa/browser/components/gjoa/content/settings/settings.js
+++ b/src/gjoa/browser/components/gjoa/content/settings/settings.js
@@ -62,15 +62,23 @@
       inp.addEventListener("change", () => { setInt(s.pref, parseInt(inp.value, 10)); rerender(); });
       return inp;
     }
-    // string / other: read-only, edit via about:config
+    if (s.type === "string") {
+      const inp = document.createElement("input");
+      inp.type = "text"; inp.className = "control-text"; inp.value = String(cur);
+      if (s.placeholder) inp.placeholder = s.placeholder;
+      inp.addEventListener("change", () => { setStr(s.pref, inp.value); rerender(); });
+      return inp;
+    }
+    // other: read-only, edit via about:config
     return el("span", "control-ro", String(cur));
   }
 
   function costText(m) {
     if (!m) return "";
-    if (m.method === "unmeasured" || m.value == null) {
-      return "cost: unmeasured" + (m.method && m.method !== "unmeasured" ? " (" + m.method + ")" : "");
-    }
+    if (m.method === "egress") return "cost: egress → " + (m.endpoint || "?");
+    if (m.method === "feature") return "cost: feature toggle" + (m.endpoint ? " (" + m.endpoint + ")" : "");
+    if (m.method === "cve-surface") return "security gate — not a perf knob";
+    if (m.method === "unmeasured" || m.value == null) return "cost: unmeasured";
     return "cost: " + m.value + " " + (m.unit || "") + " (" + (m.confidence || "") + ")";
   }
 
@@ -79,7 +87,11 @@
     const main = el("div", "row-main");
     main.appendChild(el("div", "row-title", s.title));
     if (s.help) main.appendChild(el("div", "row-help", s.help));
-    if (s.measurement) main.appendChild(el("div", "row-cost", costText(s.measurement)));
+    if (s.measurement) {
+      const cost = el("div", "row-cost", costText(s.measurement));
+      if (s.measurement.basis) cost.title = s.measurement.basis;
+      main.appendChild(cost);
+    }
     const pref = el("a", "row-pref");
     pref.textContent = s.pref;
     pref.href = "about:config";
@@ -112,6 +124,20 @@
           ul.appendChild(li);
         }
         card.appendChild(ul);
+      }
+      if (p.leaves && p.leaves.length) {
+        const det = document.createElement("details");
+        det.className = "leaves";
+        det.appendChild(el("summary", "leaves-sum", "Flips " + p.leaves.length + " preferences"));
+        const ul = el("ul", "leaves-list");
+        for (const lf of p.leaves) {
+          const li = el("li", "leaf");
+          li.appendChild(el("span", "leaf-pref", lf.pref));
+          li.appendChild(el("span", "leaf-val", " → " + lf.on));
+          ul.appendChild(li);
+        }
+        det.appendChild(ul);
+        card.appendChild(det);
       }
       root.appendChild(card);
     }

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -14,7 +14,7 @@
             [path :refer [join basename]]
             [gjoa.tools.prep.symbol-resolve :refer [check-contract]]))
 (define-mode strict)
-(declare-extern [process] Any)
+(declare-extern [process JSON RegExp] Any)
 
 ;; The old .ts used `resolve(import.meta.dir, "..", "..")` to climb from
 ;; tools/scripts/ to the repo root. There is no import.meta in beagle, and
@@ -420,6 +420,66 @@
                 (str "../beagle HEAD " (.slice actual 0 12) " != pinned " (.slice pinned 0 12)
                      " — compiling against a different beagle than pinned; bump configs/beagle.ref deliberately (review the beagle changelog) or checkout the pin"))))))
 
+;; ── Gate N: knobs backed + reversible (knob-not-delete) ────────────────────
+;; Every knob about:gjoa exposes (settings/registry.json) must be backed by a pref
+;; actually SET in source. A dangling knob — whose feature was deleted but whose
+;; toggle remains — is a no-op that lies to the user; this gate makes that deletion
+;; impossible to ship silently (restore the pref, reversibly, or remove the knob).
+;; Also asserts registry's librewolf-mode `leaves` == GjoaLoader's PROFILES leaves,
+;; so the "Flips N preferences" the page shows is exactly what the loader applies.
+(def REGISTRY-FILE :- String
+  (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "content" "settings" "registry.json"))
+(def LOADER-FILE :- String
+  (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "GjoaLoader.bjs"))
+(def PREF-DIR :- String (join REPO-ROOT "src" "gjoa" "defaults" "pref"))
+
+(defn quoted-strings [s :- String] :- Any
+  (let [m (.match s (RegExp. "\"[^\"]+\"" "g"))]
+    (if m (.map m (fn [q :- String] :- String (.slice q 1 -1))) [])))
+
+(defn profiles-leaf-prefs [loader :- String] :- Any
+  ;; the PROFILES def's leaf pref-names: every quoted string in the block except
+  ;; the type tags and the profile meta-pref.
+  (let [start (.indexOf loader "(def PROFILES")
+        end (.indexOf loader "(defn apply-profile!")
+        block (if (and (>= start 0) (> end start)) (.slice loader start end) "")]
+    (.filter (quoted-strings block)
+      (fn [q :- String] :- Bool
+        (and (not (= q "bool")) (not (= q "int")) (not (= q "string"))
+             (not (.startsWith q "gjoa.profile.")))))))
+
+(defn gateN [] :- Any
+  (if (not (and (existsSync REGISTRY-FILE) (existsSync LOADER-FILE) (existsSync PREF-DIR)))
+    (warn "N" "knobs backed + reversible (knob-not-delete)"
+      "no about:gjoa registry/loader/prefs — skipping")
+    (let [reg (JSON/parse (readFileSync REGISTRY-FILE "utf8"))
+          loader (readFileSync LOADER-FILE "utf8")
+          pref-src (.join (.map (.filter (readdirSync PREF-DIR) (fn [f :- String] :- Bool (.endsWith f ".bjs")))
+                                (fn [f :- String] :- String (readFileSync (join PREF-DIR f) "utf8"))) "\n")
+          src (str pref-src "\n" loader)
+          knob-prefs []
+          _p (doseq [p (or (.-profiles reg) [])]
+               (.push knob-prefs (.-pref p))
+               (doseq [lf (or (.-leaves p) [])] (.push knob-prefs (.-pref lf))))
+          _s (doseq [sec (or (.-sections reg) [])]
+               (doseq [s (or (.-settings sec) [])] (.push knob-prefs (.-pref s))))
+          dangling (.filter knob-prefs (fn [pf :- String] :- Bool (not (.includes src (str "\"" pf "\"")))))
+          reg-lw (.find (or (.-profiles reg) []) (fn [p :- Any] :- Bool (= (.-id p) "librewolf-mode")))
+          reg-leaves (.sort (.map (or (and reg-lw (.-leaves reg-lw)) []) (fn [lf :- Any] :- String (.-pref lf))))
+          prof-leaves (.sort (profiles-leaf-prefs loader))]
+      (cond
+        (> (.-length dangling) 0)
+        (fail "N" "knobs backed + reversible (knob-not-delete)"
+          (str (.-length dangling) " knob(s) reference a pref set nowhere in source")
+          (str "a feature was deleted but its knob remains (or a typo) — restore the pref (reversible!) or drop the knob:\n    " (.join dangling "\n    ")))
+        (not (= (.join reg-leaves "|") (.join prof-leaves "|")))
+        (fail "N" "knobs backed + reversible (knob-not-delete)"
+          "librewolf-mode leaves in registry.json != GjoaLoader PROFILES"
+          (str "the page would misrepresent what the profile flips — sync them.\n    registry: " (.join reg-leaves ", ") "\n    PROFILES: " (.join prof-leaves ", ")))
+        :else
+        (pass "N" "knobs backed + reversible (knob-not-delete)"
+          (str (.-length knob-prefs) " knobs backed by real prefs; librewolf-mode leaves (" (.-length prof-leaves) ") in sync"))))))
+
 ;; ── Run + render ──────────────────────────────────────────────────────────
 (defn main! [] :- Any
   (console/log (bold "gjoa preflight"))
@@ -428,7 +488,8 @@
 
   (let [gates [["A" gateA] ["B" gateB] ["C" gateC] ["D" gateD]
                ["E" gateE] ["F" gateF] ["G" gateG] ["H" gateH]
-               ["I" gateI] ["J" gateJ] ["K" gateK] ["L" gateL] ["M" gateM]]]
+               ["I" gateI] ["J" gateJ] ["K" gateK] ["L" gateL] ["M" gateM]
+               ["N" gateN]]]
     (doseq [gate gates]
       (let [fn (aget gate 1)]
         (try (fn)


### PR DESCRIPTION
Closes the #83 knobs follow-ons (#84):

- **Gate N (knob-not-delete)** — every about:gjoa knob must be backed by a pref set in source (dangling knob = a no-op that lies); also enforces registry librewolf-mode `leaves` == GjoaLoader `PROFILES`. Passes: 24 knobs backed, 8 leaves in sync.
- **Real cost characterization** — the debloat knobs are egress/feature toggles, so each carries its documented Firefox egress endpoint instead of an invented perf number (the registry forbids inventing). Idle-memory deltas stay honestly unmeasured (not the relevant axis).
- **PROFILES↔registry unify** — registry lists the exact 8 prefs the profile flips ("Flips 8 preferences" on the page); Gate N keeps it in sync — one enforced source of truth.
- about:gjoa renders the additions (editable allow-list, egress cost, leaves disclosure).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784555804&installation_id=141311834&pr_number=109&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F109&signature=c31e7b66f42506d8392577b9dccf1f957c03b655c768ac67728f48ba9007ad20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->