### PR TITLE
ci(release): back to free GitHub-hosted runners (out of Blacksmith credits)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,21 +16,15 @@ on:
       - "v*"
 
 jobs:
-  # Releases build on Blacksmith (fast runners) — a release is infrequent and worth
-  # the credits for a ~5x Linux/Windows, ~3x macOS cut. (build-*.yml default to free
-  # GitHub-hosted runners for everyday/PR builds; only the release forces fast.)
+  # Releases build on the free GitHub-hosted runners (slower, but no Blacksmith
+  # credits consumed). Flip `fast: true` per job to opt a release back onto
+  # Blacksmith if credits are available and the speed is worth it.
   linux:
     uses: ./.github/workflows/build-linux.yml
-    with:
-      fast: true
   macos:
     uses: ./.github/workflows/build-macos.yml
-    with:
-      fast: true
   windows:
     uses: ./.github/workflows/build-windows.yml
-    with:
-      fast: true
 
   release:
     needs: [linux, macos, windows]


### PR DESCRIPTION
Reverts the release-on-Blacksmith switch — Blacksmith free credits are exhausted. Releases use the free GitHub-hosted runners again (slower, $0). `fast: true` per job stays as the opt-in if credits return. (v0.4.0 already shipped on Blacksmith; this only affects future releases.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784560294&installation_id=141311834&pr_number=111&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F111&signature=4e9b4bb6c4e86a590524aff0067eae56b3180531b4369da7dc3368d971656edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->