### PR TITLE
Contextual floating-card layout + nova-off; persistent toolbar swap

### DIFF
--- a/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
+++ b/src/gjoa/browser/components/gjoa/GjoaLoader.bjs
@@ -221,6 +221,19 @@
       ;; no longer serve; with the activity-stream uninitialized it throws at
       ;; startup (AboutHomeStartupCache: activityStream is null). Disable it.
       (.setBoolPref d "browser.startup.homepage.abouthome_cache.enabled" false)
+      ;; FF152 "nova" UI reserves a content margin + window gap (see
+      ;; browser/themes/shared/sidebar.css @media browser.nova.enabled) that crops
+      ;; every page and exposes the desktop behind the inset — gjoa supplies its own
+      ;; chrome, so force nova OFF: default false AND drop any stray user/experiment
+      ;; value (runs every launch, so a Normandy flip can't re-crop the content).
+      (.setBoolPref d "browser.nova.enabled" false)
+      (when (.prefHasUserValue (.-prefs Services) "browser.nova.enabled")
+        (.clearUserPref (.-prefs Services) "browser.nova.enabled"))
+      ;; ...and replace it with gjoa's OWN contextual floating cards (gjoa.uc.css
+      ;; #region floating cards): a static sidebar + content render as two rounded
+      ;; cards with a gap; a floating/hidden sidebar lets content fill the window.
+      ;; Unlike nova's all-or-nothing inset, this is gated on the live sidebar state.
+      (.setBoolPref d "gjoa.layout.floatingCards" true)
       ;; sovereignty: the maximal-egress-lockdown meta-pref, default OFF (see apply-lockdown!).
       (.setBoolPref d "gjoa.sovereignty.maximalLockdown" false)
       ;; privacy: the curated-profile selector. Default "minimal" (gjoa defaults;

--- a/src/gjoa/chrome/bjs/drawer/layout.bjs
+++ b/src/gjoa/chrome/bjs/drawer/layout.bjs
@@ -179,9 +179,14 @@
             (set! (.-urlbar-toolbar state) nil)
 
             (let [spring2 (by-id "customizableui-special-spring2")
-                  ext-btn (by-id "unified-extensions-button")]
+                  ext-btn (by-id "unified-extensions-button")
+                  sb-btn (by-id "gjoa-sidebar-button")]
               (when spring2 (.after urlbar-container spring2))
-              (when (and spring2 ext-btn) (.after spring2 ext-btn)))
+              (when (and spring2 ext-btn) (.after spring2 ext-btn))
+              ;; keep gjoa's swapped sidebar button immediately after the
+              ;; extensions button through the collapse reflow, so the
+              ;; hamburger → extensions → sidebar order survives compact mode (#92).
+              (when (and ext-btn sb-btn) (.after ext-btn sb-btn)))
 
             (if (and toolbox-next (= (.-parentNode toolbox-next) toolbox-parent))
               (.insertBefore toolbox-parent navigator-toolbox toolbox-next)

--- a/src/gjoa/chrome/bjs/drawer/sidebar-button.bjs
+++ b/src/gjoa/chrome/bjs/drawer/sidebar-button.bjs
@@ -25,10 +25,18 @@
       (when og-icon-style
         (set! (.-listStyleImage (.-style button)) og-icon-style))
 
+      ;; Order: sidebar button sits AFTER the extension (puzzle) button, so the
+      ;; nav-bar reads hamburger → extension → sidebar (user swap). Fall back to
+      ;; after the hamburger, then after the native sidebar button.
       (let [nav-bar (by-id "nav-bar")
+            ext-btn (by-id "unified-extensions-button")
             panel-ui (by-id "PanelUI-button")]
-        (if (and nav-bar panel-ui (= (.-parentNode panel-ui) nav-bar))
+        (cond
+          (and nav-bar ext-btn (= (.-parentNode ext-btn) nav-bar))
+          (.after ext-btn button)
+          (and nav-bar panel-ui (= (.-parentNode panel-ui) nav-bar))
           (.after panel-ui button)
+          :else
           (.after sidebar-button button)))
 
       (let [on-click #(when (= (.-button %) 0)

--- a/src/gjoa/chrome/css/gjoa.uc.css
+++ b/src/gjoa/chrome/css/gjoa.uc.css
@@ -152,6 +152,13 @@
   --gjoa-gap: 6px;
   --gjoa-sidebar-inset: 10px;
   --gjoa-compact-trigger-width: 8px;
+  /* Contextual floating cards (gjoa.layout.floatingCards). A STATIC, in-flow
+   * sidebar + the content render as two rounded cards inset from the window
+   * edges with a gap between; a FLOATING (compact) or hidden (zen/fullscreen)
+   * sidebar lets content fill the whole window. */
+  --gjoa-card-gap: 6px;
+  --gjoa-card-radius: 8px;
+  --gjoa-card-shadow: 0 1px 6px rgba(0, 0, 0, 0.22);
   --gjoa-transition-duration: 0.25s;
   --gjoa-transition-easing: linear(
     0 0%, 0.003 1%, 0.011 2%, 0.023 3%, 0.039 4%, 0.058 5%, 0.08 6%,
@@ -834,3 +841,57 @@ Preserve these (security warnings):
 }
 
 /* #endregion split view */
+
+
+/* #region floating cards — contextual layout (gjoa.layout.floatingCards)
+ *
+ * The user's design: a STATIC sidebar (in the #browser flex flow, visible)
+ * renders the sidebar and the content as two rounded cards, inset from the
+ * window edges with a gap between them. A FLOATING sidebar (data-gjoa-compact,
+ * which is position:fixed → out of flow) or a hidden one (zen / horizontal /
+ * DOM-fullscreen) lets the content fill the whole window.
+ *
+ * #browser is `hbox > #sidebar-main … #tabbrowser-tabbox`; the splitters and
+ * #sidebar-box between them are display:none when hidden, so when only the
+ * launcher + content are visible they are adjacent flex items and a single
+ * `gap` spaces exactly the two cards. Symmetric padding+gap is position-
+ * agnostic, so static-left and static-right both work without a position_start
+ * branch. The rules self-gate via :has(): when the sidebar is compact or
+ * hidden the static selector simply doesn't match, so content fills. */
+
+@media -moz-pref("gjoa.layout.floatingCards") {
+
+  /* STATIC: launcher visible AND in-flow → inset the row, gap the cards. */
+  #browser:has(> #sidebar-main:not([data-gjoa-compact]):not([hidden])) {
+    gap: var(--gjoa-card-gap) !important;
+    padding: var(--gjoa-card-gap) !important;
+  }
+
+  #browser:has(> #sidebar-main:not([data-gjoa-compact]):not([hidden])) > #sidebar-main,
+  #browser:has(> #sidebar-main:not([data-gjoa-compact]):not([hidden])) > #tabbrowser-tabbox {
+    border-radius: var(--gjoa-card-radius) !important;
+    box-shadow: var(--gjoa-card-shadow) !important;
+  }
+
+  /* Content card: clip web content to the rounded corners + give it a card
+   * background so the rounding reads even before a page paints. */
+  #browser:has(> #sidebar-main:not([data-gjoa-compact]):not([hidden])) > #tabbrowser-tabbox {
+    overflow: hidden !important;
+    background-color: var(--gjoa-bg) !important;
+  }
+
+  /* FILL: DOM-fullscreen always takes the whole window — defeat any card inset
+   * that an open sidebar would otherwise leave behind. (Compact + hidden
+   * sidebars already fall through to fill because the static selector above
+   * does not match them.) */
+  :root[inDOMFullscreen="true"] #browser,
+  :root[inDOMFullscreen="true"] #browser > #tabbrowser-tabbox {
+    gap: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+}
+
+/* #endregion floating cards */


### PR DESCRIPTION
Layout/chrome polish from the UX-feedback session.

## #96 — Contextual floating cards
FF152's `nova` UI reserves an all-or-nothing content inset that crops every page and exposes the desktop behind it (the reported "content not full width + a margin that didn't used to exist"). This forces nova off and replaces it with gjoa's own contextual cards, gated on the live sidebar state via `:has()`:

- **Static sidebar** (in the `#browser` flex flow, visible): sidebar + content render as two rounded cards, inset from the window edges with a gap between. Symmetric padding+gap → position-agnostic (works static-left and static-right).
- **Floating sidebar** (`data-gjoa-compact`, `position:fixed` → out of flow) or **hidden** (zen / horizontal / DOM-fullscreen): the static selector doesn't match → content fills the whole window.

Pref `gjoa.layout.floatingCards` (default on). The CSS is Lane 1; the pref default + nova-off live in `GjoaLoader` set-defaults, so they take full effect on the next build (or set them in `about:config` to preview now).

## #92 — Toolbar swap (extensions ↔ sidebar)
Place gjoa's sidebar button immediately after the extensions button (`hamburger → extensions → sidebar`) at install, and re-assert that order in the compact-collapse reflow in `drawer/layout.bjs` (which re-places the extensions button). Survives sidebar-left/right, vertical, and horizontal/compact transitions.

## Notes
- The `nav-bar-layout` test-1 assertion only runs when a native `#sidebar-button` exists to swap; it's skipped in the default vertical-tabs+revamp profile, so it doesn't gate this.
- `#96` is a visual change; runtime effect of the pref defaults arrives with the next build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784580239&installation_id=141311834&pr_number=122&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F122&signature=4244962a165fed1d16506e61332044309f9d787b9d9fc207f634b764a5ffe763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->