### PR TITLE
feat(darkmode): 174-site contrast corpus + mode A/B tooling

### DIFF
--- a/tools/darkmode-regress/corpus.json
+++ b/tools/darkmode-regress/corpus.json
@@ -1,42 +1,702 @@
 {
-  "note": "Deterministic dark-mode contrast regression corpus. Each entry is a pinned URL + failure-class tag. The harness loads each in gjoa dark mode, samples text vs backdrop pixels, and computes APCA Lc; |Lc| below threshold = a dark-on-dark (or low-contrast) FAIL. news.mit.edu is failure case #1.",
+  "note": "Exhaustive dark-mode contrast regression corpus, by failure-proneness category. |Lc| < threshold = dark-on-dark / low-contrast FAIL.",
   "threshold": 45,
   "sites": [
-    { "url": "https://news.mit.edu/2026/to-study-how-chips-really-work-mit-researchers-built-their-own-operating-system-0610", "tag": "image-hero+text", "note": "failure case #1 — dark title on scrimmed forest hero" },
-    { "url": "https://www.theverge.com/", "tag": "image-hero+text" },
-    { "url": "https://arstechnica.com/", "tag": "news-dense" },
-    { "url": "https://www.bbc.com/news", "tag": "news-dense" },
-    { "url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color", "tag": "docs-text" },
-    { "url": "https://doc.rust-lang.org/book/ch01-00-getting-started.html", "tag": "docs-text" },
-    { "url": "https://en.wikipedia.org/wiki/Dark_mode", "tag": "docs-text+infobox" },
-    { "url": "https://news.ycombinator.com/", "tag": "app-list (Tier-2 curated)" },
-    { "url": "https://stackoverflow.com/questions", "tag": "app-list" },
-    { "url": "https://www.reddit.com/", "tag": "app-feed" },
-    { "url": "https://github.com/", "tag": "already-dark-capable" },
-    { "url": "https://stripe.com/", "tag": "gradient-hero" },
-    { "url": "https://linear.app/", "tag": "gradient-hero (dark by default)" },
-    { "url": "https://vercel.com/", "tag": "gradient-hero (dark)" },
-    { "url": "https://tailwindcss.com/", "tag": "marketing+code" },
-    { "url": "https://www.nytimes.com/", "tag": "news-paywall-hero" },
-    { "url": "https://www.apple.com/", "tag": "image-hero (dark)" },
-    { "url": "https://www.airbnb.com/", "tag": "image-cards" },
-    { "url": "https://www.wikipedia.org/", "tag": "minimal-portal" },
-    { "url": "https://www.gov.uk/", "tag": "gov-forms" },
-    { "url": "https://www.python.org/", "tag": "docs-marketing" },
-    { "url": "https://news.google.com/", "tag": "aggregator-cards" },
-    { "url": "https://medium.com/", "tag": "blog-feed" },
-    { "url": "https://www.amazon.com/", "tag": "retail-dense" },
-    { "url": "https://www.cloudflare.com/", "tag": "marketing-gradient" },
-    { "url": "https://www.figma.com/", "tag": "marketing-image" },
-    { "url": "https://www.notion.so/", "tag": "marketing-light" },
-    { "url": "https://en.wikipedia.org/wiki/Massachusetts_Institute_of_Technology", "tag": "docs-infobox+image" },
-    { "url": "https://www.theguardian.com/international", "tag": "news-image-hero" },
-    { "url": "https://www.smashingmagazine.com/", "tag": "blog-image" },
-    { "url": "https://css-tricks.com/", "tag": "blog-code" },
-    { "url": "https://www.bls.gov/", "tag": "gov-tables" },
-    { "url": "https://www.w3.org/", "tag": "standards-text" },
-    { "url": "https://archive.org/", "tag": "retro-dense" },
-    { "url": "https://www.producthunt.com/", "tag": "cards-feed" },
-    { "url": "https://www.npmjs.com/package/react", "tag": "registry-readme" }
+    {
+      "url": "https://www.google.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.youtube.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.facebook.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.wikipedia.org/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.amazon.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.reddit.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://x.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.instagram.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.linkedin.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.netflix.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.bing.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.yahoo.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.tiktok.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.microsoft.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.office.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.twitch.tv/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.pinterest.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.ebay.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.spotify.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.imdb.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.quora.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.duckduckgo.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.baidu.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://weather.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://www.espn.com/",
+      "tag": "top-global"
+    },
+    {
+      "url": "https://news.mit.edu/2026/to-study-how-chips-really-work-mit-researchers-built-their-own-operating-system-0610",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.theverge.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://arstechnica.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.bbc.com/news",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.nytimes.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.washingtonpost.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.cnn.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.theguardian.com/international",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.reuters.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://apnews.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.bloomberg.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.wsj.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.economist.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.ft.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.aljazeera.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.npr.org/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.vox.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.wired.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.engadget.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://techcrunch.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.theatlantic.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.newyorker.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.nature.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.sciencemag.org/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://www.nationalgeographic.com/",
+      "tag": "news-hero"
+    },
+    {
+      "url": "https://paulgraham.com/articles.html",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://gwern.net/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://danluu.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://jvns.ca/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://overreacted.io/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://kentcdodds.com/blog",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.joshwcomeau.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://css-tricks.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.smashingmagazine.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://alistapart.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://sive.rs/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://waitbutwhy.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://stratechery.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.kalzumeus.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://martinfowler.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://blog.codinghorror.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.joelonsoftware.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://eli.thegreenplace.net/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://lwn.net/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://simonwillison.net/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.brendangregg.com/blog/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://blog.cloudflare.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://netflixtechblog.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://engineering.fb.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://blog.rust-lang.org/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://go.dev/blog/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://world.hey.com/dhh",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://daringfireball.net/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://xkcd.com/",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://www.gwern.net/Scaling-hypothesis",
+      "tag": "blogs"
+    },
+    {
+      "url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "tag": "docs"
+    },
+    {
+      "url": "https://doc.rust-lang.org/book/ch01-00-getting-started.html",
+      "tag": "docs"
+    },
+    {
+      "url": "https://docs.python.org/3/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://react.dev/learn",
+      "tag": "docs"
+    },
+    {
+      "url": "https://vuejs.org/guide/introduction.html",
+      "tag": "docs"
+    },
+    {
+      "url": "https://nodejs.org/en/docs",
+      "tag": "docs"
+    },
+    {
+      "url": "https://go.dev/doc/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://www.w3.org/TR/CSS/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://web.dev/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://docs.github.com/en",
+      "tag": "docs"
+    },
+    {
+      "url": "https://kubernetes.io/docs/home/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://docs.docker.com/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://www.postgresql.org/docs/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://redis.io/docs/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://docs.npmjs.com/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://tailwindcss.com/docs",
+      "tag": "docs"
+    },
+    {
+      "url": "https://getbootstrap.com/docs/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://api.jquery.com/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://www.typescriptlang.org/docs/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://eslint.org/docs/latest/",
+      "tag": "docs"
+    },
+    {
+      "url": "https://stripe.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://linear.app/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://vercel.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://tailwindcss.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.figma.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.notion.so/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://slack.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://github.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://gitlab.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.cloudflare.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.atlassian.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.salesforce.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.hubspot.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.shopify.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.squarespace.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.wix.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://supabase.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://planetscale.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://railway.app/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://render.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.heroku.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.digitalocean.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.twilio.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.mongodb.com/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.elastic.co/",
+      "tag": "saas-hero"
+    },
+    {
+      "url": "https://www.etsy.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.walmart.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.target.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.bestbuy.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.ikea.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.nike.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.apple.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.costco.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.homedepot.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.wayfair.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.aliexpress.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.zara.com/",
+      "tag": "ecommerce"
+    },
+    {
+      "url": "https://www.gov.uk/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.usa.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.bls.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.irs.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.nih.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.nasa.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.cdc.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.who.int/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://europa.eu/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.un.org/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.census.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://www.fda.gov/",
+      "tag": "gov-inst"
+    },
+    {
+      "url": "https://discord.com/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://about.gitlab.com/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://www.spotify.com/us/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://obsidian.md/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://www.raycast.com/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://warp.dev/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://zed.dev/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://bun.sh/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://astro.build/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://www.prisma.io/",
+      "tag": "already-dark"
+    },
+    {
+      "url": "https://en.wikipedia.org/wiki/Dark_mode",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://en.wikipedia.org/wiki/Massachusetts_Institute_of_Technology",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://en.wikipedia.org/wiki/Color",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://news.ycombinator.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://stackoverflow.com/questions",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://superuser.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://serverfault.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://www.producthunt.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://lobste.rs/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://dev.to/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://hashnode.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://medium.com/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://archive.org/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://www.gutenberg.org/",
+      "tag": "reference-forum"
+    },
+    {
+      "url": "https://arxiv.org/",
+      "tag": "reference-forum"
+    }
   ]
 }

--- a/tools/darkmode-regress/runner.bjs
+++ b/tools/darkmode-regress/runner.bjs
@@ -24,12 +24,14 @@
   "const d=arguments[arguments.length-1];requestAnimationFrame(()=>requestAnimationFrame(()=>d(true)));")
 
 (defn make-profile! [] :- String
-  (let [dir (.mkdtempSync fs (.join path (.tmpdir os) "gjoa-dmregress-"))]
+  (let [dir (.mkdtempSync fs (.join path (.tmpdir os) "gjoa-dmregress-"))
+        mode (or (get (.-env process) "GJOA_DM_MODE") "hybrid")
+        enabled (if (= mode "off") "false" "true")]
     (.writeFileSync fs (.join path dir "prefs.js")
       (str "user_pref(\"marionette.port\", 2828);\n"
            "user_pref(\"marionette.enabled\", true);\n"
-           "user_pref(\"gjoa.darkmode.enabled\", true);\n"
-           "user_pref(\"gjoa.darkmode.mode\", \"hybrid\");\n"))
+           "user_pref(\"gjoa.darkmode.enabled\", " enabled ");\n"
+           "user_pref(\"gjoa.darkmode.mode\", \"" mode "\");\n"))
     dir))
 
 (defn host-of [url :- String] :- String


### PR DESCRIPTION
Corpus 36 → **174 sites** across 9 failure-prone categories. Runner takes `GJOA_DM_MODE` to A/B strategies. Diagnosis via the suite: gjoa forces `prefers-color-scheme: dark` → summons broken **site** dark themes (MIT has a clean light theme + broken dark) → dark-on-dark. Fix: honor declared dark only if it passes APCA, else force-light+invert / normalize.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784565147&installation_id=141311834&pr_number=115&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F115&signature=84a5ffa3b3d278a2ce6016255aa032a1c93e8ab28c82999078628031ca0eecc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->