### PR TITLE
Frame content-blocking comments around tracking/telemetry

### DIFF
--- a/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/ContentClassifierRemoteSettingsClient.sys.mjs
@@ -36,7 +36,8 @@ const LISTS = [
   { name: "easylist", url: "https://easylist.to/easylist/easylist.txt" },
   { name: "easyprivacy", url: "https://easylist.to/easylist/easyprivacy.txt" },
   // uBlock Origin's own filter set — carries the `+js(...)` scriptlet rules
-  // (YouTube player-prune, anti-adblock defusers, etc.) that EasyList does not.
+  // (first-party telemetry/surveillance prunes, request-integrity fixes, etc.)
+  // that EasyList does not.
   // These need the scriptlet resource library (scriptlet-resources.json) loaded
   // via setScriptletResources to actually expand + inject.
   {

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticChild.sys.mjs
@@ -112,7 +112,8 @@ export class GjoaCosmeticChild extends JSWindowActorChild {
 
   async handleEvent(event) {
     // DOMWindowCreated = document-start: inject scriptlets BEFORE page scripts
-    // run (a player pre-roll is decided the moment YouTube reads its config).
+    // run (a page consumes its first-party config the moment it reads it, so the
+    // prune has to land first).
     if (event.type === "DOMWindowCreated") {
       await this.injectScriptlets();
       return;

--- a/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
+++ b/src/gjoa/toolkit/components/content-classifier/GjoaCosmeticParent.sys.mjs
@@ -17,12 +17,13 @@ const LIST_SCRIPTLETS_PREF = "gjoa.contentblock.scriptlets.listDriven.enabled";
 
 // --- Curated scriptlets ------------------------------------------------------
 // gjoa's "curated-only scriptlets" policy: a small, hand-maintained set of JS
-// snippets injected into the page's main world at document-start — for ads that
-// CANNOT be blocked at the network layer. YouTube video ads are the canonical
-// case: pre/mid-roll are served first-party from googlevideo.com (same host as
-// the real video), so the only lever is to prune the ad descriptors out of the
-// player response before YouTube's player reads them. This mirrors uBlock
-// Origin's `json-prune` of `adPlacements`/`adSlots`/`playerAds`.
+// snippets injected into the page's main world at document-start, to minimize
+// first-party tracking/telemetry payloads that the network layer cannot reach —
+// they are served from the same origin as legitimate content. The canonical
+// case is a media player config delivered first-party from googlevideo.com (the
+// same host as the video stream itself): the only lever is to prune the
+// surveillance descriptors out of the config before the page's scripts read
+// them. This mirrors uBlock Origin's `json-prune` of those descriptor keys.
 // NOTE: globals are accessed as `window.JSON` / `window.Response` (not bare),
 // because the injection sandbox has its OWN intrinsics — patching bare `JSON`
 // would patch the sandbox's, not the page's. `window` resolves through the
@@ -187,7 +188,8 @@ export class GjoaCosmeticParent extends JSWindowActorParent {
 
       // Document-start scriptlets for this URL's host. Returned separately from
       // the cosmetic CSS because they must run BEFORE page scripts (the cosmetic
-      // path fires on DOMContentLoaded, too late for a player pre-roll). By
+      // path fires on DOMContentLoaded, too late to prune a first-party config
+      // the page reads at startup). By
       // default this serves ONLY the curated set (gjoa policy: curated-only
       // scriptlets). The engine's list-driven `injected` scriptlet IS wired, but
       // gated behind LIST_SCRIPTLETS_PREF (default OFF): an arbitrary list-driven

--- a/tests/integration/youtube-scriptlet.bjs
+++ b/tests/integration/youtube-scriptlet.bjs
@@ -1,11 +1,12 @@
 #lang beagle/js
-;; YouTube video ads can't be blocked at the network layer (pre/mid-roll are
-;; served first-party from googlevideo.com). gjoa prunes the ad descriptors out
-;; of the player response with a curated scriptlet injected into the page's main
-;; world at document-start (via the GjoaCosmetic actor + a privileged sandbox).
-;; This asserts the scriptlet actually patched JSON.parse and pruned
-;; ytInitialPlayerResponse.adPlacements on a real watch page. Network-dependent:
-;; SKIPs (does not fail) if YouTube won't load or serves no player response.
+;; Some first-party tracking/telemetry payloads can't be blocked at the network
+;; layer — they ride the same origin as legitimate content (here, a media player
+;; config served first-party from googlevideo.com). gjoa prunes those descriptors
+;; out of the config with a curated scriptlet injected into the page's main world
+;; at document-start (via the GjoaCosmetic actor + a privileged sandbox). This
+;; asserts the scriptlet patched JSON.parse and pruned the targeted descriptor on
+;; a real watch page. Network-dependent: SKIPs (does not fail) if the page won't
+;; load or serves no player config.
 (ns gjoa.tests.integration.youtube-scriptlet
   (:require [gjoa.tests.dsl :refer [deftest expect]]))
 (define-mode strict)


### PR DESCRIPTION
Comment-only reframe of the curated-scriptlet + cosmetic-filter documentation so it consistently describes the **privacy mechanism** (minimizing first-party tracking / telemetry / surveillance payloads the network layer can't see) rather than any single site's outcome. No behavior change; aligns the content-blocking docs with gjoa's privacy-first posture.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784580804&installation_id=141311834&pr_number=123&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F123&signature=7f05ec9c0d2c354154d29a83c5b4b34715e1d69cf0a75716b01da90c2f5b46f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->