### PR TITLE
fix(drawer): keep compact sidebar expanded while a context menu is open (#88)

### DIFF
--- a/src/gjoa/chrome/bjs/drawer/compact.bjs
+++ b/src/gjoa/chrome/bjs/drawer/compact.bjs
@@ -176,6 +176,12 @@
 
         is-guarded (fn []
           (bool (or (> (.-open-popups shared) 0)
+                    ;; A context menu opened via openPopupAtScreen (tab/group menus)
+                    ;; sets state='showing' SYNCHRONOUSLY, before the async popupshown
+                    ;; that bumps open-popups — and the 0ms mouseleave-collapse check
+                    ;; can run in that gap. Querying the live menu directly closes the
+                    ;; race so the sidebar never collapses out from under an open menu.
+                    (q document "menupopup[state='open'], menupopup[state='showing']")
                     (and urlbar (has? urlbar "breakout-extend"))
                     (q document "toolbarbutton[open='true']")
                     (q document ".tabbrowser-tab[multiselected]")

--- a/tests/integration/compact-context-menu.bjs
+++ b/tests/integration/compact-context-menu.bjs
@@ -1,0 +1,64 @@
+#lang beagle/js
+;; Regression for #88: the compact sidebar must NOT auto-collapse while a context
+;; menu is open (it was ripping the tab context menu away mid-selection).
+;;
+;; A tab/group context menu opens via openPopupAtScreen, which sets the menupopup's
+;; state='showing' SYNCHRONOUSLY — before the async `popupshown` that bumps the
+;; `open-popups` counter — and the 0ms mouseleave→collapse check (on-sidebar-leave)
+;; can run in that gap, so the counter-based guard loses the race. The fix: is-guarded
+;; (compact.bjs) now also queries for a live `menupopup[state='showing'|'open']`,
+;; which is true from the synchronous showing state onward.
+;;
+;; We simulate the open menu with a synthetic menupopup in state='showing' (exactly
+;; what openPopupAtScreen sets) so the test is deterministic + headless-safe — no
+;; native popup timing.
+(ns gjoa.tests.integration.compact-context-menu
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true expect wait-for sleep]]))
+(define-mode strict)
+
+(def ENABLE-COMPACT :- String "
+  Services.prefs.setBoolPref('sidebar.verticalTabs', true);
+  Services.prefs.setBoolPref('gjoa.sidebar.compact', true);
+  return true;
+")
+
+;; Reveal the sidebar (hover state), plant a live menupopup[state='showing'] (what a
+;; context menu becomes), and fire the mouseleave that — pre-fix — scheduled collapse.
+(def OPEN-MENU-AND-LEAVE :- String "
+  const XUL='http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
+  const sb=document.getElementById('sidebar-main');
+  if(!sb) return {error:'no sidebar-main'};
+  sb.setAttribute('gjoa-has-hover','true');
+  let m=document.getElementById('gjoa-test-ctxmenu');
+  if(!m){ m=document.createElementNS(XUL,'menupopup'); m.id='gjoa-test-ctxmenu'; document.documentElement.appendChild(m); }
+  m.setAttribute('state','showing');
+  sb.dispatchEvent(new MouseEvent('mouseleave',{relatedTarget:document.body}));
+  return { menuLive: !!document.querySelector(\"menupopup[state='showing'],menupopup[state='open']\") };
+")
+
+(def CLOSE-MENU-AND-LEAVE :- String "
+  const sb=document.getElementById('sidebar-main');
+  const m=document.getElementById('gjoa-test-ctxmenu');
+  if(m) m.setAttribute('state','closed');
+  sb.dispatchEvent(new MouseEvent('mouseleave',{relatedTarget:document.body}));
+  return true;
+")
+
+(def HAS-HOVER :- String "return document.getElementById('sidebar-main').hasAttribute('gjoa-has-hover');")
+
+(js/export (def tests :- Any
+  [(deftest "compact — sidebar stays expanded while a context menu is open (#88)" [mn]
+     (js/await (chrome-eval ENABLE-COMPACT))
+     (js/await (await-true "return !!document.querySelector('#sidebar-main[data-gjoa-compact]');" 4000))
+     (let [r (js/await (chrome-eval OPEN-MENU-AND-LEAVE))]
+       (expect (.-menuLive r) "precondition: a live menupopup[state=showing] should exist"))
+     ;; let the 0ms mouseleave-collapse check (+ any flash/watchdog) run
+     (js/await (sleep 400))
+     (let [held (js/await (chrome-eval HAS-HOVER))]
+       (expect held "REGRESSION #88: sidebar collapsed while a context menu was open"))
+     ;; release: once the menu closes, a later mouseleave may collapse it again — guard
+     ;; against an over-correction that pins the sidebar open forever.
+     (js/await (chrome-eval CLOSE-MENU-AND-LEAVE))
+     (js/await (await-true "return !document.getElementById('sidebar-main').hasAttribute('gjoa-has-hover');" 3000)))]))
+
+(js/export-default tests)

--- a/tests/integration/tags.json
+++ b/tests/integration/tags.json
@@ -5,7 +5,7 @@
     "contrast":  ["contrast"],
     "adblock":   ["adblock-cosmetic", "adblock-cosmetic-actor", "adblock-production", "adblock-ui", "adblock-validate"],
     "scriptlet": ["scriptlet-engine", "youtube-scriptlet"],
-    "tabs":      ["tab-mode-toggle", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys", "help-menu"],
+    "tabs":      ["tab-mode-toggle", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys", "help-menu", "compact-context-menu"],
     "spaces":    ["spaces", "spaces-header", "spaces-scope-groups", "spaces-vim", "spaces-session-restore", "session-restore"],
     "newtab":    ["newtab-home", "new-tab-honors-active-space", "new-tab-no-indent-chain", "new-tab-visibility"],
     "misc":      ["sqlite"]
@@ -19,6 +19,7 @@
     "src/gjoa/chrome/bjs/blocking/":  ["adblock", "scriptlet"],
     "src/gjoa/chrome/bjs/spaces/":    "spaces",
     "src/gjoa/chrome/bjs/tabs/":      ["tabs", "newtab"],
+    "src/gjoa/chrome/bjs/drawer/":    "tabs",
     "src/gjoa/chrome/bjs/firefox/":   ["tabs", "newtab"]
   }
 }


### PR DESCRIPTION
## Bug
Right-clicking a tab while the sidebar is in compact (auto-collapse) mode collapses the sidebar **mid-selection**, ripping the menu away.

## Root cause
A tab/group context menu opens via `openPopupAtScreen`, which sets the menupopup's `state='showing'` **synchronously** — before the async `popupshown` that bumps the `open-popups` counter. `on-sidebar-leave`'s 0ms collapse check (`compact.bjs:248-258`) can run in that gap, so the counter-based `is-guarded` loses the race and the sidebar collapses.

## Fix
`is-guarded` now also queries for a live `menupopup[state='showing'|'open']`, which is true from the synchronous showing state onward — closing the race with **no new listeners or wiring**. Released normally on `popuphidden`.

## Test
`compact-context-menu` — a synthetic `menupopup[state='showing']` (exactly what `openPopupAtScreen` sets, so it's deterministic + headless-safe) + a `mouseleave`: the sidebar must stay expanded; once the menu closes it may collapse again (guards against pin-forever). It's a genuine regression test — the synthetic menu doesn't fire `popupshown`, so the *only* thing making `is-guarded` true is the new menu query. **Verified passing against the mach binary** (1 pass, 682ms).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784570431&installation_id=141311834&pr_number=118&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F118&signature=4d4ebda42c741f54f740bd637c27546ba7e344b0f3a5d2d09cca1435a87aa5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->