### PR TITLE
ci(release): build on Blacksmith fast runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,21 @@ on:
       - "v*"
 
 jobs:
+  # Releases build on Blacksmith (fast runners) — a release is infrequent and worth
+  # the credits for a ~5x Linux/Windows, ~3x macOS cut. (build-*.yml default to free
+  # GitHub-hosted runners for everyday/PR builds; only the release forces fast.)
   linux:
     uses: ./.github/workflows/build-linux.yml
+    with:
+      fast: true
   macos:
     uses: ./.github/workflows/build-macos.yml
+    with:
+      fast: true
   windows:
     uses: ./.github/workflows/build-windows.yml
+    with:
+      fast: true
 
   release:
     needs: [linux, macos, windows]


### PR DESCRIPTION
Releases now build on Blacksmith (passes `fast: true` through workflow_call) — ~5x Linux/Windows, ~3x macOS, all validated green per BUILD-LEDGER. Everyday/PR builds still default to free GitHub-hosted runners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784556876&installation_id=141311834&pr_number=110&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F110&signature=6784b45dd267025291a3c2a14fba6f64c4e1e01f3a111dd5b6bbaea1b2148c55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->