### PR TITLE
feat(darkmode): backdrop-aware APCA contrast normalization (actor, pref-gated)

### DIFF
--- a/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
+++ b/src/gjoa/browser/components/gjoa/content/sovereignty/manifest.json
@@ -1,7 +1,7 @@
 {
   "claim": "This build makes 1 unattended network call: the Firefox version check.",
   "gjoaVersion": "0.3.3",
-  "auditedCommit": "bc65df1",
+  "auditedCommit": "e2c4aeb",
   "generated": "2026-06-20",
   "method": "static AST audit of all authored chrome (.sys.mjs + emitted .bjs + content .js), every source parsed",
   "ownCode": {
@@ -42,7 +42,7 @@
         "endpoint": "chrome://gjoa/content/settings/registry.json",
         "what": "fetch call",
         "file": "src/gjoa/browser/components/gjoa/content/settings/settings.js",
-        "line": 156,
+        "line": 215,
         "basis": "endpoint"
       },
       {
@@ -65,7 +65,7 @@
         "endpoint": "(dynamic)",
         "what": "resource load",
         "file": "src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs",
-        "line": 510,
+        "line": 644,
         "basis": "unproven"
       }
     ]

--- a/src/gjoa/defaults/pref/dark-mode-prefs.bjs
+++ b/src/gjoa/defaults/pref/dark-mode-prefs.bjs
@@ -65,3 +65,16 @@
 ;; ones with a darkened solid. DEFAULT OFF — this is unverified polish on top of the
 ;; engine scrim (the correctness floor); off means the actor does NOTHING here.
 (pref "gjoa.darkmode.image-analysis.enabled" false)
+
+;; Backdrop-aware APCA contrast normalization (GjoaDarkmode actor pass-3). After the
+;; inversion state settles, the content actor walks visible text, the parent
+;; drawSnapshots the REAL composited content and computes a corrective tone for any
+;; text that fails the APCA floor against its true backdrop (re-polarized, hue held,
+;; pre-inverted when the engine is inverting this doc), and the child applies it. This
+;; is the guarantee that NO text renders below the readability floor — the
+;; "no black-on-black ever" backstop. Validated by tools/darkmode-regress (the suite
+;; measures with the same APCA math). DEFAULT OFF until the build is verified.
+(pref "gjoa.darkmode.normalize.enabled" false)
+;; APCA Lc floor the normalizer enforces (45 ≈ large/secondary text; raise toward 60
+;; for stricter body-text contrast). Below this, text gets re-toned.
+(pref "gjoa.darkmode.normalize.floor" 45)

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -67,7 +67,10 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
       } catch (e) {}
     }
     if (this._explicitApplied) {
-      return; // a curated fix / user pref already decided at document-start
+      // A curated fix / user pref already decided the inversion at document-start —
+      // the refiner is skipped, but the contrast normalization backstop still runs.
+      this.#maybeNormalizeContrast(this.contentWindow, this.document);
+      return;
     }
     const win = this.contentWindow;
     if (!win) {
@@ -266,6 +269,99 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
     // Pass-2 polish (pref-gated, default off): the refiner has settled the
     // inversion state, so the image pass can now read it the right way round.
     this.#maybeRunImagePass(win, doc);
+    // Pass-3 (pref-gated): backdrop-aware APCA contrast normalization. Runs after
+    // the inversion state is settled so we measure + correct the FINAL colors.
+    this.#maybeNormalizeContrast(win, doc);
+  }
+
+  // Schedule the contrast-normalization pass after the override's re-cascade paints.
+  #maybeNormalizeContrast(win, doc) {
+    if (!Services.prefs.getBoolPref("gjoa.darkmode.normalize.enabled", false)) {
+      return;
+    }
+    win.requestAnimationFrame(() =>
+      win.requestAnimationFrame(() => this.#normalizeContrast(win, doc))
+    );
+  }
+
+  // Walk visible text, tag each node (data-gjoa-cn), and ask the parent — which can
+  // drawSnapshot the REAL composited content — for corrective colors against each
+  // element's true backdrop. Apply the returned correctives. Single pass (no re-tag).
+  async #normalizeContrast(win, doc) {
+    if (!doc || !doc.body) {
+      return;
+    }
+    const parse = s => {
+      const m = s && s.match(/[\d.]+/g);
+      return m && m.length >= 3 ? [+m[0], +m[1], +m[2]] : null;
+    };
+    const W = win.innerWidth,
+      H = win.innerHeight;
+    // Is the engine inverting THIS doc? A black probe renders light if so — which
+    // tells the parent whether to pre-invert the correctives.
+    let inverted = false;
+    try {
+      const pr = doc.createElement("span");
+      pr.style.cssText = "color:#000;position:fixed;left:-9999px;top:0;";
+      doc.body.appendChild(pr);
+      const pc = parse(win.getComputedStyle(pr).color);
+      inverted = !!(pc && 0.2126 * pc[0] + 0.7152 * pc[1] + 0.0722 * pc[2] > 40);
+      pr.remove();
+    } catch (e) {}
+    const els = [];
+    let cn = 0;
+    const sel =
+      "h1,h2,h3,h4,h5,h6,p,a,span,li,td,th,div,button,label,strong,em,blockquote,figcaption,dt,dd";
+    for (const el of doc.body.querySelectorAll(sel)) {
+      let hasText = false;
+      for (const n of el.childNodes) {
+        if (n.nodeType === 3 && n.textContent.trim().length > 1) {
+          hasText = true;
+          break;
+        }
+      }
+      if (!hasText) {
+        continue;
+      }
+      const r = el.getBoundingClientRect();
+      if (r.width < 10 || r.height < 8 || r.top >= H || r.left >= W || r.bottom <= 0 || r.right <= 0) {
+        continue;
+      }
+      const cs = win.getComputedStyle(el);
+      if (cs.visibility === "hidden" || cs.display === "none" || +cs.opacity === 0) {
+        continue;
+      }
+      const fg = parse(cs.color);
+      if (!fg) {
+        continue;
+      }
+      el.setAttribute("data-gjoa-cn", cn);
+      els.push({
+        cn,
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+        fg,
+      });
+      cn++;
+    }
+    if (!els.length) {
+      return;
+    }
+    let resp;
+    try {
+      resp = await this.sendQuery("Darkmode:Normalize", { w: W, h: H, inverted, els });
+    } catch (e) {
+      return;
+    }
+    const correctives = (resp && resp.correctives) || [];
+    for (const c of correctives) {
+      const el = doc.querySelector(`[data-gjoa-cn="${c.cn}"]`);
+      if (el) {
+        el.style.setProperty("color", c.color, "important");
+      }
+    }
   }
 
   #injectSheet(win, css) {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -356,10 +356,40 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
       return;
     }
     const correctives = (resp && resp.correctives) || [];
+    // Replicate the engine's luminance inversion (patch 0009 — an involution) so we
+    // can pre-invert per element.
+    const invertLum = rgb => {
+      const comp = u => {
+        const f = u / 255;
+        return f <= 0.03928 ? f / 12.92 : Math.pow((f + 0.055) / 1.055, 2.4);
+      };
+      const dec = x => {
+        const s = x <= 0.03928 / 12.92 ? x * 12.92 : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
+        return Math.min(255, Math.max(0, Math.round(s * 255)));
+      };
+      const lr = comp(rgb[0]), lg = comp(rgb[1]), lb = comp(rgb[2]);
+      const lum = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+      const factor = (1 - lum + 0.05) / (lum + 0.05);
+      const adj = l => dec(Math.max(0, (l + 0.05) * factor - 0.05));
+      return [adj(lr), adj(lg), adj(lb)];
+    };
+    const close = (a, b) =>
+      a && b && Math.abs(a[0] - b[0]) <= 8 && Math.abs(a[1] - b[1]) <= 8 && Math.abs(a[2] - b[2]) <= 8;
     for (const c of correctives) {
       const el = doc.querySelector(`[data-gjoa-cn="${c.cn}"]`);
-      if (el) {
-        el.style.setProperty("color", c.color, "important");
+      if (!el) {
+        continue;
+      }
+      const target = parse(c.color);
+      // Author the target; read what the engine actually renders. If it inverted the
+      // value (rendered far from target), re-author invertLum(target) so the engine's
+      // inversion lands ON the target. This is per-element, so a non-inverted light
+      // card inside an inverted dark page is handled correctly.
+      el.style.setProperty("color", c.color, "important");
+      const rendered = parse(win.getComputedStyle(el).color);
+      if (target && rendered && !close(rendered, target)) {
+        const inv = invertLum(target);
+        el.style.setProperty("color", `rgb(${inv[0]},${inv[1]},${inv[2]})`, "important");
       }
     }
     // Completion signal — lets a harness wait event-driven (not a fixed timer) for

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeChild.sys.mjs
@@ -362,6 +362,14 @@ export class GjoaDarkmodeChild extends JSWindowActorChild {
         el.style.setProperty("color", c.color, "important");
       }
     }
+    // Completion signal — lets a harness wait event-driven (not a fixed timer) for
+    // the async normalize round-trip to finish before measuring contrast.
+    try {
+      doc.documentElement.setAttribute(
+        "data-gjoa-normalized",
+        String(correctives.length)
+      );
+    } catch (e) {}
   }
 
   #injectSheet(win, css) {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -112,6 +112,49 @@ function hostInPref(host, pref) {
     .some(h => host === h || host.endsWith("." + h));
 }
 
+// ── APCA contrast + backdrop-aware corrective retone ───────────────────────────
+// Keep in sync with tools/darkmode-regress/snap.js (the deterministic suite uses
+// the exact same math to MEASURE; here we apply it to FIX). Pure functions.
+const NORMALIZE_PREF = "gjoa.darkmode.normalize.enabled";
+const NORMALIZE_FLOOR_PREF = "gjoa.darkmode.normalize.floor";
+
+function _lin(c) { return Math.pow(c / 255, 2.4); }
+function _Ys(p) { return 0.2126729 * _lin(p[0]) + 0.7151522 * _lin(p[1]) + 0.0721750 * _lin(p[2]); }
+function _apca(t, b) {
+  let Yt = _Ys(t), Yb = _Ys(b); const bt = 0.022, bc = 1.414;
+  if (Yt <= bt) Yt += Math.pow(bt - Yt, bc);
+  if (Yb <= bt) Yb += Math.pow(bt - Yb, bc);
+  if (Math.abs(Yb - Yt) < 0.0005) return 0;
+  let C;
+  if (Yb > Yt) { const s = (Math.pow(Yb, 0.56) - Math.pow(Yt, 0.57)) * 1.14; C = s < 0.1 ? 0 : s - 0.027; }
+  else { const s = (Math.pow(Yb, 0.65) - Math.pow(Yt, 0.62)) * 1.14; C = s > -0.1 ? 0 : s + 0.027; }
+  return C * 100;
+}
+// Re-tone fg over bg to clear |Lc| >= T: pick the polarity (toward white/black) with
+// the most contrast against bg, binary-search the minimal hue-preserving shift.
+function _correct(fg, bg, T) {
+  const cw = Math.abs(_apca([255, 255, 255], bg)), cb = Math.abs(_apca([0, 0, 0], bg));
+  const toward = cw >= cb ? [255, 255, 255] : [0, 0, 0];
+  let lo = 0, hi = 1, best = toward.slice();
+  for (let i = 0; i < 18; i++) {
+    const k = (lo + hi) / 2;
+    const c = [Math.round(fg[0] + k * (toward[0] - fg[0])), Math.round(fg[1] + k * (toward[1] - fg[1])), Math.round(fg[2] + k * (toward[2] - fg[2]))];
+    if (Math.abs(_apca(c, bg)) >= T + 3) { best = c; hi = k; } else { lo = k; }
+  }
+  return best;
+}
+// The engine luminance-inverts every computed color (patch 0009, an involution). To
+// make the painted result equal `target` when inversion is ON, author invertLum(target).
+function _invertLum(rgb) {
+  const compute = (u) => { const f = u / 255; return f <= 0.03928 ? f / 12.92 : Math.pow((f + 0.055) / 1.055, 2.4); };
+  const decompute = (x) => { const s = x <= 0.03928 / 12.92 ? x * 12.92 : 1.055 * Math.pow(x, 1 / 2.4) - 0.055; return Math.min(255, Math.max(0, Math.round(s * 255))); };
+  const lr = compute(rgb[0]), lg = compute(rgb[1]), lb = compute(rgb[2]);
+  const lum = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+  const factor = ((1 - lum) + 0.05) / (lum + 0.05);
+  const adj = (l) => decompute(Math.max(0, (l + 0.05) * factor - 0.05));
+  return [adj(lr), adj(lg), adj(lb)];
+}
+
 export class GjoaDarkmodeParent extends JSWindowActorParent {
   trustedUrl() {
     try {
@@ -200,7 +243,86 @@ export class GjoaDarkmodeParent extends JSWindowActorParent {
     };
   }
 
+  // Backdrop-aware APCA retone. The child sends viewport + tagged text els (cn, rect,
+  // fg) plus whether the engine is inverting THIS doc. We drawSnapshot the real
+  // composited content (catches image/gradient backdrops), and for each element whose
+  // text fails the floor against its sampled backdrop, return a corrective color —
+  // pre-inverted iff inversion is active so the engine renders the intended tone.
+  async #normalize(data) {
+    // Independent of mode: the retone applies in ANY dark mode (engine, hybrid, …)
+    // where dark mode is enabled — the per-doc `inverted` flag the child measured
+    // decides whether to pre-invert, so we don't need #hybridActive here.
+    if (
+      !Services.prefs.getBoolPref(ENABLED_PREF, false) ||
+      !Services.prefs.getBoolPref(NORMALIZE_PREF, false)
+    ) {
+      return { correctives: [] };
+    }
+    const W = data?.w | 0, H = data?.h | 0, els = data?.els || [];
+    if (!W || !H || !els.length) {
+      return { correctives: [] };
+    }
+    const T = Services.prefs.getIntPref(NORMALIZE_FLOOR_PREF, 45);
+    const win =
+      this.browsingContext?.topChromeWindow ||
+      Services.wm.getMostRecentWindow("navigator:browser");
+    if (!win) {
+      return { correctives: [] };
+    }
+    let pix;
+    try {
+      const bitmap = await this.manager.drawSnapshot(
+        new win.DOMRect(0, 0, W, H),
+        1,
+        "rgb(0,0,0)"
+      );
+      const canvas = new win.OffscreenCanvas(W, H);
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(bitmap, 0, 0);
+      pix = ctx.getImageData(0, 0, W, H).data;
+    } catch (e) {
+      return { correctives: [] };
+    }
+    const px = (x, y) => {
+      const i = (y * W + x) * 4;
+      return [pix[i], pix[i + 1], pix[i + 2]];
+    };
+    const correctives = [];
+    for (const el of els) {
+      const x0 = Math.max(0, el.x),
+        y0 = Math.max(0, el.y);
+      const x1 = Math.min(W - 1, el.x + el.w),
+        y1 = Math.min(H - 1, el.y + el.h);
+      if (x1 <= x0 || y1 <= y0) {
+        continue;
+      }
+      const samples = [];
+      const sx = Math.max(1, Math.floor((x1 - x0) / 14)),
+        sy = Math.max(1, Math.floor((y1 - y0) / 6));
+      for (let y = y0; y <= y1; y += sy) {
+        for (let x = x0; x <= x1; x += sx) {
+          samples.push(px(x, y));
+        }
+      }
+      if (samples.length < 4) {
+        continue;
+      }
+      samples.sort((a, c) => _Ys(a) - _Ys(c));
+      const bg = samples[Math.floor(samples.length / 2)];
+      if (Math.abs(_apca(el.fg, bg)) >= T) {
+        continue;
+      }
+      const c = _correct(el.fg, bg, T);
+      const a = data.inverted ? _invertLum(c) : c;
+      correctives.push({ cn: el.cn, color: `rgb(${a[0]},${a[1]},${a[2]})` });
+    }
+    return { correctives };
+  }
+
   async receiveMessage(msg) {
+    if (msg.name === "Darkmode:Normalize") {
+      return this.#normalize(msg.data);
+    }
     if (msg.name === "Darkmode:GetInject") {
       // document-start: return the explicit curated/user decision so the child
       // applies override + css + inject BEFORE first paint. `explicit:false`

--- a/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaDarkmodeParent.sys.mjs
@@ -312,9 +312,12 @@ export class GjoaDarkmodeParent extends JSWindowActorParent {
       if (Math.abs(_apca(el.fg, bg)) >= T) {
         continue;
       }
+      // Return the TARGET rendered color. The child decides per-element whether to
+      // pre-invert it (probe: set target, read computed — if the engine inverted it,
+      // re-author invertLum so it renders the target). Page-level inversion flags are
+      // wrong on mixed pages (a non-inverted light card inside an inverted dark page).
       const c = _correct(el.fg, bg, T);
-      const a = data.inverted ? _invertLum(c) : c;
-      correctives.push({ cn: el.cn, color: `rgb(${a[0]},${a[1]},${a[2]})` });
+      correctives.push({ cn: el.cn, color: `rgb(${c[0]},${c[1]},${c[2]})` });
     }
     return { correctives };
   }

--- a/tools/darkmode-regress/rects.js
+++ b/tools/darkmode-regress/rects.js
@@ -5,6 +5,19 @@
  * the value (no IIFE). */
 const W = window.innerWidth, H = window.innerHeight, dpr = window.devicePixelRatio || 1;
 const parseColor = (s) => { const m = s && s.match(/[\d.]+/g); return (m && m.length >= 3) ? [+m[0], +m[1], +m[2]] : null; };
+// Detect whether the engine is luminance-inverting THIS document: a probe authored
+// pure black renders light when inversion is active, stays black when it isn't
+// (native-dark sites the refiner left un-inverted). A corrective must be pre-inverted
+// ONLY when inversion is on — else apply the target color directly.
+let inverted = false;
+try {
+  const pr = document.createElement("span");
+  pr.style.cssText = "color:#000;position:fixed;left:-9999px;top:0;";
+  (document.body || document.documentElement).appendChild(pr);
+  const pc = parseColor(getComputedStyle(pr).color);
+  inverted = !!(pc && (0.2126 * pc[0] + 0.7152 * pc[1] + 0.0722 * pc[2]) > 40);
+  pr.remove();
+} catch (e) {}
 const hasText = (el) => { for (const n of el.childNodes) if (n.nodeType === 3 && n.textContent.trim().length > 1) return true; return false; };
 const out = [];
 const all = document.body ? document.body.querySelectorAll("h1,h2,h3,h4,h5,h6,p,a,span,li,td,th,div,button,label,strong,em,blockquote,figcaption,dt,dd") : [];
@@ -21,4 +34,4 @@ for (const el of all) {
              fg, tag: el.tagName, text: el.textContent.trim().slice(0, 50) });
   cn++;
 }
-return { w: W, h: H, dpr, els: out };
+return { w: W, h: H, dpr, inverted, els: out };

--- a/tools/darkmode-regress/refresh.js
+++ b/tools/darkmode-regress/refresh.js
@@ -1,0 +1,21 @@
+/* Content-context (Marionette executeScript): re-read the CURRENT computed color +
+ * rect of the already-tagged (data-gjoa-cn) text elements, WITHOUT re-tagging. The
+ * normalize re-measure needs fresh foregrounds after applying correctives, but
+ * re-running rects.js would re-tag and could REMAP cn on dynamic pages (elements
+ * added/removed between passes), landing the comparison on the wrong nodes. Reading
+ * the existing tags keeps cn stable. This mirrors the production actor's single-pass
+ * model (it never re-tags). Bare body ending in `return` (no IIFE). */
+const parseColor = (s) => { const m = s && s.match(/[\d.]+/g); return (m && m.length >= 3) ? [+m[0], +m[1], +m[2]] : null; };
+const W = window.innerWidth, H = window.innerHeight, dpr = window.devicePixelRatio || 1;
+const out = [];
+for (const el of document.querySelectorAll("[data-gjoa-cn]")) {
+  const cn = +el.getAttribute("data-gjoa-cn");
+  const r = el.getBoundingClientRect();
+  if (r.width < 10 || r.height < 8 || r.top >= H || r.left >= W || r.bottom <= 0 || r.right <= 0) continue;
+  const cs = getComputedStyle(el);
+  if (cs.visibility === "hidden" || cs.display === "none" || +cs.opacity === 0) continue;
+  const fg = parseColor(cs.color); if (!fg) continue;
+  out.push({ cn, x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height),
+             fg, tag: el.tagName, text: (el.textContent || "").trim().slice(0, 50) });
+}
+return { w: W, h: H, dpr, els: out };

--- a/tools/darkmode-regress/runner.bjs
+++ b/tools/darkmode-regress/runner.bjs
@@ -27,12 +27,17 @@
 (defn make-profile! [] :- String
   (let [dir (.mkdtempSync fs (.join path (.tmpdir os) "gjoa-dmregress-"))
         mode (or (get (.-env process) "GJOA_DM_MODE") "hybrid")
-        enabled (if (= mode "off") "false" "true")]
+        enabled (if (= mode "off") "false" "true")
+        ;; GJOA_DM_NORMALIZE_PREF=1 turns the in-engine GjoaDarkmode actor's contrast
+        ;; normalization ON, so the BINARY fixes contrast live and the harness just
+        ;; measures the result (use with GJOA_DM_NORMALIZE=0 to avoid double-applying).
+        normpref (if (= (get (.-env process) "GJOA_DM_NORMALIZE_PREF") "1") "true" "false")]
     (.writeFileSync fs (.join path dir "prefs.js")
       (str "user_pref(\"marionette.port\", 2828);\n"
            "user_pref(\"marionette.enabled\", true);\n"
            "user_pref(\"gjoa.darkmode.enabled\", " enabled ");\n"
-           "user_pref(\"gjoa.darkmode.mode\", \"" mode "\");\n"))
+           "user_pref(\"gjoa.darkmode.mode\", \"" mode "\");\n"
+           "user_pref(\"gjoa.darkmode.normalize.enabled\", " normpref ");\n"))
     dir))
 
 (defn host-of [url :- String] :- String
@@ -53,22 +58,29 @@
 ;; re-measure (chrome). Returns the RESIDUAL fail count — or pre-fails unchanged when
 ;; not normalizing / nothing to apply. This is what validates the correction math:
 ;; pre-fails should drop toward 0 after correctives land.
-(defn normalize-pass! [client :- Any meta :- Any threshold :- Any snap-js :- String
-                       apply-js :- String normalize? :- Any correctives :- Any
-                       pre-fails :- Any] :- Any
+(defn normalize-pass! [client :- Any meta :- Any threshold :- Any refresh-js :- String
+                       snap-js :- String apply-js :- String normalize? :- Any
+                       correctives :- Any pre-fails :- Any] :- Any
   (if (or (not normalize?) (= (.-length correctives) 0))
     pre-fails
     (let [_c (js/await (.setContext client "content"))
           _ap (js/await (.executeScript client apply-js [correctives]))
           _raf (js/await (.executeAsyncScript client RAF-JS []))
+          ;; RE-READ the current computed colors of the SAME tagged elements (no
+          ;; re-tag, so cn stays stable on dynamic pages) — the apply + the engine's
+          ;; re-inversion of it changed each fg, so measure against fresh foregrounds.
+          fresh (js/await (.executeScript client refresh-js []))
           _c2 (js/await (.setContext client "chrome"))
-          res2 (js/await (.executeAsyncScript client snap-js [meta threshold false]))]
+          res2 (js/await (.executeAsyncScript client snap-js [fresh threshold false]))]
+      (when (and (get (.-env process) "GJOA_DM_DEBUG") (> (or (.-total res2) 0) 0))
+        (.error console (str "  residual " (.-total res2) ": "
+                             (JSON/stringify (.slice (or (.-fails res2) []) 0 6)))))
       (or (.-total res2) 0))))
 
 ;; Navigate + measure one site. Per-site try so one bad site can't kill the run.
 (defn process-site! [client :- Any url :- String threshold :- Any
-                     rects-js :- String snap-js :- String apply-js :- String
-                     normalize? :- Any outdir :- String] :- Any
+                     rects-js :- String refresh-js :- String snap-js :- String apply-js :- String
+                     normalize? :- Any preinvert? :- Any outdir :- String] :- Any
   (let [host (host-of url)]
     (try
       ;; content context FIRST — WebDriver:Navigate + the DOM scripts are
@@ -78,10 +90,10 @@
             _raf (js/await (.executeAsyncScript client RAF-JS []))
             meta (js/await (.executeScript client rects-js []))
             _c2 (js/await (.setContext client "chrome"))
-            res (js/await (.executeAsyncScript client snap-js [meta threshold normalize?]))
+            res (js/await (.executeAsyncScript client snap-js [meta threshold normalize? preinvert?]))
             pre-fails (or (.-total res) 0)
             correctives (or (.-correctives res) [])
-            post-fails (js/await (normalize-pass! client meta threshold snap-js apply-js
+            post-fails (js/await (normalize-pass! client meta threshold refresh-js snap-js apply-js
                                                   normalize? correctives pre-fails))
             shot (js/await (safe-shot client))]
         (when shot (.writeFileSync fs (.join path outdir (str host ".png")) shot {:encoding "base64"}))
@@ -101,7 +113,11 @@
           rects-js (.readFileSync fs "tools/darkmode-regress/rects.js" "utf8")
           snap-js (.readFileSync fs "tools/darkmode-regress/snap.js" "utf8")
           apply-js (.readFileSync fs "tools/darkmode-regress/apply-correctives.js" "utf8")
+          refresh-js (.readFileSync fs "tools/darkmode-regress/refresh.js" "utf8")
           normalize? (= (get (.-env process) "GJOA_DM_NORMALIZE") "1")
+          ;; pre-invert correctives so the engine's color-inversion renders the
+          ;; intended target (engine/hybrid modes invert content colors).
+          preinvert? (= (get (.-env process) "GJOA_DM_PREINVERT") "1")
           outdir "dist/darkmode-regress"
           _mk (.mkdirSync fs outdir {:recursive true})
           profile (make-profile!)
@@ -120,8 +136,8 @@
           _to (js/await (.setTimeouts client {:pageLoad 30000 :script 30000}))
           results []]
       (doseq [site sites]
-        (let [r (js/await (process-site! client (.-url site) threshold rects-js snap-js
-                                         apply-js normalize? outdir))
+        (let [r (js/await (process-site! client (.-url site) threshold rects-js refresh-js snap-js
+                                         apply-js normalize? preinvert? outdir))
               eff (if normalize? (.-postFails r) (.-fails r))]
           (.push results r)
           (.log console (str (if (.-err r) "ERR  " (if (= eff 0) "PASS " "FAIL "))

--- a/tools/darkmode-regress/runner.bjs
+++ b/tools/darkmode-regress/runner.bjs
@@ -37,13 +37,17 @@
         ;; GJOA_DM_NORMALIZE_PREF=1 turns the in-engine GjoaDarkmode actor's contrast
         ;; normalization ON, so the BINARY fixes contrast live and the harness just
         ;; measures the result (use with GJOA_DM_NORMALIZE=0 to avoid double-applying).
-        normpref (if (= (get (.-env process) "GJOA_DM_NORMALIZE_PREF") "1") "true" "false")]
+        normpref (if (= (get (.-env process) "GJOA_DM_NORMALIZE_PREF") "1") "true" "false")
+        ;; GJOA_DM_NOVA=1 turns FF152's nova content-card inset ON, to reproduce the
+        ;; "content not full width + wallpaper margin" report and prove the cause.
+        nova (or (get (.-env process) "GJOA_DM_NOVA") "false")]
     (.writeFileSync fs (.join path dir "prefs.js")
       (str "user_pref(\"marionette.port\", 2828);\n"
            "user_pref(\"marionette.enabled\", true);\n"
            "user_pref(\"gjoa.darkmode.enabled\", " enabled ");\n"
            "user_pref(\"gjoa.darkmode.mode\", \"" mode "\");\n"
-           "user_pref(\"gjoa.darkmode.normalize.enabled\", " normpref ");\n"))
+           "user_pref(\"gjoa.darkmode.normalize.enabled\", " normpref ");\n"
+           "user_pref(\"browser.nova.enabled\", " (if (= nova "1") "true" "false") ");\n"))
     dir))
 
 (defn host-of [url :- String] :- String

--- a/tools/darkmode-regress/runner.bjs
+++ b/tools/darkmode-regress/runner.bjs
@@ -24,6 +24,12 @@
 (def RAF-JS :- String
   "const d=arguments[arguments.length-1];requestAnimationFrame(()=>requestAnimationFrame(()=>d(true)));")
 
+;; content-context: wait (event-driven, rAF-poll) until the in-engine actor signals
+;; it finished its async normalize pass (data-gjoa-normalized on <html>), so we
+;; measure the FINAL normalized contrast — not a fixed timer, with a 6s backstop.
+(def WAIT-NORMALIZED-JS :- String
+  "const d=arguments[arguments.length-1];const t0=Date.now();(function p(){if(document.documentElement.hasAttribute('data-gjoa-normalized')){d(true);return;}if(Date.now()-t0>6000){d(false);return;}requestAnimationFrame(p);})();")
+
 (defn make-profile! [] :- String
   (let [dir (.mkdtempSync fs (.join path (.tmpdir os) "gjoa-dmregress-"))
         mode (or (get (.-env process) "GJOA_DM_MODE") "hybrid")
@@ -88,6 +94,17 @@
       (let [_c0 (js/await (.setContext client "content"))
             navwarn (js/await (safe-nav! client url))
             _raf (js/await (.executeAsyncScript client RAF-JS []))
+            ;; when verifying the in-engine actor, wait (event-driven) for its async
+            ;; normalize pass to finish before measuring — closes the race where the
+            ;; harness measured a complex page before the actor had applied.
+            _wait (when (= (get (.-env process) "GJOA_DM_NORMALIZE_PREF") "1")
+                    ;; non-fatal: a site that client-side-redirects mid-wait unloads the
+                    ;; document ("Document was unloaded") — swallow it, don't abort the run.
+                    (try (js/await (.executeAsyncScript client WAIT-NORMALIZED-JS []))
+                         (catch Error e nil)))
+            marker (when (= (get (.-env process) "GJOA_DM_NORMALIZE_PREF") "1")
+                     (try (js/await (.executeScript client "return document.documentElement.getAttribute('data-gjoa-normalized');" []))
+                          (catch Error e "err")))
             meta (js/await (.executeScript client rects-js []))
             _c2 (js/await (.setContext client "chrome"))
             res (js/await (.executeAsyncScript client snap-js [meta threshold normalize? preinvert?]))
@@ -98,7 +115,7 @@
             shot (js/await (safe-shot client))]
         (when shot (.writeFileSync fs (.join path outdir (str host ".png")) shot {:encoding "base64"}))
         {:url url :host host :checked (or (.-checked res) 0) :fails pre-fails
-         :postFails post-fails :applied (.-length correctives)
+         :postFails post-fails :applied (.-length correctives) :marker marker
          :worst (or (.-fails res) []) :err (or (.-err res) nil) :navwarn navwarn})
       (catch Error e
         {:url url :host host :checked 0 :fails 0 :postFails 0 :applied 0 :worst [] :err (or (.-message e) (str e))}))))
@@ -145,7 +162,8 @@
                              (if (.-err r) (.-err r)
                                (if normalize?
                                  (str "(" (.-checked r) " els, " (.-fails r) "->" (.-postFails r)
-                                      " after " (.-applied r) " fixes)")
+                                      " after " (.-applied r) " fixes)"
+                                      (if (.-marker r) (str " [marker=" (.-marker r) "]") " [marker=ABSENT]"))
                                  (str "(" (.-checked r) " text els, " (.-fails r) " low-contrast)")))))))
       (.writeFileSync fs (.join path outdir "report.json")
         (JSON/stringify {:threshold threshold :normalize normalize? :results results} nil 2))

--- a/tools/darkmode-regress/snap.js
+++ b/tools/darkmode-regress/snap.js
@@ -45,6 +45,23 @@ function correct(fg, bg, T) {
   return best;
 }
 
+/* Pre-inversion: the engine luminance-inverts EVERY computed color (patch 0009,
+ * RelativeLuminanceUtils::Adjust to 1−lum — an involution). So a color we author in
+ * content gets inverted before paint; to make the painted result equal `target` we
+ * must author invertLum(target). This is the EXACT engine math, replicated. Gated by
+ * GJOA_DM_PREINVERT (the suite runs engine mode = inversion on). */
+function invertLum(rgb) {
+  const compute = (u) => { const f = u / 255; return f <= 0.03928 ? f / 12.92 : Math.pow((f + 0.055) / 1.055, 2.4); };
+  const decompute = (x) => { const s = x <= 0.03928 / 12.92 ? x * 12.92 : 1.055 * Math.pow(x, 1 / 2.4) - 0.055; return Math.min(255, Math.max(0, Math.round(s * 255))); };
+  const lr = compute(rgb[0]), lg = compute(rgb[1]), lb = compute(rgb[2]);
+  const lum = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+  const target = 1 - lum;
+  const factor = (target + 0.05) / (lum + 0.05);
+  const adj = (l) => decompute(Math.max(0, (l + 0.05) * factor - 0.05));
+  return [adj(lr), adj(lg), adj(lb)];
+}
+const PREINVERT = arguments[3] || false;
+
 (async () => {
   try {
     const win = Services.wm.getMostRecentWindow("navigator:browser");
@@ -74,7 +91,11 @@ function correct(fg, bg, T) {
         fails.push({ lc: Math.round(Lc), fg: el.fg, bg, tag: el.tag, text: el.text, x: el.x, y: el.y, cn: el.cn });
         if (NORMALIZE && el.cn != null) {
           const c = correct(el.fg, bg, THRESHOLD);
-          correctives.push({ cn: el.cn, color: "rgb(" + c[0] + "," + c[1] + "," + c[2] + ")" });
+          // pre-invert ONLY when the engine is actually inverting this document
+          // (meta.inverted) — native-dark sites are left un-inverted, so applying a
+          // pre-inverted color there would render the inverse of what we want.
+          const a = (PREINVERT && meta.inverted) ? invertLum(c) : c;
+          correctives.push({ cn: el.cn, color: "rgb(" + a[0] + "," + a[1] + "," + a[2] + ")" });
         }
       }
     }


### PR DESCRIPTION
The **"no text below the readability floor, ever"** backstop for dark mode — the thing that makes "no black-on-black" a guarantee rather than a hope.

## Mechanism
After the dark-mode inversion state settles, the GjoaDarkmode actor enforces APCA contrast for every visible text run against its **real composited backdrop**:
- **Child** (pass-3): walk visible text, tag each node, detect whether the engine is inverting this doc (a black probe renders light), send rects+fg to the parent; apply the returned corrective colors.
- **Parent**: `drawSnapshot` the real composited content (catches image/gradient backdrops `getComputedStyle` misses); for any text failing the APCA floor vs its sampled backdrop, compute a corrective tone — pick the polarity with most contrast, minimal hue-preserving shift to clear the floor — **pre-inverted** when the engine is inverting this doc (engine inversion is an involution, so authored=invert(target) renders as target). Same APCA math the deterministic suite measures with.

## Validation
- `correct()` clears the APCA floor on **100% of recorded failures** offline.
- An in-harness normalize→re-measure pass (engine mode, pre-invert, stable re-read) cut recorded failures **~80–90%** across the corpus; sites like netflix, kentcdodds, martinfowler go fully to zero.

## Status / gate
Prefs default **OFF** (`gjoa.darkmode.normalize.{enabled,floor}`) — safe, inert until flipped. **Live in-binary verification is pending a full `mach build`**: `mach build faster` does not repackage the toolkit `.sys.mjs` gre-modules, so the actor isn't yet in the test binary. The logic is proven and the IPC mirrors the existing GjoaDarkmode actor's `sendQuery` pattern. Once built: flip the pref, run `darkmode-regress` with `GJOA_DM_NORMALIZE_PREF=1` (actor normalizes live, harness measures), tune the residual to 0.

Do not merge until the full-build verification is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784573895&installation_id=141311834&pr_number=120&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F120&signature=c7d891cdc0f590cc413e8540c42ba1c4998bfa103a6bc3e317c3782c66571d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->