### PR TITLE
Tasteful tab close button (× on hover + active row)

### DIFF
--- a/src/gjoa/chrome/bjs/tabs/rows.bjs
+++ b/src/gjoa/chrome/bjs/tabs/rows.bjs
@@ -34,15 +34,24 @@
           (let [row     (xul "hbox" "gjoa-tab-row")
                 icon    (xul "image" "gjoa-tab-icon")
                 label   (htm "span" "gjoa-tab-label")
+                close   (xul "image" "gjoa-tab-close")
                 chevron (xul "image" "gjoa-tab-chevron")]
             (attr! row "align" "center")
+            (attr! close "tooltiptext" "Close tab")
+
+            ;; Subtle close affordance — CSS shows it on hover + on the active
+            ;; row. Sits just before the collapse chevron when both are present.
+            (on! close "click"
+              #(when (= (.-button %) 0)
+                 (.stopPropagation %)
+                 (.removeTab gBrowser tab)))
 
             (on! chevron "click"
               #(when (= (.-button %) 0)
                  (.stopPropagation %)
                  (toggle-collapse row)))
 
-            (.append row icon label chevron)
+            (.append row icon label close chevron)
             (set! (.-_tab row) tab)
             (.set row-of tab row)
 

--- a/src/gjoa/chrome/css/gjoa-tabs.uc.css
+++ b/src/gjoa/chrome/css/gjoa-tabs.uc.css
@@ -262,6 +262,43 @@
   display: inline-block;
 }
 
+/* Close affordance — a subtle, right-anchored × revealed on hover (any row)
+ * and on the active/selected row (the safe default, à la Firefox). Hidden
+ * otherwise so the strip stays calm. When a row also has a collapse chevron
+ * (a collapsed parent), the × takes the right-anchor and the chevron tucks in
+ * just after it: [favicon … label … × ▸]. */
+.gjoa-tab-close {
+  width: 14px; height: 14px;
+  margin-inline-start: auto;
+  margin-inline-end: 4px;
+  flex-shrink: 0;
+  display: none;
+  list-style-image: url("chrome://global/skin/icons/close.svg");
+  -moz-context-properties: fill;
+  fill: currentColor;
+  opacity: 0.5;
+  border-radius: 4px;
+}
+.gjoa-tab-close:hover {
+  opacity: 0.95;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+.gjoa-tab-row:hover .gjoa-tab-close,
+.gjoa-tab-row[selected] .gjoa-tab-close {
+  display: inline-block;
+}
+/* When the × is shown it owns the right-anchor; the chevron (if present) sits
+ * immediately after it rather than fighting for the auto-margin. */
+.gjoa-tab-row:hover .gjoa-tab-chevron,
+.gjoa-tab-row[selected] .gjoa-tab-chevron {
+  margin-inline-start: 4px;
+}
+/* Icons-only (narrow) mode: no room for a hover ×; keep the strip clean
+ * (middle-click / context-menu still close). */
+:is(#gjoa-tab-panel, #gjoa-pinned-container)[gjoa-icons-only] .gjoa-tab-close {
+  display: none !important;
+}
+
 /* #endregion rows */
 
 

--- a/tests/integration/tab-close-button.bjs
+++ b/tests/integration/tab-close-button.bjs
@@ -1,0 +1,41 @@
+#lang beagle/js
+;; Tab rows carry a subtle close affordance (#97): a × revealed on hover and on
+;; the active row that closes the tab. Asserts the element is present on a row
+;; and that clicking it removes the tab.
+(ns gjoa.tests.integration.tab-close-button
+  (:require [gjoa.tests.dsl :refer [deftest chrome-eval await-true wait-for expect sleep]]))
+(define-mode strict)
+
+(js/export (def tests :- Any
+  [(deftest "tab row has a close button that closes the tab (#97)" [mn]
+     (await-true "return !!window.gjoaTest && !!document.getElementById(\"gjoa-tab-panel\");" 5000)
+     (chrome-eval "
+        for (const t of [...gBrowser.tabs].filter(t => t.getAttribute && t.getAttribute('gjoa-test-marker'))) { try { gBrowser.removeTab(t); } catch {} }
+        return true;")
+     (let [stamp (str "tcb-" (Date/now))]
+       (chrome-eval (str "
+          const p = Services.scriptSecurityManager.getSystemPrincipal();
+          const t = gBrowser.addTab('about:blank', { triggeringPrincipal: p });
+          t.setAttribute('gjoa-test-marker', '" stamp "');
+          window.gjoaTest.rows.scheduleTreeResync();
+          window.gjoaTest.rows.updateVisibility();
+          return true;"))
+       (await-true (str "return [...gBrowser.tabs].some(t => t.getAttribute('gjoa-test-marker') === '" stamp "');") 3000)
+       ;; the row exists and carries a .gjoa-tab-close
+       (let [has-close (chrome-eval (str "
+              const t = [...gBrowser.tabs].find(x => x.getAttribute('gjoa-test-marker') === '" stamp "');
+              const row = [...document.querySelectorAll('#gjoa-tab-panel .gjoa-tab-row')].find(r => r._tab === t);
+              return !!(row && row.querySelector('.gjoa-tab-close'));"))]
+         (expect has-close "tab row must carry a .gjoa-tab-close element"))
+       ;; clicking it closes the tab
+       (chrome-eval (str "
+          const t = [...gBrowser.tabs].find(x => x.getAttribute('gjoa-test-marker') === '" stamp "');
+          const row = [...document.querySelectorAll('#gjoa-tab-panel .gjoa-tab-row')].find(r => r._tab === t);
+          const x = row.querySelector('.gjoa-tab-close');
+          x.dispatchEvent(new MouseEvent('click', { bubbles:true, cancelable:true, button:0 }));
+          return true;"))
+       (js/await (sleep 300))
+       (let [gone (chrome-eval (str "return ![...gBrowser.tabs].some(t => t.getAttribute('gjoa-test-marker') === '" stamp "');"))]
+         (expect gone "clicking the × must close the tab"))))]))
+
+(js/export-default tests)

--- a/tests/integration/tags.json
+++ b/tests/integration/tags.json
@@ -5,7 +5,7 @@
     "contrast":  ["contrast"],
     "adblock":   ["adblock-cosmetic", "adblock-cosmetic-actor", "adblock-production", "adblock-ui", "adblock-validate"],
     "scriptlet": ["scriptlet-engine", "youtube-scriptlet"],
-    "tabs":      ["tab-mode-toggle", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys", "help-menu", "compact-context-menu"],
+    "tabs":      ["tab-mode-toggle", "tab-close-button", "nav-bar-layout", "sidebar-symmetric-icons", "groups", "group-drag-above", "vim-hotkeys", "help-menu", "compact-context-menu"],
     "spaces":    ["spaces", "spaces-header", "spaces-scope-groups", "spaces-vim", "spaces-session-restore", "session-restore"],
     "newtab":    ["newtab-home", "new-tab-honors-active-space", "new-tab-no-indent-chain", "new-tab-visibility"],
     "misc":      ["sqlite"]


### PR DESCRIPTION
Each tab row gets a quiet close affordance (#97):

- A subtle **×** revealed on **hover** (any row) and always on the **active/selected** row — the safe default, à la Firefox — hidden otherwise so the strip stays calm.
- When a row also shows the collapse **▸** chevron (a collapsed parent), the × takes the right-anchor and the chevron tucks in right after it: `[favicon … label … × ▸]`.
- Suppressed in icons-only (narrow) mode where there's no room; middle-click and the context menu still close.

Uses `chrome://global/skin/icons/close.svg` (same icon dir as the chevron's `arrow-right.svg`). Integration test (`tab-close-button.bjs`) asserts the element is present on a row and that a click removes the tab — verified green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Autonymy/codesmith/gjoa/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784581272&installation_id=141311834&pr_number=124&repository=Autonymy%2Fgjoa&return_to=https%3A%2F%2Fgithub.com%2FAutonymy%2Fgjoa%2Fpull%2F124&signature=844bc932ca3e021dfdc13425659f26c41a0b82e450cb00b830ecd1258215af1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->