### PR TITLE
feat(settings): Privacy profile picker (LibreWolf-Inspired* / Balanced / Minimal)

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -223,8 +223,9 @@
       (.setBoolPref d "browser.startup.homepage.abouthome_cache.enabled" false)
       ;; sovereignty: the maximal-egress-lockdown meta-pref, default OFF (see apply-lockdown!).
       (.setBoolPref d "gjoa.sovereignty.maximalLockdown" false)
-      ;; knobs: profile meta-prefs, default OFF (see PROFILES / apply-profile!).
-      (.setBoolPref d "gjoa.profile.librewolf-mode.enabled" false))
+      ;; privacy: the curated-profile selector. Default "minimal" (gjoa defaults;
+      ;; zero site breakage). See PRIVACY-PRESETS / apply-privacy-profile!.
+      (.setCharPref d "gjoa.privacy.profile" "minimal"))
     (catch Any e
       (console/error "gjoa-loader: setDefaults failed" e))))
 
@@ -298,41 +299,58 @@
 (def lockdown-observer :- Any
   {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-lockdown!))})
 
-;; --- knob profiles -----------------------------------------------------------
-;; A profile is a named meta-pref (gjoa.profile.<id>.enabled, default false) that
-;; batch-overrides a set of leaf prefs when ON. Same machine as apply-lockdown!,
-;; generalized: each leaf is [name on-value off-value type] — when the profile is on
-;; we set on-value, when off we set off-value (the gjoa/Firefox default), so toggling
-;; is cleanly reversible and nothing is ever destroyed. The about:knobs dashboard
-;; reads the live state; see private-docs/plan-knobs-debloat-librewolf.md.
-;; #79(a): "LibreWolf-grade DEFAULTS as one toggle" — NOT "as secure as LibreWolf".
-(def PROFILES :- Any
-  [{:pref "gjoa.profile.librewolf-mode.enabled"
-    :leaves [["privacy.resistFingerprinting" true false "bool"]
-             ["privacy.resistFingerprinting.letterboxing" true false "bool"]
-             ["network.http.referer.XOriginPolicy" 2 0 "int"]
-             ["network.http.referer.XOriginTrimmingPolicy" 2 0 "int"]
-             ["browser.search.suggest.enabled" false true "bool"]
-             ["browser.urlbar.suggest.searches" false true "bool"]
-             ["extensions.update.enabled" false true "bool"]
-             ["privacy.donottrackheader.enabled" true false "bool"]]}])
+;; --- privacy profiles --------------------------------------------------------
+;; CURATED presets. `gjoa.privacy.profile` selects one ("minimal"/"balanced"/
+;; "librewolf"/"custom"); applying it batch-sets a curated subset of privacy prefs
+;; on the DEFAULT branch (so each stays individually overridable, reversible — the
+;; about:gjoa picker flips to "custom" the moment a user hand-edits one). Each leaf
+;; is [name value type]. Presets escalate: minimal ⊂ balanced ⊂ librewolf. Kept in
+;; sync with settings/registry.json `sets` by preflight Gate N. #79(a):
+;; "LibreWolf-INSPIRED" — a curated subset of LibreWolf's DEFAULTS, NOT LibreWolf.
+(def PRIVACY-PRESETS :- Any
+  {"minimal"
+   [["privacy.resistFingerprinting" false "bool"]
+    ["privacy.resistFingerprinting.letterboxing" false "bool"]
+    ["network.http.referer.XOriginPolicy" 0 "int"]
+    ["network.http.referer.XOriginTrimmingPolicy" 0 "int"]
+    ["browser.search.suggest.enabled" true "bool"]
+    ["browser.urlbar.suggest.searches" true "bool"]
+    ["extensions.update.enabled" true "bool"]
+    ["privacy.donottrackheader.enabled" true "bool"]]
+   "balanced"
+   [["privacy.resistFingerprinting" false "bool"]
+    ["privacy.resistFingerprinting.letterboxing" false "bool"]
+    ["network.http.referer.XOriginPolicy" 0 "int"]
+    ["network.http.referer.XOriginTrimmingPolicy" 2 "int"]
+    ["browser.search.suggest.enabled" false "bool"]
+    ["browser.urlbar.suggest.searches" false "bool"]
+    ["extensions.update.enabled" true "bool"]
+    ["privacy.donottrackheader.enabled" true "bool"]]
+   "librewolf"
+   [["privacy.resistFingerprinting" true "bool"]
+    ["privacy.resistFingerprinting.letterboxing" true "bool"]
+    ["network.http.referer.XOriginPolicy" 2 "int"]
+    ["network.http.referer.XOriginTrimmingPolicy" 2 "int"]
+    ["browser.search.suggest.enabled" false "bool"]
+    ["browser.urlbar.suggest.searches" false "bool"]
+    ["extensions.update.enabled" false "bool"]
+    ["privacy.donottrackheader.enabled" true "bool"]]})
 
-(defn apply-profile! [profile :- Any] :- Any
+(defn apply-privacy-profile! [] :- Any
   (try
-    (let [d (.getDefaultBranch (.-prefs Services) "")
-          on (.getBoolPref (.-prefs Services) (.-pref profile) false)]
-      (doseq [leaf (.-leaves profile)]
-        (let [name (aget leaf 0) v (if on (aget leaf 1) (aget leaf 2))]
-          (if (= (aget leaf 3) "int") (.setIntPref d name v) (.setBoolPref d name v))))
-      (console/log (str "gjoa-loader: profile " (.-pref profile) " " (if on "ON" "off"))))
+    (let [id (.getCharPref (.-prefs Services) "gjoa.privacy.profile" "minimal")
+          preset (get PRIVACY-PRESETS id)
+          d (.getDefaultBranch (.-prefs Services) "")]
+      (when (and (not (= id "custom")) preset)
+        (doseq [leaf preset]
+          (let [name (aget leaf 0) v (aget leaf 1)]
+            (if (= (aget leaf 2) "int") (.setIntPref d name v) (.setBoolPref d name v))))
+        (console/log (str "gjoa-loader: privacy profile '" id "' applied"))))
     (catch Any e
-      (console/error "gjoa-loader: apply-profile failed" e))))
-
-(defn apply-all-profiles! [] :- Any
-  (doseq [p PROFILES] (apply-profile! p)))
+      (console/error "gjoa-loader: apply-privacy-profile failed" e))))
 
 (def profile-observer :- Any
-  {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-all-profiles!))})
+  {:observe (fn [_subject :- Any _topic :- Any _data :- Any] :- Any (apply-privacy-profile!))})
 
 ;; --- about: pages (sovereignty + knobs) --------------------------------------
 ;; Register a privileged chrome page as a real about:<what> page at runtime (no
@@ -393,8 +411,8 @@
       (set-defaults)
       (apply-lockdown!)
       (.addObserver (.-prefs Services) LOCKDOWN-PREF lockdown-observer)
-      (apply-all-profiles!)
-      (.addObserver (.-prefs Services) "gjoa.profile." profile-observer)
+      (apply-privacy-profile!)
+      (.addObserver (.-prefs Services) "gjoa.privacy.profile" profile-observer)
       (register-about-pages!)
       (register-aboutprefs-actor!)
       (set-new-tab-url!)

--- a/src/gjoa/browser/components/gjoa/content/settings/registry.json
+++ b/src/gjoa/browser/components/gjoa/content/settings/registry.json
@@ -1,25 +1,70 @@
 {
-  "note": "The about:gjoa settings registry. gjoa's single settings home. Each setting is a live pref (present + reversible). Costs are MEASURED, characterized as real EGRESS endpoints, or honestly 'unmeasured' — never invented. The `leaves` of a profile are the exact prefs it flips, kept in sync with GjoaLoader's PROFILES by preflight Gate N. Firefox's own settings stay in Firefox Settings; this is gjoa's surface.",
-  "profiles": [
-    { "id": "librewolf-mode", "pref": "gjoa.profile.librewolf-mode.enabled", "type": "bool", "title": "LibreWolf mode",
-      "claim": "LibreWolf-grade privacy DEFAULTS, as one toggle.",
-      "disclaimer": "NOT 'as secure as LibreWolf'. These prefs are only part of LibreWolf's hardening (their compile-time disables and ~20 C++ patches are not here), and flipping this changes none of gjoa's own added surface (the adblock classifier, content actors, custom about: pages).",
-      "leaves": [
-        { "pref": "privacy.resistFingerprinting", "on": true, "off": false, "type": "bool" },
-        { "pref": "privacy.resistFingerprinting.letterboxing", "on": true, "off": false, "type": "bool" },
-        { "pref": "network.http.referer.XOriginPolicy", "on": 2, "off": 0, "type": "int" },
-        { "pref": "network.http.referer.XOriginTrimmingPolicy", "on": 2, "off": 0, "type": "int" },
-        { "pref": "browser.search.suggest.enabled", "on": false, "off": true, "type": "bool" },
-        { "pref": "browser.urlbar.suggest.searches", "on": false, "off": true, "type": "bool" },
-        { "pref": "extensions.update.enabled", "on": false, "off": true, "type": "bool" },
-        { "pref": "privacy.donottrackheader.enabled", "on": true, "off": false, "type": "bool" }
-      ],
-      "tradeoffs": [
-        { "title": "resistFingerprinting has a high UX cost", "detail": "Breaks canvas-reliant sites, letterboxes the window, reports UTC timezone + a generic UA. Default-off for a reason; on only inside this profile." },
-        { "title": "Safe Browsing stays ON (conflict, not flipped)", "detail": "LibreWolf neuters Safe Browsing, but gjoa deliberately KEPT download-reputation on (security finding F5). LibreWolf mode does NOT disable it here — the conflict is surfaced, not silently resolved." },
-        { "title": "Prefetch stays ON (gjoa speed decision)", "detail": "LibreWolf disables prefetch/dns-prefetch; gjoa keeps them on for page-load speed. Not changed by this profile." }
-      ] }
-  ],
+  "note": "The about:gjoa settings registry. gjoa's single settings home. Each setting is a live pref (present + reversible). Privacy profiles are CURATED presets — pick one and it flips a curated subset of the granular toggles; hand-editing any toggle switches you to Custom. Costs are MEASURED, characterized as real EGRESS endpoints, or honestly 'unmeasured' — never invented. Profile `sets` are kept in sync with GjoaLoader's PRIVACY-PRESETS by preflight Gate N. Firefox's own settings stay in Firefox Settings; this is gjoa's surface.",
+  "privacy": {
+    "title": "Privacy",
+    "intro": "Pick a profile, or tune the individual toggles below (which switches you to Custom). Profiles escalate — each is a superset of the one before it.",
+    "selector": {
+      "pref": "gjoa.privacy.profile",
+      "default": "minimal",
+      "profiles": [
+        { "id": "minimal", "title": "Minimal",
+          "summary": "gjoa's privacy defaults — telemetry and phone-home off, Do-Not-Track on. Zero site breakage.",
+          "sets": {
+            "privacy.resistFingerprinting": false,
+            "privacy.resistFingerprinting.letterboxing": false,
+            "network.http.referer.XOriginPolicy": 0,
+            "network.http.referer.XOriginTrimmingPolicy": 0,
+            "browser.search.suggest.enabled": true,
+            "browser.urlbar.suggest.searches": true,
+            "extensions.update.enabled": true,
+            "privacy.donottrackheader.enabled": true
+          } },
+        { "id": "balanced", "title": "Balanced",
+          "summary": "Minimal + trims cross-site referers and turns off search / URL-bar suggestions (no keystroke leak to your search engine). Negligible breakage.",
+          "sets": {
+            "privacy.resistFingerprinting": false,
+            "privacy.resistFingerprinting.letterboxing": false,
+            "network.http.referer.XOriginPolicy": 0,
+            "network.http.referer.XOriginTrimmingPolicy": 2,
+            "browser.search.suggest.enabled": false,
+            "browser.urlbar.suggest.searches": false,
+            "extensions.update.enabled": true,
+            "privacy.donottrackheader.enabled": true
+          } },
+        { "id": "librewolf", "title": "LibreWolf-Inspired",
+          "asterisk": "A curated subset of LibreWolf's privacy DEFAULTS — not LibreWolf itself: its compile-time disables and ~20 C++ patches aren't here, and this changes none of gjoa's own added surface (the adblock classifier, content actors, about: pages).",
+          "summary": "Balanced + resistFingerprinting (canvas / timezone / UA spoofing + window letterboxing), strict referer policy, and extension auto-update off. Real UX cost: RFP breaks some sites.",
+          "sets": {
+            "privacy.resistFingerprinting": true,
+            "privacy.resistFingerprinting.letterboxing": true,
+            "network.http.referer.XOriginPolicy": 2,
+            "network.http.referer.XOriginTrimmingPolicy": 2,
+            "browser.search.suggest.enabled": false,
+            "browser.urlbar.suggest.searches": false,
+            "extensions.update.enabled": false,
+            "privacy.donottrackheader.enabled": true
+          } }
+      ]
+    },
+    "granular": [
+      { "pref": "privacy.resistFingerprinting", "type": "bool", "title": "Resist fingerprinting (RFP)", "firefoxDefault": false,
+        "help": "Spoofs canvas, timezone (UTC), and a generic UA to defeat fingerprinting. High UX cost — breaks canvas-reliant sites." },
+      { "pref": "privacy.resistFingerprinting.letterboxing", "type": "bool", "title": "Letterboxing", "firefoxDefault": false,
+        "help": "Pads the viewport to a generic size so window dimensions can't fingerprint you. Visible grey margins." },
+      { "pref": "network.http.referer.XOriginPolicy", "type": "int", "title": "Cross-origin referer policy", "firefoxDefault": 0,
+        "help": "0 = send full referer; 2 = send only on same-origin requests (strictest)." },
+      { "pref": "network.http.referer.XOriginTrimmingPolicy", "type": "int", "title": "Cross-origin referer trimming", "firefoxDefault": 0,
+        "help": "0 = full URL; 2 = trim cross-origin referer to scheme+host+port (no path/query leak)." },
+      { "pref": "browser.search.suggest.enabled", "type": "bool", "title": "Search suggestions", "firefoxDefault": true,
+        "help": "Off stops sending what you type to the search engine for suggestions." },
+      { "pref": "browser.urlbar.suggest.searches", "type": "bool", "title": "URL-bar search suggestions", "firefoxDefault": true,
+        "help": "Off stops URL-bar keystrokes reaching the search engine." },
+      { "pref": "extensions.update.enabled", "type": "bool", "title": "Extension auto-update", "firefoxDefault": true,
+        "help": "Off stops automatic add-on update checks (an egress + supply-chain consideration). You update manually." },
+      { "pref": "privacy.donottrackheader.enabled", "type": "bool", "title": "Do-Not-Track header", "firefoxDefault": false,
+        "help": "Sends DNT:1. Advisory only — most sites ignore it; gjoa's native blocking is what actually stops trackers." }
+    ]
+  },
   "sections": [
     { "id": "dark-mode", "title": "Dark mode", "intro": "Engine-level dark mode.",
       "settings": [

--- a/src/gjoa/browser/components/gjoa/content/settings/settings.css
+++ b/src/gjoa/browser/components/gjoa/content/settings/settings.css
@@ -126,3 +126,16 @@ html, body {
 .leaf { font-size: 12px; padding: 2px 0; }
 .leaf-pref { color: var(--faint); font-family: monospace; }
 .leaf-val { color: var(--ok); }
+
+/* privacy profile picker */
+.picker { display: flex; flex-direction: column; gap: 8px; margin: 6px 0 16px; }
+.pick {
+  display: flex; gap: 12px; align-items: flex-start; padding: 12px 14px;
+  border: 1px solid var(--line); border-radius: 10px; cursor: pointer;
+}
+.pick:hover { border-color: var(--faint); }
+.pick-on { border-color: var(--accent); background: rgba(122,162,247,0.06); }
+.pick input { margin-top: 2px; accent-color: var(--accent); }
+.pick-title { font-weight: 600; color: var(--ink); }
+.pick-sum { color: var(--muted); font-size: 12.5px; margin-top: 2px; }
+.pick-custom .pick-title { opacity: 0.75; }

--- a/src/gjoa/browser/components/gjoa/content/settings/settings.html
+++ b/src/gjoa/browser/components/gjoa/content/settings/settings.html
@@ -21,11 +21,8 @@
         reversible — flip it back any time.
       </p>
 
-      <section>
-        <h2 class="h2">Profiles</h2>
-        <p class="sub">A profile flips a whole bundle of settings at once, and reverts cleanly when off.</p>
-        <div id="profiles"></div>
-      </section>
+      <!-- Privacy section (profile picker + granular toggles) is rendered into #profiles. -->
+      <div id="profiles"></div>
 
       <div id="sections"></div>
 

--- a/src/gjoa/browser/components/gjoa/content/settings/settings.js
+++ b/src/gjoa/browser/components/gjoa/content/settings/settings.js
@@ -102,45 +102,78 @@
     return row;
   }
 
-  function renderProfiles(reg, rerender) {
+  // A privacy profile's `sets` all match the live pref state?
+  function profileMatches(p) {
+    return Object.keys(p.sets).every((k) => {
+      const want = p.sets[k];
+      const typ = (typeof want === "number") ? "int" : "bool";
+      return getPref(k, typ, want) === want;
+    });
+  }
+
+  function applyProfile(p, selPref, rerender) {
+    for (const k of Object.keys(p.sets)) {
+      const v = p.sets[k];
+      if (typeof v === "number") setInt(k, v); else setBool(k, !!v);
+    }
+    if (selPref) setStr(selPref, p.id);
+    rerender();
+  }
+
+  // Privacy: a curated profile picker (presets flip a subset of the granular
+  // toggles below; hand-editing any toggle drops you to Custom).
+  function renderPrivacy(reg, rerender) {
     const root = $("profiles");
     root.textContent = "";
-    for (const p of reg.profiles || []) {
-      const card = el("div", "profile");
-      const head = el("div", "profile-head");
-      const txt = el("div", "profile-txt");
-      txt.appendChild(el("div", "profile-title", p.title));
-      if (p.claim) txt.appendChild(el("div", "profile-claim", p.claim));
-      head.appendChild(txt);
-      head.appendChild(toggle(getPref(p.pref, "bool", false), (on) => { setBool(p.pref, on); rerender(); }));
-      card.appendChild(head);
-      if (p.disclaimer) card.appendChild(el("p", "profile-disclaimer", p.disclaimer));
-      if (p.tradeoffs && p.tradeoffs.length) {
-        const ul = el("ul", "tradeoffs");
-        for (const t of p.tradeoffs) {
-          const li = el("li", "tradeoff");
-          li.appendChild(el("span", "tradeoff-title", t.title));
-          li.appendChild(el("span", "tradeoff-detail", t.detail));
-          ul.appendChild(li);
-        }
-        card.appendChild(ul);
-      }
-      if (p.leaves && p.leaves.length) {
-        const det = document.createElement("details");
-        det.className = "leaves";
-        det.appendChild(el("summary", "leaves-sum", "Flips " + p.leaves.length + " preferences"));
-        const ul = el("ul", "leaves-list");
-        for (const lf of p.leaves) {
-          const li = el("li", "leaf");
-          li.appendChild(el("span", "leaf-pref", lf.pref));
-          li.appendChild(el("span", "leaf-val", " → " + lf.on));
-          ul.appendChild(li);
-        }
-        det.appendChild(ul);
-        card.appendChild(det);
-      }
-      root.appendChild(card);
+    const pv = reg.privacy;
+    if (!pv) return;
+    const sel = pv.selector || {};
+    const profiles = sel.profiles || [];
+    const selPref = sel.pref;
+
+    const active = profiles.find(profileMatches);
+    const activeId = active ? active.id : "custom";
+
+    const block = el("section", "block");
+    block.appendChild(el("h2", "h2", pv.title || "Privacy"));
+    if (pv.intro) block.appendChild(el("p", "sub", pv.intro));
+
+    const picker = el("div", "picker");
+    const addCard = (id, title, summary, onPick, disabled) => {
+      const card = el("label", "pick" + (id === activeId ? " pick-on" : ""));
+      const radio = document.createElement("input");
+      radio.type = "radio"; radio.name = "privacy-profile";
+      radio.checked = (id === activeId);
+      if (disabled) radio.disabled = true;
+      else radio.addEventListener("change", onPick);
+      card.appendChild(radio);
+      const txt = el("div", "pick-txt");
+      txt.appendChild(el("div", "pick-title", title));
+      if (summary) txt.appendChild(el("div", "pick-sum", summary));
+      card.appendChild(txt);
+      picker.appendChild(card);
+    };
+    for (const p of profiles) {
+      addCard(p.id, p.title + (p.asterisk ? " *" : ""), p.summary,
+              () => applyProfile(p, selPref, rerender), false);
     }
+    // Custom is reached by editing a toggle, not chosen directly.
+    addCard("custom", "Custom", "Your own mix — set by editing the toggles below.", null, true);
+    block.appendChild(picker);
+
+    const ast = (active && active.asterisk) ||
+                ((profiles.find((p) => p.asterisk) || {}).asterisk);
+    if (ast) block.appendChild(el("p", "profile-disclaimer", "* " + ast));
+
+    // granular toggles — editing one recomputes the active profile (-> Custom).
+    for (const g of pv.granular || []) {
+      block.appendChild(settingRow(g, () => {
+        const now = profiles.find(profileMatches);
+        if (selPref) setStr(selPref, now ? now.id : "custom");
+        rerender();
+      }));
+    }
+    root.appendChild(block);
   }
 
   function renderSections(reg, rerender) {
@@ -169,7 +202,7 @@
 
   let REG = null;
   function render() {
-    renderProfiles(REG, render);
+    renderPrivacy(REG, render);
     renderSections(REG, render);
     renderLinks(REG);
     $("foot").textContent =

--- a/tools/scripts/preflight.bjs
+++ b/tools/scripts/preflight.bjs
@@ -14,7 +14,7 @@
             [path :refer [join basename]]
             [gjoa.tools.prep.symbol-resolve :refer [check-contract]]))
 (define-mode strict)
-(declare-extern [process JSON RegExp] Any)
+(declare-extern [process JSON RegExp Object Set Array] Any)
 
 ;; The old .ts used `resolve(import.meta.dir, "..", "..")` to climb from
 ;; tools/scripts/ to the repo root. There is no import.meta in beagle, and
@@ -425,8 +425,8 @@
 ;; actually SET in source. A dangling knob — whose feature was deleted but whose
 ;; toggle remains — is a no-op that lies to the user; this gate makes that deletion
 ;; impossible to ship silently (restore the pref, reversibly, or remove the knob).
-;; Also asserts registry's librewolf-mode `leaves` == GjoaLoader's PROFILES leaves,
-;; so the "Flips N preferences" the page shows is exactly what the loader applies.
+;; Also asserts the registry privacy-profile `sets` prefs == GjoaLoader's
+;; PRIVACY-PRESETS prefs, so the picker sets exactly what the loader applies.
 (def REGISTRY-FILE :- String
   (join REPO-ROOT "src" "gjoa" "browser" "components" "gjoa" "content" "settings" "registry.json"))
 (def LOADER-FILE :- String
@@ -437,16 +437,13 @@
   (let [m (.match s (RegExp. "\"[^\"]+\"" "g"))]
     (if m (.map m (fn [q :- String] :- String (.slice q 1 -1))) [])))
 
-(defn profiles-leaf-prefs [loader :- String] :- Any
-  ;; the PROFILES def's leaf pref-names: every quoted string in the block except
-  ;; the type tags and the profile meta-pref.
-  (let [start (.indexOf loader "(def PROFILES")
-        end (.indexOf loader "(defn apply-profile!")
+(defn preset-pref-names [loader :- String] :- Any
+  ;; pref-names referenced in the PRIVACY-PRESETS def: quoted strings containing a
+  ;; "." (pref names have dots; "bool"/"int" and the profile-id keys don't).
+  (let [start (.indexOf loader "(def PRIVACY-PRESETS")
+        end (.indexOf loader "(defn apply-privacy-profile!")
         block (if (and (>= start 0) (> end start)) (.slice loader start end) "")]
-    (.filter (quoted-strings block)
-      (fn [q :- String] :- Bool
-        (and (not (= q "bool")) (not (= q "int")) (not (= q "string"))
-             (not (.startsWith q "gjoa.profile.")))))))
+    (.filter (quoted-strings block) (fn [q :- String] :- Bool (.includes q ".")))))
 
 (defn gateN [] :- Any
   (if (not (and (existsSync REGISTRY-FILE) (existsSync LOADER-FILE) (existsSync PREF-DIR)))
@@ -457,28 +454,30 @@
           pref-src (.join (.map (.filter (readdirSync PREF-DIR) (fn [f :- String] :- Bool (.endsWith f ".bjs")))
                                 (fn [f :- String] :- String (readFileSync (join PREF-DIR f) "utf8"))) "\n")
           src (str pref-src "\n" loader)
+          pv (.-privacy reg)
+          sel (and pv (.-selector pv))
+          profiles (or (and sel (.-profiles sel)) [])
           knob-prefs []
-          _p (doseq [p (or (.-profiles reg) [])]
-               (.push knob-prefs (.-pref p))
-               (doseq [lf (or (.-leaves p) [])] (.push knob-prefs (.-pref lf))))
+          _g (doseq [g (or (and pv (.-granular pv)) [])] (.push knob-prefs (.-pref g)))
+          _ps (doseq [p profiles] (doseq [k (Object/keys (.-sets p))] (.push knob-prefs k)))
           _s (doseq [sec (or (.-sections reg) [])]
                (doseq [s (or (.-settings sec) [])] (.push knob-prefs (.-pref s))))
           dangling (.filter knob-prefs (fn [pf :- String] :- Bool (not (.includes src (str "\"" pf "\"")))))
-          reg-lw (.find (or (.-profiles reg) []) (fn [p :- Any] :- Bool (= (.-id p) "librewolf-mode")))
-          reg-leaves (.sort (.map (or (and reg-lw (.-leaves reg-lw)) []) (fn [lf :- Any] :- String (.-pref lf))))
-          prof-leaves (.sort (profiles-leaf-prefs loader))]
+          reg-prefs (.sort (Array/from (Set. (.flatMap profiles (fn [p :- Any] :- Any (Object/keys (.-sets p)))))))
+          preset-prefs (.sort (Array/from (Set. (preset-pref-names loader))))
+          drift (not (= (.join reg-prefs "|") (.join preset-prefs "|")))]
       (cond
         (> (.-length dangling) 0)
         (fail "N" "knobs backed + reversible (knob-not-delete)"
           (str (.-length dangling) " knob(s) reference a pref set nowhere in source")
           (str "a feature was deleted but its knob remains (or a typo) — restore the pref (reversible!) or drop the knob:\n    " (.join dangling "\n    ")))
-        (not (= (.join reg-leaves "|") (.join prof-leaves "|")))
+        drift
         (fail "N" "knobs backed + reversible (knob-not-delete)"
-          "librewolf-mode leaves in registry.json != GjoaLoader PROFILES"
-          (str "the page would misrepresent what the profile flips — sync them.\n    registry: " (.join reg-leaves ", ") "\n    PROFILES: " (.join prof-leaves ", ")))
+          "registry privacy `sets` prefs != GjoaLoader PRIVACY-PRESETS prefs"
+          (str "the picker would set different prefs than the loader applies — sync them.\n    registry: " (.join reg-prefs ", ") "\n    PRESETS:  " (.join preset-prefs ", ")))
         :else
         (pass "N" "knobs backed + reversible (knob-not-delete)"
-          (str (.-length knob-prefs) " knobs backed by real prefs; librewolf-mode leaves (" (.-length prof-leaves) ") in sync"))))))
+          (str (.-length knob-prefs) " knobs backed by real prefs; privacy presets (" (.-length preset-prefs) " prefs) in sync with the loader"))))))
 
 ;; ── Run + render ──────────────────────────────────────────────────────────
 (defn main! [] :- Any


### PR DESCRIPTION
Reframes the overclaiming 'LibreWolf mode' into an honest **curated profile picker**. A Privacy section with mutually-exclusive presets that escalate (Minimal ⊂ Balanced ⊂ LibreWolf-Inspired); picking one flips a curated subset of granular toggles + shows its trade-off summary; hand-editing any toggle drops to Custom. **LibreWolf-Inspired** carries an asterisk (a curated subset of LibreWolf's *defaults*, not LibreWolf). Loader: `PRIVACY-PRESETS` + `apply-privacy-profile!` on `gjoa.privacy.profile`; Gate N keeps registry `sets` == loader presets. v0.4.0 notes already reframed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784561698&installation_id=141311834&pr_number=112&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F112&signature=5a7e8dc272d1da9f702f23271eae5df6f541923b8e57c4508869b9b80db36238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->